### PR TITLE
fix: deep clone node data on paste to prevent shared references

### DIFF
--- a/src/composables/useCopyPaste.js
+++ b/src/composables/useCopyPaste.js
@@ -40,7 +40,7 @@ export function useCopyPaste(flowStore, viewport, mousePosition) {
     const ioConfig = getNodeIOConfig(copiedNode.value.type)
 
     // Use already cloned data from handleCopy
-    const clonedData = { ...copiedNode.value.data }
+    const clonedData = JSON.parse(JSON.stringify(copiedNode.value.data))
 
     // Update label to indicate it's a copy
     if (clonedData.label) {
@@ -49,7 +49,7 @@ export function useCopyPaste(flowStore, viewport, mousePosition) {
 
     // Create new node with same type and data
     const newNode = createNode(
-      `node_${Date.now()}`,
+      `node_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`,
       copiedNode.value.type,
       position,
       clonedData,


### PR DESCRIPTION
# What

Se corrige un bug donde al copiar y pegar nodos rápidamente (ej: PromptTemplate), modificar el valor de una variable en un nodo afectaba también a los otros nodos pegados. Ahora cada nodo pegado es completamente independiente.

Además, se mejora la generación de IDs para evitar colisiones cuando se pega muy rápido.

# Why

Al pegar nodos rápido, todos compartían la misma referencia a objetos internos como `variables` o `params`. Esto hacía que editar uno modificara todos los demás. El problema afectaba a nodos con datos anidados: PromptTemplate, ImageGenerator, TextGenerator y Draw.

El shallow copy (`{ ...data }`) solo clonaba el primer nivel, mientras que los objetos anidados seguían siendo la misma referencia en memoria.

# Tests

Local

## How to test

- [ ] Crear un nodo PromptTemplate y poner un valor en una variable
- [ ] Copiar (Ctrl+C) y pegar (Ctrl+V) 3+ veces rápidamente
- [ ] Editar la variable en una copia → verificar que las otras NO cambian
- [ ] Repetir con ImageGenerator (cambiar params del modelo)
- [ ] Guardar/exportar flow y reimportar → verificar integridad