### PR TITLE
feat: open a filtered node menu when a connection is dropped on empty canvas

### DIFF
--- a/e2e/connection-drop.spec.js
+++ b/e2e/connection-drop.spec.js
@@ -1,0 +1,196 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  getHandleCenter,
+  positionNodes,
+} from './helpers/canvas.js'
+
+/**
+ * Drag a connection from a handle and release it on empty canvas.
+ */
+async function dropConnectionOnPane(page, nodeLocator, handleId, target) {
+  const from = await getHandleCenter(nodeLocator, handleId)
+  await page.mouse.move(from.x, from.y)
+  await page.mouse.down()
+  await page.mouse.move(target.x, target.y, { steps: 10 })
+  await page.mouse.up()
+}
+
+/**
+ * Read the edges currently stored in the flow store.
+ */
+async function getEdges(page) {
+  return page.evaluate(() => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    return pinia._s.get('flow').edges.map(e => ({
+      source: e.source,
+      sourceHandle: e.sourceHandle,
+      target: e.target,
+      targetHandle: e.targetHandle,
+    }))
+  })
+}
+
+/**
+ * Read a node's id and type by node type + index.
+ */
+async function getNode(page, nodeType, nth = 0) {
+  return page.evaluate(({ nodeType, nth }) => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const matching = pinia._s.get('flow').nodes.filter(n => n.type === nodeType)
+    const node = matching[nth]
+    return node ? { id: node.id, type: node.type, position: node.position } : null
+  }, { nodeType, nth })
+}
+
+test.describe('Connection dropped on empty canvas', () => {
+  test('offers only image targets when dragging from an image output', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await positionNodes(page, [{ type: 'image', x: 100, y: 200 }])
+
+    const imageNode = page.locator('.vue-flow__node-image')
+    await dropConnectionOnPane(page, imageNode, 'output-0', { x: 800, y: 400 })
+
+    const menu = page.locator('.nodes-menu')
+    await expect(menu).toBeVisible()
+    await expect(menu.locator('.header')).toHaveText('Connect to')
+
+    const items = menu.locator('.node-item .node-text')
+    // Nodes with an `image` input
+    await expect(items.filter({ hasText: /^Image Generator$/ })).toHaveCount(1)
+    await expect(items.filter({ hasText: /^Text Generator$/ })).toHaveCount(1)
+    await expect(items.filter({ hasText: /^Draw$/ })).toHaveCount(1)
+    // Diff and Compare have two image inputs, so both ports are listed
+    await expect(items.filter({ hasText: /^Image Diff · image [12]$/ })).toHaveCount(2)
+    await expect(items.filter({ hasText: /^Image Compare · image [12]$/ })).toHaveCount(2)
+    // Nodes without an `image` input must not be offered
+    await expect(items.filter({ hasText: /^Prompt$/ })).toHaveCount(0)
+    await expect(items.filter({ hasText: /^Prompt Template$/ })).toHaveCount(0)
+    await expect(items.filter({ hasText: /^Comment$/ })).toHaveCount(0)
+  })
+
+  test('creates the chosen node already connected to the origin output', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await positionNodes(page, [{ type: 'image', x: 100, y: 200 }])
+
+    const imageNode = page.locator('.vue-flow__node-image')
+    await dropConnectionOnPane(page, imageNode, 'output-0', { x: 800, y: 400 })
+
+    await page.locator('.nodes-menu .node-item .node-text')
+      .filter({ hasText: /^Image Generator$/ })
+      .click()
+
+    await expect(page.locator('.vue-flow__node-image-generator')).toBeVisible()
+    await expect(page.locator('.nodes-menu')).toBeHidden()
+
+    const source = await getNode(page, 'image')
+    const target = await getNode(page, 'image-generator')
+    const edges = await getEdges(page)
+
+    expect(edges).toHaveLength(1)
+    expect(edges[0]).toMatchObject({
+      source: source.id,
+      sourceHandle: 'output-0',
+      target: target.id,
+      targetHandle: 'input-0',
+    })
+    // New node is placed to the right of the origin
+    expect(target.position.x).toBeGreaterThan(source.position.x)
+  })
+
+  test('offers only prompt sources when dragging backwards from a prompt input', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image Generator')
+    await positionNodes(page, [{ type: 'image-generator', x: 600, y: 200 }])
+
+    const generatorNode = page.locator('.vue-flow__node-image-generator')
+    await dropConnectionOnPane(page, generatorNode, 'input-1', { x: 200, y: 400 })
+
+    const menu = page.locator('.nodes-menu')
+    await expect(menu).toBeVisible()
+
+    const items = menu.locator('.node-item .node-text')
+    await expect(items.filter({ hasText: /^Prompt$/ })).toHaveCount(1)
+    await expect(items.filter({ hasText: /^Prompt Template$/ })).toHaveCount(1)
+    await expect(items.filter({ hasText: /^Text Generator$/ })).toHaveCount(1)
+    await expect(items.filter({ hasText: /^Image$/ })).toHaveCount(0)
+    await expect(items.filter({ hasText: /^Draw$/ })).toHaveCount(0)
+
+    await items.filter({ hasText: /^Prompt$/ }).click()
+
+    const promptNode = await getNode(page, 'prompt')
+    const generator = await getNode(page, 'image-generator')
+    const edges = await getEdges(page)
+
+    expect(edges).toHaveLength(1)
+    expect(edges[0]).toMatchObject({
+      source: promptNode.id,
+      sourceHandle: 'output-0',
+      target: generator.id,
+      targetHandle: 'input-1',
+    })
+    // New node is placed to the left of the origin
+    expect(promptNode.position.x).toBeLessThan(generator.position.x)
+  })
+
+  test('places the new node at the drop point after zooming and panning', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await positionNodes(page, [{ type: 'image', x: 100, y: 200 }])
+
+    // Zoom out and pan the canvas so screen and flow coordinates diverge
+    await page.mouse.move(700, 400)
+    await page.mouse.wheel(0, 300)
+    await page.waitForTimeout(300)
+    await page.mouse.move(900, 500)
+    await page.mouse.down()
+    await page.mouse.move(820, 430, { steps: 10 })
+    await page.mouse.up()
+    await page.waitForTimeout(300)
+
+    // Guard: the assertions below are only meaningful if the viewport actually moved
+    const transform = await page.locator('.vue-flow__transformationpane').evaluate(el => el.style.transform)
+    expect(transform).not.toMatch(/scale\(1\)/)
+
+    const dropPoint = { x: 700, y: 450 }
+    const imageNode = page.locator('.vue-flow__node-image')
+    await dropConnectionOnPane(page, imageNode, 'output-0', dropPoint)
+
+    await page.locator('.nodes-menu .node-item .node-text')
+      .filter({ hasText: /^Draw$/ })
+      .click()
+
+    const drawNode = page.locator('.vue-flow__node-draw')
+    await expect(drawNode).toBeVisible()
+
+    // The node must render where the connection was released, not somewhere else
+    const box = await drawNode.boundingBox()
+    expect(Math.abs(box.x - dropPoint.x)).toBeLessThan(60)
+    expect(Math.abs(box.y + box.height / 2 - dropPoint.y)).toBeLessThan(80)
+  })
+
+  test('does not open the menu when the connection lands on a valid handle', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Image Generator')
+    await positionNodes(page, [
+      { type: 'image', x: 100, y: 200 },
+      { type: 'image-generator', x: 600, y: 200 },
+    ])
+
+    const imageNode = page.locator('.vue-flow__node-image')
+    const generatorNode = page.locator('.vue-flow__node-image-generator')
+    const target = await getHandleCenter(generatorNode, 'input-0')
+
+    await dropConnectionOnPane(page, imageNode, 'output-0', target)
+
+    await expect(page.locator('.nodes-menu')).toBeHidden()
+
+    const edges = await getEdges(page)
+    expect(edges).toHaveLength(1)
+    expect(edges[0].targetHandle).toBe('input-0')
+  })
+})

