### PR TITLE
feat: auto-tidy node layout (beta, off by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ public/examples/toy_packaging.json
 CLAUDE.md
 test-results
 docs/deepwiki
+tmp

--- a/src/components/canvas/SettingsModal.vue
+++ b/src/components/canvas/SettingsModal.vue
@@ -37,6 +37,24 @@
         </div>
       </div>
 
+      <!-- Beta Features Section -->
+      <div class="settings-section">
+        <h3 class="settings-section-title">
+          Beta Features
+          <span class="settings-beta-badge">beta</span>
+        </h3>
+        <div class="settings-option">
+          <BaseCheckbox
+            id="auto-tidy-beta"
+            v-model="settingsStore.autoTidyBeta"
+            label="Auto-tidy layout"
+          />
+          <p class="settings-option-description">
+            Adds a Tidy button to auto-arrange nodes on the canvas. Experimental — layout may not be perfect for every workflow.
+          </p>
+        </div>
+      </div>
+
       <!-- API Keys Section -->
       <div class="settings-section">
         <h3 class="settings-section-title">API Keys</h3>
@@ -161,12 +179,28 @@ function handleClearKeys() {
 }
 
 .settings-section-title {
+  display: flex;
+  align-items: center;
+  gap: var(--flora-space-2);
   margin: 0;
   font-size: var(--flora-font-size-base);
   font-weight: var(--flora-font-weight-semibold);
   color: var(--flora-color-text-primary);
   padding-bottom: var(--flora-space-2);
   border-bottom: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+}
+
+.settings-beta-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--flora-space-2);
+  font-size: var(--flora-font-size-xs);
+  font-weight: var(--flora-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--flora-color-accent-text);
+  background: var(--flora-color-accent-subtle);
+  border-radius: var(--flora-radius-sm);
 }
 
 .settings-option {

--- a/src/components/workflow/WorkflowControls.vue
+++ b/src/components/workflow/WorkflowControls.vue
@@ -10,6 +10,7 @@
         <span class="play-icon-collapsed">▶</span>
       </button>
       <button
+        v-if="settingsStore.autoTidyBeta"
         class="tidy-button-collapsed"
         @click="handleTidy"
         title="Auto-tidy layout"
@@ -37,6 +38,7 @@
 
       <!-- Tidy button -->
       <button
+        v-if="settingsStore.autoTidyBeta"
         class="tidy-btn"
         @click="handleTidy"
         :disabled="isExecuting"
@@ -94,6 +96,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 import { useWorkflowExecution } from '@/composables/useWorkflowExecution'
 import { useAutoLayout } from '@/composables/useAutoLayout'
+import { useSettingsStore } from '@/stores/settings'
 
 const {
   isExecuting,
@@ -111,6 +114,7 @@ const {
 
 const { fitView } = useVueFlow()
 const { autoLayoutNodes } = useAutoLayout()
+const settingsStore = useSettingsStore()
 
 const isExpanded = ref(false)
 
@@ -146,6 +150,7 @@ function handleStop() {
 }
 
 function handleTidy() {
+  if (!settingsStore.autoTidyBeta) return
   if (isExecuting.value) return
   autoLayoutNodes()
   requestAnimationFrame(() => fitView({ padding: 0.2 }))

--- a/src/components/workflow/WorkflowControls.vue
+++ b/src/components/workflow/WorkflowControls.vue
@@ -1,14 +1,24 @@
 <template>
   <div class="workflow-controls">
-    <!-- Collapsed state: just the play button -->
-    <button
-      v-if="!isExpanded && !isExecuting"
-      class="play-button-collapsed"
-      @click="handlePlay"
-      title="Execute Workflow (Ctrl+Enter)"
-    >
-      <span class="play-icon-collapsed">▶</span>
-    </button>
+    <!-- Collapsed state: play + tidy buttons -->
+    <div v-if="!isExpanded && !isExecuting" class="collapsed-cluster">
+      <button
+        class="play-button-collapsed"
+        @click="handlePlay"
+        title="Execute Workflow (Ctrl+Enter)"
+      >
+        <span class="play-icon-collapsed">▶</span>
+      </button>
+      <button
+        class="tidy-button-collapsed"
+        @click="handleTidy"
+        title="Auto-tidy layout"
+      >
+        <svg class="tidy-icon-collapsed" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" />
+        </svg>
+      </button>
+    </div>
 
     <!-- Expanded state: horizontal panel -->
     <div v-else class="controls-panel">
@@ -23,6 +33,19 @@
           <polygon points="0,0 8,4 0,8" />
         </svg>
         <span class="play-text">Play</span>
+      </button>
+
+      <!-- Tidy button -->
+      <button
+        class="tidy-btn"
+        @click="handleTidy"
+        :disabled="isExecuting"
+        title="Auto-tidy layout"
+      >
+        <svg class="tidy-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" />
+        </svg>
+        <span class="tidy-text">Tidy</span>
       </button>
 
       <!-- Info section -->
@@ -68,7 +91,9 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useVueFlow } from '@vue-flow/core'
 import { useWorkflowExecution } from '@/composables/useWorkflowExecution'
+import { useAutoLayout } from '@/composables/useAutoLayout'
 
 const {
   isExecuting,
@@ -83,6 +108,9 @@ const {
   stopExecution,
   resetExecution
 } = useWorkflowExecution()
+
+const { fitView } = useVueFlow()
+const { autoLayoutNodes } = useAutoLayout()
 
 const isExpanded = ref(false)
 
@@ -115,6 +143,12 @@ function collapse() {
 function handleStop() {
   stopExecution()
   resetExecution()
+}
+
+function handleTidy() {
+  if (isExecuting.value) return
+  autoLayoutNodes()
+  requestAnimationFrame(() => fitView({ padding: 0.2 }))
 }
 
 // Format duration as mm:ss or hh:mm:ss
@@ -162,6 +196,13 @@ onUnmounted(() => {
   width: fit-content;
 }
 
+/* Collapsed cluster (play + tidy) */
+.collapsed-cluster {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* Collapsed play button */
 .play-button-collapsed {
   width: 44px;
@@ -190,6 +231,36 @@ onUnmounted(() => {
   color: white;
   font-size: 18px;
   margin-left: 2px;
+}
+
+/* Collapsed tidy button */
+.tidy-button-collapsed {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #3a3a3a;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.tidy-button-collapsed:hover {
+  background: #4a4a4a;
+  transform: scale(1.05);
+}
+
+.tidy-button-collapsed:active {
+  transform: scale(0.95);
+}
+
+.tidy-icon-collapsed {
+  width: 20px;
+  height: 20px;
+  color: white;
 }
 
 /* Expanded panel */
@@ -232,6 +303,41 @@ onUnmounted(() => {
 }
 
 .play-text {
+  color: white;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+/* Tidy button inside panel */
+.tidy-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #3a3a3a;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tidy-btn:hover:not(:disabled) {
+  background: #4a4a4a;
+}
+
+.tidy-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tidy-icon {
+  width: 12px;
+  height: 12px;
+  color: white;
+}
+
+.tidy-text {
   color: white;
   font-family: 'Inter', sans-serif;
   font-size: 12px;

--- a/src/composables/useAutoLayout.js
+++ b/src/composables/useAutoLayout.js
@@ -1,0 +1,142 @@
+import { useFlowStore } from '@/stores/flow'
+import { topologicalSort } from '@/lib/graph-utils'
+
+const H_GAP = 80
+const V_GAP = 40
+const FALLBACK_W = 220
+const FALLBACK_H = 150
+
+function getNodeWidth(node) {
+  return node.dimensions?.width || node.width || FALLBACK_W
+}
+
+function getNodeHeight(node) {
+  return node.dimensions?.height || node.height || FALLBACK_H
+}
+
+function gridFallback(nodes) {
+  const cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)))
+  const sorted = [...nodes].sort((a, b) => a.id.localeCompare(b.id))
+
+  const rowHeights = []
+  const colWidths = []
+  sorted.forEach((node, i) => {
+    const r = Math.floor(i / cols)
+    const c = i % cols
+    rowHeights[r] = Math.max(rowHeights[r] || 0, getNodeHeight(node))
+    colWidths[c] = Math.max(colWidths[c] || 0, getNodeWidth(node))
+  })
+
+  const colX = []
+  colWidths.forEach((w, c) => {
+    colX[c] = c === 0 ? 0 : colX[c - 1] + colWidths[c - 1] + H_GAP
+  })
+  const rowY = []
+  rowHeights.forEach((h, r) => {
+    rowY[r] = r === 0 ? 0 : rowY[r - 1] + rowHeights[r - 1] + V_GAP
+  })
+
+  sorted.forEach((node, i) => {
+    const r = Math.floor(i / cols)
+    const c = i % cols
+    node.position = { x: colX[c], y: rowY[r] }
+  })
+}
+
+export function useAutoLayout() {
+  const flowStore = useFlowStore()
+
+  function autoLayoutNodes() {
+    const allNodes = flowStore.nodes
+    if (allNodes.length < 2) return
+
+    const layoutNodes = allNodes.filter(n => !n.parentNode)
+    if (layoutNodes.length < 2) return
+
+    const layoutIds = new Set(layoutNodes.map(n => n.id))
+    const layoutEdges = flowStore.edges.filter(
+      e => layoutIds.has(e.source) && layoutIds.has(e.target)
+    )
+
+    const { levels, hasCycle } = topologicalSort(layoutNodes, layoutEdges)
+
+    if (hasCycle) {
+      gridFallback(layoutNodes)
+      return
+    }
+
+    const nodeById = new Map(layoutNodes.map(n => [n.id, n]))
+
+    const incoming = new Map()
+    layoutNodes.forEach(n => incoming.set(n.id, []))
+    layoutEdges.forEach(e => {
+      incoming.get(e.target)?.push(e.source)
+    })
+
+    const colW = levels.map(level =>
+      level.reduce((max, id) => Math.max(max, getNodeWidth(nodeById.get(id))), 0)
+    )
+
+    const colX = []
+    colW.forEach((w, i) => {
+      colX[i] = i === 0 ? 0 : colX[i - 1] + colW[i - 1] + H_GAP
+    })
+
+    const positionsY = new Map()
+
+    const colHeights = []
+    levels.forEach((level, i) => {
+      let ordered
+      if (i === 0) {
+        ordered = [...level].sort((a, b) => a.localeCompare(b))
+      } else {
+        ordered = [...level].sort((a, b) => {
+          const ba = barycenter(a, incoming, positionsY, nodeById)
+          const bb = barycenter(b, incoming, positionsY, nodeById)
+          if (ba === bb) return a.localeCompare(b)
+          return ba - bb
+        })
+      }
+
+      let y = 0
+      ordered.forEach((id, k) => {
+        const node = nodeById.get(id)
+        if (k > 0) y += V_GAP
+        positionsY.set(id, y)
+        y += getNodeHeight(node)
+      })
+      colHeights[i] = y
+
+      // Replace level with ordered IDs so the apply step uses the new order.
+      levels[i] = ordered
+    })
+
+    const maxColHeight = colHeights.reduce((m, h) => Math.max(m, h), 0)
+    const centerY = maxColHeight / 2
+
+    levels.forEach((level, i) => {
+      const offset = centerY - colHeights[i] / 2
+      level.forEach(id => {
+        const node = nodeById.get(id)
+        const yLocal = positionsY.get(id)
+        node.position = { x: colX[i], y: offset + yLocal }
+      })
+    })
+  }
+
+  return { autoLayoutNodes }
+}
+
+function barycenter(id, incoming, positionsY, nodeById) {
+  const sources = incoming.get(id) || []
+  if (sources.length === 0) return positionsY.get(id) ?? 0
+  let sum = 0
+  let count = 0
+  for (const s of sources) {
+    const y = positionsY.get(s)
+    if (y === undefined) continue
+    sum += y + getNodeHeight(nodeById.get(s)) / 2
+    count++
+  }
+  return count > 0 ? sum / count : 0
+}

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -40,6 +40,9 @@ export const useSettingsStore = defineStore('settings', () => {
   const showNodeHeaders = ref(persisted.showNodeHeaders ?? false)
   const skipSaveDialog = ref(persisted.skipSaveDialog ?? false)
 
+  // Beta Features (off by default)
+  const autoTidyBeta = ref(persisted.autoTidyBeta ?? false)
+
   // API Keys Settings
   const replicateApiKey = ref(persisted.replicateApiKey ?? '')
   const openaiApiKey = ref(persisted.openaiApiKey ?? '')
@@ -49,6 +52,7 @@ export const useSettingsStore = defineStore('settings', () => {
     () => ({
       showNodeHeaders: showNodeHeaders.value,
       skipSaveDialog: skipSaveDialog.value,
+      autoTidyBeta: autoTidyBeta.value,
       replicateApiKey: replicateApiKey.value,
       openaiApiKey: openaiApiKey.value
     }),
@@ -69,6 +73,10 @@ export const useSettingsStore = defineStore('settings', () => {
 
   function setSkipSaveDialog(value) {
     skipSaveDialog.value = value
+  }
+
+  function setAutoTidyBeta(value) {
+    autoTidyBeta.value = value
   }
 
   // API Keys Actions
@@ -106,6 +114,7 @@ export const useSettingsStore = defineStore('settings', () => {
     // State
     showNodeHeaders,
     skipSaveDialog,
+    autoTidyBeta,
     replicateApiKey,
     openaiApiKey,
 
@@ -113,6 +122,7 @@ export const useSettingsStore = defineStore('settings', () => {
     toggleNodeHeaders,
     setNodeHeaders,
     setSkipSaveDialog,
+    setAutoTidyBeta,
     setReplicateApiKey,
     setOpenaiApiKey,
     getReplicateApiKey,


### PR DESCRIPTION
# What

Adds an **auto-tidy** action to the workflow canvas that automatically arranges nodes into a clean, readable layout with a single click. Because the layout algorithm is still experimental, the feature ships **behind a beta toggle that is off by default** — users opt in from Settings → Beta Features. When enabled, a "Tidy" button appears next to the Play control (both in the collapsed and expanded states); when disabled, the canvas looks exactly as before.

# Why

Manually organizing nodes on a growing canvas is tedious. The new `useAutoLayout` composable computes positions based on the graph structure (topological levels + a barycenter pass to reduce edge crossings, with a grid fallback for cyclic graphs) and re-centers the view via `fitView`.

Since the layout may not be perfect for every workflow yet, it is gated behind a new `autoTidyBeta` setting in the settings store, surfaced in `SettingsModal` under a "Beta Features" section (with a `beta` badge), following the same pattern as the existing "Show node headers" option. The Tidy buttons in `WorkflowControls` only render when the setting is on.

# Tests

e2e tests and local.

## How to test

- [ ] Open the app on a canvas with several connected nodes.
- [ ] Confirm no "Tidy" button is visible by default (feature is off).
- [ ] Open Settings and check there is a "Beta Features" section with a `beta` badge and an "Auto-tidy layout" checkbox (unchecked).
- [ ] Enable "Auto-tidy layout" and close Settings.
- [ ] Confirm a "Tidy" button now appears next to Play (both collapsed and expanded control states).
- [ ] Click "Tidy" and verify nodes rearrange into a tidy layout and the view fits to them.
- [ ] Reload the page and confirm the setting persists (button still shown).
- [ ] Disable the setting again and confirm the Tidy button disappears.