### PR TITLE
feat: preserve input edges when pasting copied nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ public/examples/toy_packaging.json
 CLAUDE.md
 test-results
 docs/deepwiki
+tmp

--- a/src/composables/useCopyPaste.js
+++ b/src/composables/useCopyPaste.js
@@ -6,7 +6,7 @@
 import { ref } from 'vue'
 import { createNode, getNodeIOConfig } from '@/lib/node-shapes'
 
-export function useCopyPaste(flowStore, viewport, mousePosition) {
+export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
   const copiedNode = ref(null)
 
   /**
@@ -68,18 +68,19 @@ export function useCopyPaste(flowStore, viewport, mousePosition) {
 
     // Recreate input edges pointing to the new node
     const inputEdges = copiedNode.value._inputEdges || []
-    inputEdges.forEach((edgeTemplate, index) => {
-      const sourceExists = flowStore.nodes.some(n => n.id === edgeTemplate.source)
-      if (!sourceExists) return
-
-      flowStore.edges.push({
+    const newEdges = inputEdges
+      .filter(edgeTemplate => flowStore.nodes.some(n => n.id === edgeTemplate.source))
+      .map((edgeTemplate, index) => ({
         id: `edge_${Date.now()}_${index}_${Math.random().toString(36).substr(2, 5)}`,
         source: edgeTemplate.source,
         target: newNode.id,
         sourceHandle: edgeTemplate.sourceHandle,
         targetHandle: edgeTemplate.targetHandle
-      })
-    })
+      }))
+
+    if (newEdges.length > 0) {
+      addEdges(newEdges)
+    }
 
     console.log('Node pasted:', newNode.type, 'with data:', clonedData)
   }

--- a/src/composables/useCopyPaste.js
+++ b/src/composables/useCopyPaste.js
@@ -3,7 +3,7 @@
  * Handles copying and pasting nodes
  */
 
-import { ref } from 'vue'
+import { ref, nextTick } from 'vue'
 import { createNode, getNodeIOConfig } from '@/lib/node-shapes'
 
 export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
@@ -34,7 +34,7 @@ export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
   /**
    * Paste copied node at mouse position
    */
-  function handlePaste() {
+  async function handlePaste() {
     if (!copiedNode.value) return
 
     // Calculate position at mouse, accounting for zoom and pan
@@ -65,6 +65,9 @@ export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
 
     // Add to store
     flowStore.nodes.push(newNode)
+
+    // Wait for VueFlow to process the new node before adding edges
+    await nextTick()
 
     // Recreate input edges pointing to the new node
     const inputEdges = copiedNode.value._inputEdges || []

--- a/src/composables/useCopyPaste.js
+++ b/src/composables/useCopyPaste.js
@@ -18,7 +18,14 @@ export function useCopyPaste(flowStore, viewport, mousePosition) {
       // Create a deep copy immediately to capture current state
       copiedNode.value = {
         ...selectedNode,
-        data: JSON.parse(JSON.stringify(selectedNode.data))
+        data: JSON.parse(JSON.stringify(selectedNode.data)),
+        _inputEdges: flowStore.edges
+          .filter(e => e.target === selectedNode.id)
+          .map(e => ({
+            source: e.source,
+            sourceHandle: e.sourceHandle || null,
+            targetHandle: e.targetHandle || null
+          }))
       }
       console.log('Node copied:', selectedNode.type, 'with data:', copiedNode.value.data)
     }
@@ -58,6 +65,22 @@ export function useCopyPaste(flowStore, viewport, mousePosition) {
 
     // Add to store
     flowStore.nodes.push(newNode)
+
+    // Recreate input edges pointing to the new node
+    const inputEdges = copiedNode.value._inputEdges || []
+    inputEdges.forEach((edgeTemplate, index) => {
+      const sourceExists = flowStore.nodes.some(n => n.id === edgeTemplate.source)
+      if (!sourceExists) return
+
+      flowStore.edges.push({
+        id: `edge_${Date.now()}_${index}_${Math.random().toString(36).substr(2, 5)}`,
+        source: edgeTemplate.source,
+        target: newNode.id,
+        sourceHandle: edgeTemplate.sourceHandle,
+        targetHandle: edgeTemplate.targetHandle
+      })
+    })
+
     console.log('Node pasted:', newNode.type, 'with data:', clonedData)
   }
 

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -151,7 +151,7 @@ function toggleNodesMenu() {
   }
 }
 const { isLocked, handleLockToggle, handleFitView } = useViewportControls(fitView)
-const { copiedNode, handleCopy, handlePaste } = useCopyPaste(flowStore, viewport, mousePosition)
+const { copiedNode, handleCopy, handlePaste } = useCopyPaste(flowStore, viewport, mousePosition, { addEdges })
 const { createNodeAtPosition } = useNodeCreation(flowStore)
 const { menuPosition, handlePaneContextMenu, resetMenuPosition, closeMenu } = useContextMenu(isNodesMenuOpen)
 const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, { addEdges }, resetMenuPosition)


### PR DESCRIPTION
# What

When copying and pasting a node, the pasted node now automatically inherits the input connections from the original node. For example, if a "prompt" node is connected to an "image generator" and you copy-paste the "image generator", the new copy will already be connected to the same "prompt" node.

Output edges are intentionally not copied.

# Why

Previously, pasting a node would create a completely disconnected copy, forcing users to manually re-wire all input connections. This is tedious, especially for nodes with multiple inputs. Preserving input edges makes the copy-paste workflow much faster and more intuitive.

# Tests

Local testing.

## How to test

- [ ] Create a "prompt" node and connect it to an "image generator" node
- [ ] Select the "image generator" and press Ctrl+C then Ctrl+V
- [ ] Verify the pasted node has an input edge from the same "prompt" node
- [ ] Verify the original node's connections are unchanged
- [ ] Delete the "prompt" node, then paste again — verify no broken edge is created
- [ ] Test with nodes that have multiple inputs (e.g., image generator with both image and prompt inputs)
- [ ] Paste the same node multiple times and verify each copy gets its own edges