--- a/e2e/connection-drop.spec.js
+++ b/e2e/connection-drop.spec.js
@@ -62,9 +62,9 @@ test.describe('Connection dropped on empty canvas', () => {
     await expect(items.filter({ hasText: /^Image Generator$/ })).toHaveCount(1)
     await expect(items.filter({ hasText: /^Text Generator$/ })).toHaveCount(1)
     await expect(items.filter({ hasText: /^Draw$/ })).toHaveCount(1)
-    // Diff and Compare have two image inputs, so both ports are listed
-    await expect(items.filter({ hasText: /^Image Diff · image [12]$/ })).toHaveCount(2)
-    await expect(items.filter({ hasText: /^Image Compare · image [12]$/ })).toHaveCount(2)
+    // Diff and Compare have two image inputs, but are listed once each
+    await expect(items.filter({ hasText: /^Image Diff$/ })).toHaveCount(1)
+    await expect(items.filter({ hasText: /^Image Compare$/ })).toHaveCount(1)
     // Nodes without an `image` input must not be offered
     await expect(items.filter({ hasText: /^Prompt$/ })).toHaveCount(0)
     await expect(items.filter({ hasText: /^Prompt Template$/ })).toHaveCount(0)
@@ -99,6 +99,25 @@ test.describe('Connection dropped on empty canvas', () => {
     })
     // New node is placed to the right of the origin
     expect(target.position.x).toBeGreaterThan(source.position.x)
+  })
+
+  test('wires a node with several compatible ports to its first one', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await positionNodes(page, [{ type: 'image', x: 100, y: 200 }])
+
+    const imageNode = page.locator('.vue-flow__node-image')
+    await dropConnectionOnPane(page, imageNode, 'output-0', { x: 800, y: 400 })
+
+    await page.locator('.nodes-menu .node-item .node-text')
+      .filter({ hasText: /^Image Diff$/ })
+      .click()
+
+    await expect(page.locator('.vue-flow__node-diff')).toBeVisible()
+
+    const edges = await getEdges(page)
+    expect(edges).toHaveLength(1)
+    expect(edges[0].targetHandle).toBe('input-0')
   })
 
   test('offers only prompt sources when dragging backwards from a prompt input', async ({ page }) => {

--- a/src/components/canvas/NodesSidebar.vue
+++ b/src/components/canvas/NodesSidebar.vue
@@ -1,54 +1,73 @@
 <template>
   <aside class="nodes-menu" :style="positionStyle">
-    <h3 class="header">Nodes</h3>
+    <h3 class="header">{{ isConnectMode ? 'Connect to' : 'Nodes' }}</h3>
 
-    <!-- AI Section -->
-    <span class="section-label">AI</span>
-    <div
-      v-for="nodeDef in aiNodes"
-      :key="nodeDef.type"
-      class="node-item"
-      draggable="true"
-      @dragstart="emit('drag-start', $event, nodeDef.type)"
-      @click="emit('node-click', nodeDef.type)"
-    >
-      <span class="node-icon">{{ getNodeIcon(nodeDef.type) }}</span>
-      <span class="node-text">{{ nodeDef.label }}</span>
-    </div>
+    <!-- Connect Mode: only the nodes/ports compatible with the dropped connection -->
+    <template v-if="isConnectMode">
+      <div
+        v-for="option in connectionOptions"
+        :key="`${option.nodeType}-${option.handleId}`"
+        class="node-item"
+        @click="emit('connect-option', option)"
+      >
+        <span class="node-icon">{{ getNodeIcon(option.nodeType) }}</span>
+        <span class="node-text">{{ getOptionLabel(option) }}</span>
+      </div>
 
-    <!-- Separator -->
-    <div class="separator"></div>
+      <span v-if="connectionOptions.length === 0" class="empty-label">
+        No compatible nodes
+      </span>
+    </template>
 
-    <!-- Inputs Section -->
-    <span class="section-label">Inputs</span>
-    <div
-      v-for="nodeDef in inputNodes"
-      :key="nodeDef.type"
-      class="node-item"
-      draggable="true"
-      @dragstart="emit('drag-start', $event, nodeDef.type)"
-      @click="emit('node-click', nodeDef.type)"
-    >
-      <span class="node-icon">{{ getNodeIcon(nodeDef.type) }}</span>
-      <span class="node-text">{{ nodeDef.label }}</span>
-    </div>
+    <template v-else>
+      <!-- AI Section -->
+      <span class="section-label">AI</span>
+      <div
+        v-for="nodeDef in aiNodes"
+        :key="nodeDef.type"
+        class="node-item"
+        draggable="true"
+        @dragstart="emit('drag-start', $event, nodeDef.type)"
+        @click="emit('node-click', nodeDef.type)"
+      >
+        <span class="node-icon">{{ getNodeIcon(nodeDef.type) }}</span>
+        <span class="node-text">{{ nodeDef.label }}</span>
+      </div>
 
-    <!-- Separator -->
-    <div class="separator"></div>
+      <!-- Separator -->
+      <div class="separator"></div>
 
-    <!-- Helpers Section -->
-    <span class="section-label">Helpers</span>
-    <div
-      v-for="nodeDef in helperNodes"
-      :key="nodeDef.type"
-      class="node-item"
-      draggable="true"
-      @dragstart="emit('drag-start', $event, nodeDef.type)"
-      @click="emit('node-click', nodeDef.type)"
-    >
-      <span class="node-icon">{{ getNodeIcon(nodeDef.type) }}</span>
-      <span class="node-text">{{ nodeDef.label }}</span>
-    </div>
+      <!-- Inputs Section -->
+      <span class="section-label">Inputs</span>
+      <div
+        v-for="nodeDef in inputNodes"
+        :key="nodeDef.type"
+        class="node-item"
+        draggable="true"
+        @dragstart="emit('drag-start', $event, nodeDef.type)"
+        @click="emit('node-click', nodeDef.type)"
+      >
+        <span class="node-icon">{{ getNodeIcon(nodeDef.type) }}</span>
+        <span class="node-text">{{ nodeDef.label }}</span>
+      </div>
+
+      <!-- Separator -->
+      <div class="separator"></div>
+
+      <!-- Helpers Section -->
+      <span class="section-label">Helpers</span>
+      <div
+        v-for="nodeDef in helperNodes"
+        :key="nodeDef.type"
+        class="node-item"
+        draggable="true"
+        @dragstart="emit('drag-start', $event, nodeDef.type)"
+        @click="emit('node-click', nodeDef.type)"
+      >
+        <span class="node-icon">{{ getNodeIcon(nodeDef.type) }}</span>
+        <span class="node-text">{{ nodeDef.label }}</span>
+      </div>
+    </template>
   </aside>
 </template>
 
@@ -64,8 +83,16 @@ const props = defineProps({
   position: {
     type: Object,
     default: null
+  },
+  // When set, the menu switches to "connect mode" and only lists these options
+  connectionOptions: {
+    type: Array,
+    default: null
   }
 })
+
+// Connect mode is driven by a pending connection dropped on the empty canvas
+const isConnectMode = computed(() => props.connectionOptions !== null)
 
 // Computed style for positioned menu (double-click mode)
 const positionStyle = computed(() => {
@@ -79,7 +106,7 @@ const positionStyle = computed(() => {
   return null
 })
 
-const emit = defineEmits(['drag-start', 'node-click'])
+const emit = defineEmits(['drag-start', 'node-click', 'connect-option'])
 
 // Categorize nodes
 const aiNodes = computed(() =>
@@ -105,6 +132,15 @@ const helperNodes = computed(() =>
     n.type === NODE_TYPES.COMMENT
   )
 )
+
+/**
+ * Label for a connect option, disambiguating nodes with several compatible ports
+ * (e.g. Image Diff, whose two inputs are both "image")
+ */
+function getOptionLabel(option) {
+  if (option.portCount <= 1) return option.label
+  return `${option.label} · ${option.portType} ${option.portIndex + 1}`
+}
 
 function getNodeIcon(type) {
   const icons = {
@@ -155,6 +191,13 @@ function getNodeIcon(type) {
   margin-top: 4px;
 }
 
+.empty-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  color: #666666;
+  padding: 8px 0;
+}
+
 .node-item {
   display: flex;
   align-items: center;
@@ -164,6 +207,11 @@ function getNodeIcon(type) {
   border-radius: 6px;
   cursor: grab;
   transition: all 0.15s ease;
+}
+
+/* In connect mode items are click-only, so no grab cursor */
+.node-item:not([draggable='true']) {
+  cursor: pointer;
 }
 
 .node-item:hover {

--- a/src/components/canvas/NodesSidebar.vue
+++ b/src/components/canvas/NodesSidebar.vue
@@ -6,12 +6,12 @@
     <template v-if="isConnectMode">
       <div
         v-for="option in connectionOptions"
-        :key="`${option.nodeType}-${option.handleId}`"
+        :key="option.nodeType"
         class="node-item"
         @click="emit('connect-option', option)"
       >
         <span class="node-icon">{{ getNodeIcon(option.nodeType) }}</span>
-        <span class="node-text">{{ getOptionLabel(option) }}</span>
+        <span class="node-text">{{ option.label }}</span>
       </div>
 
       <span v-if="connectionOptions.length === 0" class="empty-label">
@@ -132,15 +132,6 @@ const helperNodes = computed(() =>
     n.type === NODE_TYPES.COMMENT
   )
 )
-
-/**
- * Label for a connect option, disambiguating nodes with several compatible ports
- * (e.g. Image Diff, whose two inputs are both "image")
- */
-function getOptionLabel(option) {
-  if (option.portCount <= 1) return option.label
-  return `${option.label} · ${option.portType} ${option.portIndex + 1}`
-}
 
 function getNodeIcon(type) {
   const icons = {

--- a/src/composables/useConnectionDrop.js
+++ b/src/composables/useConnectionDrop.js
@@ -1,0 +1,178 @@
+/**
+ * Composable for Connection Drop on empty canvas
+ * When a connection is dragged from a handle and released over the empty pane,
+ * opens the nodes menu filtered to the types that can actually connect to that port,
+ * and creates the chosen node already wired to the origin handle
+ */
+
+import { computed, nextTick, ref } from 'vue'
+import {
+  getHandlePortType,
+  getCompatibleConnectionOptions,
+  validateConnection
+} from '@/lib/connection'
+
+// Rough node size used to place the new node around the drop point
+const NODE_WIDTH = 220
+const NODE_HALF_HEIGHT = 50
+
+export function useConnectionDrop(
+  flowStore,
+  createNodeAtPosition,
+  screenToFlowCoordinate,
+  { addEdges },
+  openNodesMenuAt,
+  closeMenu
+) {
+  const pendingConnection = ref(null)
+
+  // Origin of the connection currently being dragged
+  let connectionOrigin = null
+  // VueFlow emits `connect` before `connectEnd`, so this flag tells
+  // "dropped in the void" apart from "dropped on a valid handle"
+  let connectionMade = false
+  // Timestamp of the drop, to recognise the click fired by that very same gesture
+  let dropTimeStamp = -Infinity
+
+  /**
+   * Node types (and specific handles) the pending connection can be wired to
+   */
+  const connectionOptions = computed(() => {
+    if (!pendingConnection.value) return []
+
+    return getCompatibleConnectionOptions(
+      pendingConnection.value.portType,
+      pendingConnection.value.handleType
+    )
+  })
+
+  /**
+   * Handle the start of a connection drag
+   * @param {Object} params - VueFlow payload { event, nodeId, handleId, handleType }
+   */
+  function handleConnectStart({ nodeId, handleId, handleType }) {
+    connectionMade = false
+    connectionOrigin = { nodeId, handleId, handleType }
+  }
+
+  /**
+   * Flag that a real connection was created, so the menu is not opened
+   */
+  function markConnectionMade() {
+    connectionMade = true
+  }
+
+  /**
+   * Handle the end of a connection drag
+   * @param {MouseEvent|TouchEvent|undefined} event - Pointer event that ended the drag
+   */
+  function handleConnectEnd(event) {
+    const origin = connectionOrigin
+    connectionOrigin = null
+
+    if (connectionMade || !origin || !event) return
+
+    // Only react when dropped on the empty pane, never on top of a node
+    if (!event.target?.classList?.contains('vue-flow__pane')) return
+
+    const originNode = flowStore.nodes.find(n => n.id === origin.nodeId)
+    if (!originNode) return
+
+    const portType = getHandlePortType(originNode.type, origin.handleId, origin.handleType)
+    if (!portType) return
+
+    const dropPosition = screenToFlowCoordinate({ x: event.clientX, y: event.clientY })
+
+    // Dragging from an output places the new node to the right of the drop point,
+    // dragging from an input places it to the left
+    const position = {
+      x: origin.handleType === 'source' ? dropPosition.x : dropPosition.x - NODE_WIDTH,
+      y: dropPosition.y - NODE_HALF_HEIGHT
+    }
+
+    pendingConnection.value = { ...origin, portType, position }
+    dropTimeStamp = event.timeStamp
+
+    // Defer opening until VueFlow has finished tearing down the connection line
+    nextTick(() => openNodesMenuAt(event.clientX, event.clientY))
+  }
+
+  /**
+   * Whether a click belongs to the same gesture that just dropped the connection
+   * Releasing the drag fires mouseup and click back to back, and that click must
+   * not be treated as "clicked outside the menu"
+   * @param {MouseEvent} event - Click event
+   * @returns {boolean}
+   */
+  function isDropGestureClick(event) {
+    return event.timeStamp - dropTimeStamp < 100
+  }
+
+  /**
+   * Create the chosen node at the drop position and connect it to the origin handle
+   * @param {Object} option - Option from connectionOptions
+   */
+  async function createNodeFromConnection(option) {
+    const pending = pendingConnection.value
+    if (!pending || !option) return
+
+    const newNode = createNodeAtPosition(option.nodeType, pending.position)
+    if (!newNode) {
+      cancelPendingConnection()
+      return
+    }
+
+    // Wait for VueFlow to process the new node before adding the edge
+    await nextTick()
+
+    const draggedFromOutput = pending.handleType === 'source'
+    const connection = {
+      source: draggedFromOutput ? pending.nodeId : newNode.id,
+      sourceHandle: draggedFromOutput ? pending.handleId : option.handleId,
+      target: draggedFromOutput ? newNode.id : pending.nodeId,
+      targetHandle: draggedFromOutput ? option.handleId : pending.handleId
+    }
+
+    const sourceNode = flowStore.nodes.find(n => n.id === connection.source)
+    const targetNode = flowStore.nodes.find(n => n.id === connection.target)
+
+    const validation = validateConnection(
+      connection,
+      sourceNode,
+      targetNode,
+      flowStore.edges,
+      flowStore.nodes
+    )
+
+    if (validation.valid) {
+      addEdges([connection])
+      flowStore.clearError()
+    } else {
+      console.warn('Connection rejected:', validation.reason)
+    }
+
+    cancelPendingConnection()
+    closeMenu()
+  }
+
+  /**
+   * Drop the pending connection, leaving the menu in its regular mode
+   */
+  function cancelPendingConnection() {
+    pendingConnection.value = null
+    connectionOrigin = null
+    connectionMade = false
+    dropTimeStamp = -Infinity
+  }
+
+  return {
+    pendingConnection,
+    connectionOptions,
+    handleConnectStart,
+    handleConnectEnd,
+    markConnectionMade,
+    isDropGestureClick,
+    createNodeFromConnection,
+    cancelPendingConnection
+  }
+}

--- a/src/composables/useContextMenu.js
+++ b/src/composables/useContextMenu.js
@@ -42,19 +42,28 @@ export function useContextMenu(isNodesMenuOpen) {
   }
 
   /**
-   * Handle right-click on empty canvas to show context menu
+   * Open the nodes menu at a given screen position, bounded to the window
+   * @param {number} clientX - Screen X coordinate
+   * @param {number} clientY - Screen Y coordinate
    */
-  function handlePaneContextMenu(event) {
+  function openNodesMenuAt(clientX, clientY) {
     const canvasWrapper = document.querySelector('.canvas-wrapper')
     if (!canvasWrapper) return
 
     const rect = canvasWrapper.getBoundingClientRect()
-    const clickX = event.clientX - rect.left
-    const clickY = event.clientY - rect.top
+    const posX = clientX - rect.left
+    const posY = clientY - rect.top
 
-    menuPosition.value = calculateBoundedPosition(clickX, clickY, rect)
+    menuPosition.value = calculateBoundedPosition(posX, posY, rect)
     closeNodeMenu()
     isNodesMenuOpen.value = true
+  }
+
+  /**
+   * Handle right-click on empty canvas to show context menu
+   */
+  function handlePaneContextMenu(event) {
+    openNodesMenuAt(event.clientX, event.clientY)
   }
 
   /**
@@ -107,6 +116,7 @@ export function useContextMenu(isNodesMenuOpen) {
     menuPosition,
     nodeMenuPosition,
     contextNode,
+    openNodesMenuAt,
     handlePaneContextMenu,
     handleNodeContextMenu,
     resetMenuPosition,

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -32,6 +32,28 @@ export function getEdgePortType(edge, nodes, registry, isSource = true) {
 }
 
 /**
+ * Get the PORT_TYPE of a single handle from the registry
+ * Handle IDs follow the `input-<index>` / `output-<index>` convention
+ * @param {string} nodeType - Node type
+ * @param {string} handleId - Handle ID (e.g., "output-0")
+ * @param {string} handleType - VueFlow handle type ('source' or 'target')
+ * @returns {string|null} PORT_TYPE ('image', 'prompt') or null
+ */
+export function getHandlePortType(nodeType, handleId, handleType) {
+  if (!nodeType || !handleId) return null
+
+  const nodeDef = nodeRegistry.getNodeDef(nodeType)
+  if (!nodeDef) return null
+
+  const handleIndex = parseInt(handleId.split('-')[1])
+  if (isNaN(handleIndex)) return null
+
+  const portTypes = handleType === 'source' ? nodeDef.outputs : nodeDef.inputs
+
+  return portTypes[handleIndex] || null
+}
+
+/**
  * Validates if two port types are compatible to connect (private)
  * @param {string} sourcePortType - Output port type
  * @param {string} targetPortType - Input port type
@@ -40,6 +62,46 @@ export function getEdgePortType(edge, nodes, registry, isSource = true) {
 function canConnect(sourcePortType, targetPortType) {
   // Ports must be of the same type to connect
   return sourcePortType === targetPortType
+}
+
+/**
+ * List every node type + handle that can connect to a given port
+ * Used when a connection is dropped on empty canvas: the menu only offers
+ * the nodes (and the specific ports) that are actually connectable
+ * @param {string} portType - PORT_TYPE of the port the connection started from
+ * @param {string} handleType - Handle type of the origin ('source' or 'target')
+ * @returns {Array<Object>} Options: { nodeType, label, handleId, portType, portIndex, portCount }
+ */
+export function getCompatibleConnectionOptions(portType, handleType) {
+  if (!portType) return []
+
+  // Dragging from an output looks for inputs, and the other way around
+  const lookingForInputs = handleType === 'source'
+  const handlePrefix = lookingForInputs ? 'input' : 'output'
+
+  const options = []
+
+  nodeRegistry.listNodes().forEach(nodeDef => {
+    if (nodeDef.config?.hidden) return
+
+    const portTypes = lookingForInputs ? nodeDef.inputs : nodeDef.outputs
+    const compatibleIndexes = portTypes
+      .map((type, index) => (canConnect(portType, type) ? index : -1))
+      .filter(index => index !== -1)
+
+    compatibleIndexes.forEach(index => {
+      options.push({
+        nodeType: nodeDef.type,
+        label: nodeDef.label,
+        handleId: `${handlePrefix}-${index}`,
+        portType: portTypes[index],
+        portIndex: index,
+        portCount: compatibleIndexes.length
+      })
+    })
+  })
+
+  return options
 }
 
 /**

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -65,12 +65,13 @@ function canConnect(sourcePortType, targetPortType) {
 }
 
 /**
- * List every node type + handle that can connect to a given port
+ * List the node types that can connect to a given port
  * Used when a connection is dropped on empty canvas: the menu only offers
- * the nodes (and the specific ports) that are actually connectable
+ * the nodes that are actually connectable, once each, wired to their first
+ * compatible port
  * @param {string} portType - PORT_TYPE of the port the connection started from
  * @param {string} handleType - Handle type of the origin ('source' or 'target')
- * @returns {Array<Object>} Options: { nodeType, label, handleId, portType, portIndex, portCount }
+ * @returns {Array<Object>} Options: { nodeType, label, handleId, portType }
  */
 export function getCompatibleConnectionOptions(portType, handleType) {
   if (!portType) return []
@@ -85,19 +86,14 @@ export function getCompatibleConnectionOptions(portType, handleType) {
     if (nodeDef.config?.hidden) return
 
     const portTypes = lookingForInputs ? nodeDef.inputs : nodeDef.outputs
-    const compatibleIndexes = portTypes
-      .map((type, index) => (canConnect(portType, type) ? index : -1))
-      .filter(index => index !== -1)
+    const portIndex = portTypes.findIndex(type => canConnect(portType, type))
+    if (portIndex === -1) return
 
-    compatibleIndexes.forEach(index => {
-      options.push({
-        nodeType: nodeDef.type,
-        label: nodeDef.label,
-        handleId: `${handlePrefix}-${index}`,
-        portType: portTypes[index],
-        portIndex: index,
-        portCount: compatibleIndexes.length
-      })
+    options.push({
+      nodeType: nodeDef.type,
+      label: nodeDef.label,
+      handleId: `${handlePrefix}-${portIndex}`,
+      portType: portTypes[portIndex]
     })
   })
 

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -30,8 +30,10 @@
         ref="sidebarMenu"
         :nodes="availableNodes"
         :position="menuPosition"
+        :connection-options="pendingConnection ? connectionOptions : null"
         @drag-start="onDragStart"
         @node-click="onNodeItemClick"
+        @connect-option="createNodeFromConnection"
       />
 
       <!-- Node Context Menu -->
@@ -117,6 +119,7 @@ import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import { useGroupManagement } from '@/composables/useGroupManagement'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 import { useContextMenu } from '@/composables/useContextMenu'
+import { useConnectionDrop } from '@/composables/useConnectionDrop'
 
 const flowStore = useFlowStore()
 const settingsStore = useSettingsStore()
@@ -136,7 +139,7 @@ const showIntro = ref(false)
 const showAlert = computed(() => !settingsStore.getReplicateApiKey())
 
 // VueFlow composable
-const { findNode, onConnect, addEdges, viewport, onNodeDragStop, fitView, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()
+const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()
 
 // Use composables
 const { fileInput, handleExport, handleImport, onFileSelected, getDefaultFilename } = useFlowIO(flowStore, { addEdges })
@@ -158,11 +161,18 @@ function onSaveDialogSave(filename) {
   handleExport(filename)
 }
 
+// Close the nodes menu and drop any connection waiting for a node
+function closeNodesMenu() {
+  cancelPendingConnection()
+  closeMenu()
+}
+
 // Toggle nodes menu from floating menu (reset position for sidebar mode)
 function toggleNodesMenu() {
   if (isNodesMenuOpen.value) {
-    closeMenu()
+    closeNodesMenu()
   } else {
+    cancelPendingConnection() // Ensure regular mode (not filtered by a connection)
     resetMenuPosition() // Ensure sidebar mode (no custom position)
     isNodesMenuOpen.value = true
   }
@@ -174,18 +184,33 @@ const {
   menuPosition,
   nodeMenuPosition,
   contextNode,
+  openNodesMenuAt,
   handlePaneContextMenu,
   handleNodeContextMenu,
   resetMenuPosition,
   closeNodeMenu,
   closeMenu
 } = useContextMenu(isNodesMenuOpen)
-const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, { addEdges }, resetMenuPosition)
+const {
+  pendingConnection,
+  connectionOptions,
+  handleConnectStart,
+  handleConnectEnd,
+  markConnectionMade,
+  isDropGestureClick,
+  createNodeFromConnection,
+  cancelPendingConnection
+} = useConnectionDrop(flowStore, createNodeAtPosition, screenToFlowCoordinate, { addEdges }, openNodesMenuAt, closeMenu)
+const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, { addEdges }, closeNodesMenu)
 const { handleGroup } = useGroupManagement(flowStore, onNodeDragStop)
 
 // Register right-click handlers for context menus
 onPaneContextMenu(handlePaneContextMenu)
 onNodeContextMenu(handleNodeContextMenu)
+
+// Register connection drop handlers (drag from a handle, release on empty canvas)
+onConnectStart(handleConnectStart)
+onConnectEnd(handleConnectEnd)
 
 // Set (or clear) the batch role of the node targeted by the context menu
 function onSetBatchRole(role) {
@@ -201,6 +226,7 @@ useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowSto
 // Register connection handler - use addEdges directly
 onConnect((params) => {
   // Validation already done by isValidConnection
+  markConnectionMade()
   addEdges([params])
   flowStore.clearError()
 })
@@ -225,6 +251,9 @@ function handleClickOutside(event) {
 
   if (!isNodesMenuOpen.value) return
 
+  // The click that released the connection must not close the menu it just opened
+  if (pendingConnection.value && isDropGestureClick(event)) return
+
   const floatingMenuEl = floatingMenu.value?.$el || floatingMenu.value
   const sidebarMenuEl = sidebarMenu.value?.$el || sidebarMenu.value
 
@@ -232,7 +261,7 @@ function handleClickOutside(event) {
   const clickedSidebar = sidebarMenuEl?.contains(event.target)
 
   if (!clickedFloatingMenu && !clickedSidebar) {
-    closeMenu()
+    closeNodesMenu()
   }
 }
 


### PR DESCRIPTION
# What

Dragging a cable out of a node's port and releasing it on the empty canvas used to do nothing: the gesture was lost and you had to open the nodes menu, create the node, and wire it by hand.

Now, releasing the cable in the void opens the nodes menu right at the cursor, titled **Connect to**, showing **only** the node types that can actually be connected to that port. Picking one creates the node where you dropped the cable, already connected.

It works in both directions:
- from an **output** port, the new node lands to the right;
- from an **input** port, the new node lands to the left.

Each compatible node type is listed **once**, and gets wired to its first compatible port. So dragging an `image` cable offers Image Generator, Text Generator, Draw, Image Diff and Image Compare, while Prompt or Comment never show up.

If the cable is released on top of a node, or close enough to a valid handle for it to snap, nothing changes: it connects as before and no menu appears.

# Why

The canvas already knew which ports are compatible with which — `validateConnection` rejects invalid edges — but that knowledge was only used to say *no*. This reuses it to actively suggest what comes next, turning a dead-end gesture into the fastest way to grow a pipeline.

The port compatibility logic lives in `connection.js`, next to the existing validation, as two new helpers: `getHandlePortType` (what type is this port?) and `getCompatibleConnectionOptions` (what can it reach?). Both read the `NodeRegistry`, so a newly registered node type shows up in the menu with no extra wiring.

The gesture itself is owned by a new `useConnectionDrop` composable, following the same composable-first pattern as `useDragAndDrop` and `useCopyPaste`, so `FlowCanvasView` only orchestrates. `useContextMenu` gained an `openNodesMenuAt()` function — extracted from the existing right-click handler — so both entry points position the menu the same way. `NodesSidebar` takes an optional `connectionOptions` prop that switches it to a flat list; without it, the menu renders exactly as before.

One subtlety worth noting: the click that ends the drag was reaching the global "click outside" handler and closing the menu the very instant it opened. Disabling the guard makes 3 of the tests fail, so it is covered.

# Tests

e2e tests and local.

Added `e2e/connection-drop.spec.js` with 6 tests. Full suite: **34/34 passing** (28 pre-existing + 6 new). `npm run build` compiles.

## How to test

1. `npm run dev` and open a blank canvas.
2. Add an **Image** node. Drag from its right (green) port and release over empty canvas.
   - [ ] The menu opens at the cursor with the header **Connect to**.
   - [ ] It lists Image Generator, Text Generator, Draw, Image Diff, Image Compare.
   - [ ] It does **not** list Prompt, Prompt Template or Comment.
   - [ ] Image Diff and Image Compare each appear only once.
3. Click **Image Generator**.
   - [ ] The node is created where you released the cable, already connected.
4. Add an **Image Generator** and drag from its lower-left (purple, `prompt`) port towards the left, releasing on empty canvas.
   - [ ] Only Prompt, Prompt Template and Text Generator are offered.
   - [ ] Picking Prompt creates the node to the **left**, connected into the prompt input.
5. Zoom out with the wheel and pan the canvas, then repeat step 2.
   - [ ] The new node still lands where you released the cable.
6. Drag a cable and release it right on top of a valid port of another node.
   - [ ] It connects as usual and **no** menu appears.
7. Open the menu with the `+` button in the floating toolbar, and with right-click on empty canvas.
   - [ ] Both still show the full palette with the AI / Inputs / Helpers sections.