### PR TITLE
feat: rename nodes from the header and keep names unique

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,10 +164,11 @@ useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowSto
 - `id` - Unique node ID
 - `type` - Node type
 - `data` - Node data
-- `label` - Node title
+- `label` - Fallback node title (the real one is read from `data.label`, see below)
 - `inputs` - Array of input types
 - `outputs` - Array of output types
 - `icon` - Emoji for header
+- `hideHeader` - Never show the header, even when the setting is on (used by `CommentNode`, whose content is already its text)
 - `loading` - Loading state
 - `error` - Error message
 - `selected` - If selected
@@ -178,6 +179,15 @@ useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowSto
 - Optional action button (`@action:run`)
 - Consistent styles for all nodes
 - Optional header display controlled by settings store
+- **Renamable title:** double-clicking the header title turns it into an input (Enter confirms, Escape reverts, an empty name keeps the previous one). BaseNode owns the write — `updateNodeData(id, { label })` after `ensureUniqueLabel()` — so no node component duplicates it. Renaming with the header hidden goes through the right-click menu instead (`RenameNodeDialog`).
+
+**The title comes from `data.label`, not from the `label` prop:**
+```javascript
+// VueFlow passes a top-level `label` down to every node component. Being
+// undeclared there, that undefined value falls through $attrs into BaseNode and
+// overrides the `:label="nodeData.label"` the node binds explicitly
+const nodeLabel = computed(() => props.data?.label || props.label)
+```
 
 **Settings integration:**
 ```javascript
@@ -975,7 +985,7 @@ Each row also has its own **Run / Retry** button, which executes only that row t
 
 The input table can be downloaded as CSV, filled in elsewhere (Excel, Sheets, a script) and imported back. The imported row count wins, so handing back 8 rows for a 4-row template is fine.
 
-- **Headers are the human-readable column labels** (`Prompt Template · ANIMAL`). Import matches by exact header; a header that matches nothing is reported as ignored rather than silently landing in the wrong column. A header for a variable the canvas does not declare yet is resolved through its `<node label> · <VARIABLE>` prefix, since a row's own template may introduce it.
+- **Headers are the human-readable column labels** (`Prompt Template · ANIMAL`), i.e. the node names the user can edit from the header. Import matches by exact header; a header that matches nothing is reported as ignored rather than silently landing in the wrong column. A header for a variable the canvas does not declare yet is resolved through its `<node label> · <VARIABLE>` prefix, since a row's own template may introduce it. This is why node names are kept unique (`src/lib/node-label.js`): two homonymous inputs would collapse into a single column on import, and the first one would silently never receive its values.
 - **Quoting is handled properly** — prompts routinely contain commas, quotes and newlines. Export writes a UTF-8 BOM so Excel does not mangle accents, and import sniffs the delimiter (`,`, `;`, tab) because localized Excel writes `;`.
 - **Images travel as filenames.** An image cell holds `{ name, src }`: the CSV carries only `name`, and the bytes arrive when the user drops the files on the panel's upload zone, where they are matched to every cell referencing that filename. A file used by several rows is applied to all of them.
 - **A row missing its image is skipped, not blocking.** `Run batch` generates the complete rows and marks the rest `Missing image: <file>`; their per-row Run button stays disabled until the file is uploaded.

--- a/docs/CREATING-NODES.md
+++ b/docs/CREATING-NODES.md
@@ -71,7 +71,11 @@ Create a file in `src/components/nodes/` (e.g., `TextAnalyzerNode.vue`).
     </div>
   </BaseNode>
 </template>
+```
 
+> **About the title:** always pass `:id="id"` and `:data="nodeData"` — BaseNode reads the node name from `data.label` and owns the in-place rename (double-click on the header). Do not write `label` from the node component: it would duplicate logic BaseNode already has, including the uniqueness check (`src/lib/node-label.js`). Pass `:hide-header="true"` if your node must never show a header, like `CommentNode`, whose content is already its text.
+
+```vue
 <script setup>
 import { ref, computed } from 'vue'
 import { useNode, useVueFlow } from '@vue-flow/core'

--- a/e2e/batch-run.spec.js
+++ b/e2e/batch-run.spec.js
@@ -5,6 +5,7 @@ import {
   addNodeFromSidebar,
   connectNodes,
   positionNodes,
+  renameNode,
   TEST_IMAGE_PATH,
 } from './helpers/canvas.js'
 
@@ -619,6 +620,76 @@ test.describe('Batch Run CSV', () => {
     await expect(rows.nth(1)).toContainText('Missing image: shot-b.png')
 
     expect(received).toHaveLength(1)
+  })
+
+  test('renamed nodes name the modal columns and the CSV headers', async ({ page }) => {
+    const received = []
+    await mockNanaBananaPro(page, { assertRequest: (b) => received.push(b.input.prompt) })
+
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt Template')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    const templateNode = page.locator('.vue-flow__node-prompt-template')
+    const generatorNode = page.locator('.vue-flow__node-image-generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 20, y: 40 },
+      { type: 'prompt-template', x: 540, y: 40 },
+      { type: 'image-generator', x: 950, y: 40 },
+    ])
+
+    await promptNode.locator('textarea').fill('A {{ANIMAL}} here')
+    await promptNode.locator('textarea').blur()
+    await page.waitForTimeout(300)
+
+    await connectNodes(page, promptNode, 'output-0', templateNode, 'input-0')
+    await connectNodes(page, templateNode, 'output-0', generatorNode, 'input-1')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(2, { timeout: 5000 })
+
+    await renameNode(page, templateNode, 'Scene')
+    await renameNode(page, generatorNode, 'Render')
+
+    await markBatchRole(page, templateNode, 'Mark as batch input')
+    await markBatchRole(page, generatorNode, 'Mark as batch output')
+
+    await page.locator('button[title="Batch Run"]').click()
+    const modal = page.locator('.batch-content')
+
+    // The table header and the legend are built from the node names
+    await expect(modal.locator('th.col-input')).toHaveText('Scene · ANIMAL')
+    await expect(modal.locator('th.col-output')).toHaveText('Render')
+    await expect(modal.locator('.batch-legend')).toContainText('Inputs: Scene')
+    await expect(modal.locator('.batch-legend')).toContainText('Outputs: Render')
+
+    await modal.locator('#run-count').fill('2')
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      modal.getByRole('button', { name: 'Download CSV' }).click(),
+    ])
+    const csvText = await (await import('fs/promises')).readFile(await download.path(), 'utf8')
+    expect(csvText).toContain('Scene · ANIMAL')
+    expect(csvText).not.toContain('New Prompt Template')
+
+    // The renamed header still maps back on import
+    const header = csvText.split(/\r?\n/)[0]
+    await modal.locator('input[type="file"][accept*="csv"]').setInputFiles({
+      name: 'filled.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from([header, '1,fox', '2,bear'].join('\r\n'), 'utf8'),
+    })
+
+    const rows = modal.locator('.batch-table tbody tr')
+    await expect(rows).toHaveCount(2)
+    await expect(modal.locator('.csv-message')).toContainText('Imported 2 rows')
+
+    await modal.getByRole('button', { name: 'Run batch' }).click()
+    await expect(rows.nth(1).locator('.status-done')).toBeVisible({ timeout: 60000 })
+
+    expect(received).toEqual(['A fox here', 'A bear here'])
   })
 })
 

--- a/e2e/helpers/canvas.js
+++ b/e2e/helpers/canvas.js
@@ -5,16 +5,34 @@ export const TEST_IMAGE_PATH = path.resolve(import.meta.dirname, '../assets/back
 
 /**
  * Set a fake API key in localStorage and navigate to a blank canvas.
+ * @param {import('@playwright/test').Page} page
+ * @param {Object} [options]
+ * @param {boolean} [options.showNodeHeaders=false] - Node headers are off by
+ *        default in the app, and the rename editor lives in them
  */
-export async function setupBlankCanvas(page) {
-  await page.addInitScript(() => {
-    localStorage.setItem(
-      'flora-settings',
-      JSON.stringify({ replicateApiKey: 'test-api-key-fake', openaiApiKey: 'test-openai-key-fake' })
-    )
+export async function setupBlankCanvas(page, { showNodeHeaders = false } = {}) {
+  await page.addInitScript((settings) => {
+    localStorage.setItem('flora-settings', JSON.stringify(settings))
+  }, {
+    replicateApiKey: 'test-api-key-fake',
+    openaiApiKey: 'test-openai-key-fake',
+    showNodeHeaders,
   })
   await page.goto('/')
   await page.getByText('Blank canvas').click()
+}
+
+/**
+ * Rename a node by double-clicking its header title.
+ * Requires setupBlankCanvas(page, { showNodeHeaders: true }).
+ */
+export async function renameNode(page, nodeLocator, newName) {
+  await nodeLocator.locator('.node-label').dblclick()
+  const input = nodeLocator.locator('.node-label-input')
+  await input.waitFor({ state: 'visible', timeout: 3000 })
+  await input.fill(newName)
+  await input.press('Enter')
+  await input.waitFor({ state: 'detached', timeout: 3000 })
 }
 
 /**

--- a/e2e/node-rename.spec.js
+++ b/e2e/node-rename.spec.js
@@ -88,6 +88,35 @@ test.describe('Node rename', () => {
     await expect(promptNode.locator('.node-label')).toHaveText('A')
   })
 
+  test('a long name is truncated instead of widening the node', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 240, y: 200 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    const label = promptNode.locator('.node-label')
+    const widthBefore = (await promptNode.boundingBox()).width
+
+    const longName = 'A ridiculously long node name that must not stretch the node at all'
+    await renameNode(page, promptNode, longName)
+
+    // The node keeps its size and the title is ellipsized
+    expect((await promptNode.boundingBox()).width).toBe(widthBefore)
+    const { clientWidth, scrollWidth } = await label.evaluate(el => ({
+      clientWidth: el.clientWidth,
+      scrollWidth: el.scrollWidth,
+    }))
+    expect(scrollWidth).toBeGreaterThan(clientWidth)
+
+    // The full name is still reachable through the native tooltip
+    await expect(label).toHaveAttribute('title', longName)
+
+    // Editing it again does not widen the node either
+    await label.dblclick()
+    await expect(promptNode.locator('.node-label-input')).toBeVisible()
+    expect((await promptNode.boundingBox()).width).toBe(widthBefore)
+  })
+
   test('a repeated name gets a number', async ({ page }) => {
     await setupBlankCanvas(page, { showNodeHeaders: true })
     await addNodeFromSidebar(page, 'Prompt')

--- a/e2e/node-rename.spec.js
+++ b/e2e/node-rename.spec.js
@@ -1,0 +1,168 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+  renameNode,
+} from './helpers/canvas.js'
+
+/**
+ * Read a node's persisted label straight from the store (works with the header
+ * hidden, where there is nothing to assert against in the DOM).
+ */
+async function readLabels(page, type) {
+  return page.evaluate((nodeType) => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    return flowStore.nodes.filter(n => n.type === nodeType).map(n => n.data?.label)
+  }, type)
+}
+
+test.describe('Node rename', () => {
+  test('double-click on the header renames a node', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 240, y: 200 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await expect(promptNode.locator('.node-label')).toHaveText('New Prompt')
+
+    await renameNode(page, promptNode, 'Character sheet')
+    await expect(promptNode.locator('.node-label')).toHaveText('Character sheet')
+
+    // The context menu title reads the same data
+    await promptNode.click({ button: 'right' })
+    await expect(page.locator('.node-context-menu .header')).toHaveText('Character sheet')
+  })
+
+  test('Escape reverts the rename', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 240, y: 200 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await promptNode.locator('.node-label').dblclick()
+
+    const input = promptNode.locator('.node-label-input')
+    await input.fill('discard me')
+    await input.press('Escape')
+
+    await expect(input).toBeHidden()
+    await expect(promptNode.locator('.node-label')).toHaveText('New Prompt')
+  })
+
+  test('an empty name keeps the previous one', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 240, y: 200 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await promptNode.locator('.node-label').dblclick()
+
+    const input = promptNode.locator('.node-label-input')
+    await input.fill('   ')
+    await input.blur()
+
+    await expect(promptNode.locator('.node-label')).toHaveText('New Prompt')
+  })
+
+  test('editing the title neither deletes nor copies the node', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 240, y: 200 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await promptNode.locator('.node-label').dblclick()
+
+    const input = promptNode.locator('.node-label-input')
+    await input.fill('AB')
+
+    // The canvas deletes selected nodes on Backspace/Delete and pastes on Ctrl+V
+    await input.press('Backspace')
+    await input.press('Delete')
+    await input.press('Control+c')
+    await input.press('Control+v')
+    await expect(page.locator('.vue-flow__node-prompt')).toHaveCount(1)
+
+    await input.press('Enter')
+    await expect(promptNode.locator('.node-label')).toHaveText('A')
+  })
+
+  test('a repeated name gets a number', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [
+      { type: 'prompt', x: 120, y: 80 },
+      { type: 'prompt', x: 120, y: 320 },
+      { type: 'prompt', x: 120, y: 560 },
+    ])
+
+    const promptNodes = page.locator('.vue-flow__node-prompt')
+    await renameNode(page, promptNodes.nth(0), 'Scene')
+    await renameNode(page, promptNodes.nth(1), 'Scene')
+    await renameNode(page, promptNodes.nth(2), 'Scene')
+
+    await expect(promptNodes.nth(0).locator('.node-label')).toHaveText('Scene')
+    await expect(promptNodes.nth(1).locator('.node-label')).toHaveText('Scene 2')
+    await expect(promptNodes.nth(2).locator('.node-label')).toHaveText('Scene 3')
+  })
+
+  test('two nodes of the same type get different names on creation', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+
+    expect(await readLabels(page, 'prompt')).toEqual(['New Prompt', 'New Prompt 2'])
+  })
+
+  test('the new name survives export/import', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 240, y: 200 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await renameNode(page, promptNode, 'Character sheet')
+
+    const exported = await page.evaluate(async () => {
+      const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+      const flowStore = pinia._s.get('flow')
+      const { exportFlow } = await import('/src/lib/flow-io.js')
+      return exportFlow(flowStore)
+    })
+
+    expect(exported.nodes.find(n => n.type === 'prompt').data.label).toBe('Character sheet')
+
+    await page.evaluate(async (flowData) => {
+      const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+      const flowStore = pinia._s.get('flow')
+      const { importFlow } = await import('/src/lib/flow-io.js')
+      flowStore.nodes.splice(0, flowStore.nodes.length)
+      await importFlow(flowData, flowStore)
+    }, exported)
+
+    await expect(page.locator('.vue-flow__node-prompt .node-label')).toHaveText('Character sheet')
+  })
+
+  test('renaming from the context menu works with headers hidden', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 240, y: 200 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await expect(promptNode.locator('.node-label')).toBeHidden()
+
+    await promptNode.click({ button: 'right' })
+    const menu = page.locator('.node-context-menu')
+    await menu.waitFor({ state: 'visible', timeout: 3000 })
+    await menu.locator('.menu-text').filter({ hasText: 'Rename' }).click()
+
+    const dialog = page.locator('#node-name')
+    await dialog.waitFor({ state: 'visible', timeout: 3000 })
+    await dialog.fill('Renamed from menu')
+    await dialog.press('Enter')
+
+    expect(await readLabels(page, 'prompt')).toEqual(['Renamed from menu'])
+  })
+})

--- a/src/components/base/BaseNode.vue
+++ b/src/components/base/BaseNode.vue
@@ -62,10 +62,25 @@
     </div>
 
     <!-- Header Slot -->
-    <div v-if="settingsStore.showNodeHeaders" class="node-header">
+    <div v-if="settingsStore.showNodeHeaders && !hideHeader" class="node-header">
       <slot name="header">
         <span class="node-icon">{{ icon }}</span>
-        <span class="node-label">{{ label }}</span>
+        <input
+          v-if="isEditingLabel"
+          ref="labelInput"
+          v-model="labelDraft"
+          class="node-label-input nodrag nopan"
+          @mousedown.stop
+          @dblclick.stop
+          @keydown="onLabelKeydown"
+          @blur="commitLabel"
+        />
+        <span
+          v-else
+          class="node-label"
+          title="Double-click to rename"
+          @dblclick.stop.prevent="startEditingLabel"
+        >{{ nodeLabel }}</span>
       </slot>
     </div>
 
@@ -93,12 +108,14 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
-import { Handle, Position } from '@vue-flow/core'
+import { computed, nextTick, ref } from 'vue'
+import { Handle, Position, useVueFlow } from '@vue-flow/core'
 import { useSettingsStore } from '@/stores/settings'
 import { canTakeBatchRole } from '@/lib/batch-io'
+import { ensureUniqueLabel } from '@/lib/node-label'
 
 const settingsStore = useSettingsStore()
+const { updateNodeData, getNodes } = useVueFlow()
 
 const props = defineProps({
   id: {
@@ -120,6 +137,10 @@ const props = defineProps({
   icon: {
     type: String,
     default: '⚙️'
+  },
+  hideHeader: {
+    type: Boolean,
+    default: false
   },
   selected: {
     type: Boolean,
@@ -173,6 +194,54 @@ const batchRole = computed(() => {
 const emit = defineEmits(['update:data', 'action:run', 'action:upload'])
 
 const isSelected = computed(() => props.selected)
+
+/**
+ * Node title. Read from `data` rather than the `label` prop: VueFlow passes a
+ * top-level `label` down to every node component, and that undefined value
+ * falls through $attrs and wins over the binding the node makes explicitly
+ */
+const nodeLabel = computed(() => props.data?.label || props.label)
+
+// In-place rename of the node title (double-click on the header)
+const isEditingLabel = ref(false)
+const labelDraft = ref('')
+const labelInput = ref(null)
+
+async function startEditingLabel() {
+  labelDraft.value = nodeLabel.value
+  isEditingLabel.value = true
+  await nextTick()
+  labelInput.value?.focus()
+  labelInput.value?.select()
+}
+
+/**
+ * Enter confirms, Escape reverts. Keydown never leaves the input: the canvas
+ * deletes nodes on Backspace and groups them on Ctrl+G
+ */
+function onLabelKeydown(event) {
+  event.stopPropagation()
+
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    commitLabel()
+  } else if (event.key === 'Escape') {
+    event.preventDefault()
+    isEditingLabel.value = false
+  }
+}
+
+function commitLabel() {
+  // Escape already closed the editor; the blur it fires must not re-commit
+  if (!isEditingLabel.value) return
+  isEditingLabel.value = false
+
+  // An empty name would leave the node unidentifiable: keep the previous one
+  const next = labelDraft.value.trim()
+  if (!next || next === nodeLabel.value) return
+
+  updateNodeData(props.id, { label: ensureUniqueLabel(next, getNodes.value, props.id) })
+}
 
 /**
  * Calculate handle position for even distribution
@@ -243,6 +312,26 @@ function getPortColor(portType) {
   font-weight: var(--flora-font-weight-semibold);
   color: var(--flora-color-text-primary);
   font-size: var(--flora-font-size-sm);
+  cursor: text;
+  /* The double-click must not leave a word selected behind the input */
+  user-select: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-label-input {
+  flex: 1;
+  min-width: 0;
+  font-family: inherit;
+  font-weight: var(--flora-font-weight-semibold);
+  font-size: var(--flora-font-size-sm);
+  color: var(--flora-color-text-primary);
+  background: var(--flora-color-surface);
+  border: var(--flora-border-width-thin) solid var(--flora-color-accent);
+  border-radius: var(--flora-radius-sm);
+  padding: 0 var(--flora-space-1);
+  outline: none;
 }
 
 .node-content {

--- a/src/components/base/BaseNode.vue
+++ b/src/components/base/BaseNode.vue
@@ -70,6 +70,7 @@
           ref="labelInput"
           v-model="labelDraft"
           class="node-label-input nodrag nopan"
+          size="1"
           @mousedown.stop
           @dblclick.stop
           @keydown="onLabelKeydown"
@@ -78,7 +79,7 @@
         <span
           v-else
           class="node-label"
-          title="Double-click to rename"
+          :title="nodeLabel"
           @dblclick.stop.prevent="startEditingLabel"
         >{{ nodeLabel }}</span>
       </slot>
@@ -302,10 +303,16 @@ function getPortColor(portType) {
   background: var(--flora-color-bg-secondary);
   border-bottom: var(--flora-border-width-thin) solid var(--flora-color-border-subtle);
   border-radius: var(--flora-radius-md) var(--flora-radius-md) 0 0;
+  /* The title must never widen the node: zero intrinsic width, stretched to
+     whatever the node content decides */
+  width: 0;
+  min-width: 100%;
+  overflow: hidden;
 }
 
 .node-icon {
   font-size: var(--flora-font-size-xl);
+  flex-shrink: 0;
 }
 
 .node-label {
@@ -315,13 +322,18 @@ function getPortColor(portType) {
   cursor: text;
   /* The double-click must not leave a word selected behind the input */
   user-select: none;
+  /* A long name is truncated; the native tooltip shows it in full */
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .node-label-input {
+  /* width:0 keeps the input from widening the header past the node */
   flex: 1;
+  width: 0;
   min-width: 0;
   font-family: inherit;
   font-weight: var(--flora-font-weight-semibold);

--- a/src/components/canvas/NodeContextMenu.vue
+++ b/src/components/canvas/NodeContextMenu.vue
@@ -1,6 +1,12 @@
 <template>
   <aside class="node-context-menu" :style="positionStyle">
     <h3 class="header">{{ nodeLabel }}</h3>
+
+    <div class="menu-item" @click="emit('rename')">
+      <span class="menu-icon">✏️</span>
+      <span class="menu-text">Rename</span>
+    </div>
+
     <span class="section-label">Batch Run</span>
 
     <template v-if="supportsBatch">
@@ -56,7 +62,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['set-role'])
+const emit = defineEmits(['set-role', 'rename'])
 
 const positionStyle = computed(() => ({
   left: `${props.position.x}px`,

--- a/src/components/canvas/RenameNodeDialog.vue
+++ b/src/components/canvas/RenameNodeDialog.vue
@@ -1,0 +1,149 @@
+<template>
+  <BaseModal
+    v-model="isOpen"
+    title="Rename Node"
+    :show-header="true"
+    :show-footer="true"
+    size="sm"
+  >
+    <div class="rename-dialog-content">
+      <div class="input-group">
+        <label for="node-name" class="input-label">Name</label>
+        <BaseInput
+          id="node-name"
+          ref="nameInput"
+          v-model="name"
+          placeholder="Enter node name"
+          @keydown.enter="handleRename"
+        />
+        <p class="input-hint">Names must be unique: a repeated one gets a number appended</p>
+      </div>
+    </div>
+
+    <template #footer>
+      <button class="cancel-btn" @click="handleCancel">Cancel</button>
+      <button class="rename-btn" @click="handleRename">Rename</button>
+    </template>
+  </BaseModal>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick } from 'vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import BaseInput from '@/components/ui/BaseInput.vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    required: true
+  },
+  currentLabel: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'rename', 'cancel'])
+
+const nameInput = ref(null)
+
+const isOpen = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+const name = ref('')
+
+// Seed the input with the current name and select it when the dialog opens
+watch(isOpen, (newValue) => {
+  if (newValue) {
+    name.value = props.currentLabel
+
+    nextTick(() => {
+      const input = nameInput.value?.$el
+      if (input && typeof input.focus === 'function') {
+        input.focus()
+        input.select()
+      }
+    })
+  }
+})
+
+function handleRename() {
+  const trimmed = name.value.trim()
+
+  // An empty name would leave the node unidentifiable
+  if (!trimmed) return
+
+  emit('rename', trimmed)
+  isOpen.value = false
+}
+
+function handleCancel() {
+  emit('cancel')
+  isOpen.value = false
+}
+</script>
+
+<style scoped>
+.rename-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-4);
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-1);
+}
+
+.input-label {
+  font-size: var(--flora-font-size-sm);
+  font-weight: var(--flora-font-weight-medium);
+  color: var(--flora-color-text-secondary);
+}
+
+.input-hint {
+  margin: 0;
+  font-size: var(--flora-font-size-xs);
+  color: var(--flora-color-text-tertiary);
+}
+
+.cancel-btn {
+  padding: var(--flora-space-2) var(--flora-space-4);
+  background: transparent;
+  color: var(--flora-color-text-secondary);
+  border: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+  border-radius: var(--flora-radius-md);
+  font-size: var(--flora-font-size-sm);
+  font-weight: var(--flora-font-weight-medium);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.cancel-btn:hover {
+  background: var(--flora-color-bg-secondary);
+  color: var(--flora-color-text-primary);
+}
+
+.rename-btn {
+  padding: var(--flora-space-2) var(--flora-space-4);
+  background: #1ac460;
+  color: white;
+  border: none;
+  border-radius: var(--flora-radius-md);
+  font-size: var(--flora-font-size-sm);
+  font-weight: var(--flora-font-weight-medium);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.rename-btn:hover {
+  background: #15a352;
+}
+
+.rename-btn:active {
+  transform: scale(0.98);
+}
+</style>

--- a/src/components/nodes/GroupNode.vue
+++ b/src/components/nodes/GroupNode.vue
@@ -18,8 +18,10 @@
 
 <script setup>
 import { ref } from 'vue'
+import { useVueFlow } from '@vue-flow/core'
 import { NodeResizer } from '@vue-flow/node-resizer'
 import '@vue-flow/node-resizer/dist/style.css'
+import { ensureUniqueLabel } from '@/lib/node-label'
 
 const props = defineProps({
   id: { type: String, required: true },
@@ -28,11 +30,13 @@ const props = defineProps({
   selected: { type: Boolean, default: false }
 })
 
+const { updateNodeData, getNodes } = useVueFlow()
+
 const labelDiv = ref(null)
 
 function updateLabel(event) {
-  const newLabel = event.target.textContent.trim()
-  props.data.label = newLabel || 'Group'
+  const newLabel = event.target.textContent.trim() || 'Group'
+  updateNodeData(props.id, { label: ensureUniqueLabel(newLabel, getNodes.value, props.id) })
 }
 
 function blurOnEnter(event) {

--- a/src/composables/useCopyPaste.js
+++ b/src/composables/useCopyPaste.js
@@ -5,6 +5,7 @@
 
 import { ref, nextTick } from 'vue'
 import { createNode, getNodeIOConfig } from '@/lib/node-shapes'
+import { ensureUniqueLabel } from '@/lib/node-label'
 
 export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
   const copiedNode = ref(null)
@@ -49,9 +50,10 @@ export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
     // Use already cloned data from handleCopy
     const clonedData = JSON.parse(JSON.stringify(copiedNode.value.data))
 
-    // Update label to indicate it's a copy
+    // The copy cannot reuse the original name: it would collapse both nodes into
+    // a single batch column
     if (clonedData.label) {
-      clonedData.label = `${clonedData.label}`
+      clonedData.label = ensureUniqueLabel(clonedData.label, flowStore.nodes)
     }
 
     // Create new node with same type and data

--- a/src/composables/useDragAndDrop.js
+++ b/src/composables/useDragAndDrop.js
@@ -6,6 +6,7 @@
  */
 
 import { createNode, NODE_TYPES, getNodeIOConfig } from '@/lib/node-shapes'
+import { ensureUniqueLabel } from '@/lib/node-label'
 import { loadFlowFromFile } from '@/lib/flow-io'
 
 export function useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, vueFlowHelpers = {}, onMenuClose = null) {
@@ -68,7 +69,7 @@ export function useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, 
         NODE_TYPES.IMAGE,
         position,
         {
-          label: 'Image',
+          label: ensureUniqueLabel('Image', flowStore.nodes),
           src: event.target.result,
           name: file.name
         },

--- a/src/composables/useGroupManagement.js
+++ b/src/composables/useGroupManagement.js
@@ -6,6 +6,7 @@
 
 import { nextTick } from 'vue'
 import { createNode, NODE_TYPES, getNodeIOConfig } from '@/lib/node-shapes'
+import { ensureUniqueLabel } from '@/lib/node-label'
 
 export function useGroupManagement(flowStore, onNodeDragStop) {
   /**
@@ -143,7 +144,7 @@ export function useGroupManagement(flowStore, onNodeDragStop) {
       parentId,
       NODE_TYPES.GROUP,
       { x: minX, y: minY },
-      { label: 'Group' },
+      { label: ensureUniqueLabel('Group', flowStore.nodes) },
       ioConfig
     )
 

--- a/src/composables/useNodeCreation.js
+++ b/src/composables/useNodeCreation.js
@@ -5,6 +5,7 @@
 
 import { createNode, NODE_TYPES, getNodeIOConfig } from '@/lib/node-shapes'
 import nodeRegistry from '@/lib/node-registry'
+import { ensureUniqueLabel } from '@/lib/node-label'
 import replicateService from '@/services/replicate'
 
 export function useNodeCreation(flowStore) {
@@ -24,9 +25,9 @@ export function useNodeCreation(flowStore) {
     // Get IO configuration for this node type
     const ioConfig = getNodeIOConfig(nodeType)
 
-    // Create node data
+    // Create node data. Labels name the batch columns, so they must be unique
     const data = {
-      label: `New ${nodeDef.label}`
+      label: ensureUniqueLabel(`New ${nodeDef.label}`, flowStore.nodes)
     }
 
     // Add prompt field and model params for generator nodes

--- a/src/lib/node-label.js
+++ b/src/lib/node-label.js
@@ -1,0 +1,44 @@
+/**
+ * Node label utilities
+ * Labels are how a human identifies a node: they name the batch table columns,
+ * the CSV headers and the files inside the batch ZIP, so two nodes on the same
+ * canvas must never share one
+ */
+
+/**
+ * Strip a trailing " 2" / " 3" so a re-colliding name keeps growing from the
+ * same root instead of stacking suffixes ("Scene 2 2")
+ * @param {string} label
+ * @returns {string} Label without its numeric suffix
+ */
+function getLabelRoot(label) {
+  const match = label.match(/^(.*?)\s+\d+$/)
+  return match ? match[1] : label
+}
+
+/**
+ * Make a label unique among the given nodes by appending an incrementing number
+ * @param {string} label - Desired label
+ * @param {Array} nodes - All nodes on the canvas
+ * @param {string|null} [excludeId] - Node being renamed (its own label is free)
+ * @returns {string} The label as-is, or "<label> N" when it was already taken
+ */
+export function ensureUniqueLabel(label, nodes, excludeId = null) {
+  const desired = (label || '').trim()
+  if (!desired) return desired
+
+  const taken = new Set(
+    (nodes || [])
+      .filter(node => node.id !== excludeId)
+      .map(node => (node.data?.label || '').trim())
+      .filter(Boolean)
+  )
+
+  if (!taken.has(desired)) return desired
+
+  const root = getLabelRoot(desired)
+  let suffix = 2
+  while (taken.has(`${root} ${suffix}`)) suffix++
+
+  return `${root} ${suffix}`
+}

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -43,6 +43,7 @@
         :node="contextNode"
         :position="nodeMenuPosition"
         @set-role="onSetBatchRole"
+        @rename="onRenameNode"
       />
 
       <!-- Hidden file input for import -->
@@ -91,6 +92,14 @@
       :default-filename="saveDialogFilename"
       @save="onSaveDialogSave"
     />
+
+    <!-- Rename Node Dialog -->
+    <RenameNodeDialog
+      v-model="isRenameDialogOpen"
+      :current-label="renameTarget?.data?.label || ''"
+      @rename="onRenameConfirm"
+      @cancel="renameTarget = null"
+    />
   </div>
 </template>
 
@@ -102,6 +111,7 @@ import { useFlowStore } from '@/stores/flow'
 import { useSettingsStore } from '@/stores/settings'
 import { validateConnection } from '@/lib/connection'
 import nodeRegistry from '@/lib/node-registry'
+import { ensureUniqueLabel } from '@/lib/node-label'
 import FloatingMenu from '@/components/canvas/FloatingMenu.vue'
 import NodesSidebar from '@/components/canvas/NodesSidebar.vue'
 import NodeContextMenu from '@/components/canvas/NodeContextMenu.vue'
@@ -109,6 +119,7 @@ import SettingsModal from '@/components/canvas/SettingsModal.vue'
 import IntroModal from '@/components/canvas/IntroModal.vue'
 import AlertBanner from '@/components/canvas/AlertBanner.vue'
 import SaveDialog from '@/components/canvas/SaveDialog.vue'
+import RenameNodeDialog from '@/components/canvas/RenameNodeDialog.vue'
 import WorkflowControls from '@/components/workflow/WorkflowControls.vue'
 import BatchRunModal from '@/components/batch/BatchRunModal.vue'
 import { useFlowIO } from '@/composables/useFlowIO'
@@ -132,6 +143,8 @@ const nodeContextMenu = ref(null)
 const isSettingsModalOpen = ref(false)
 const isSaveDialogOpen = ref(false)
 const isBatchModalOpen = ref(false)
+const isRenameDialogOpen = ref(false)
+const renameTarget = ref(null)
 const saveDialogFilename = ref('')
 const showIntro = ref(false)
 
@@ -218,6 +231,23 @@ function onSetBatchRole(role) {
     updateNodeData(contextNode.value.id, { batchRole: role })
   }
   closeNodeMenu()
+}
+
+// Rename the node targeted by the context menu. Headers can be hidden, and the
+// in-place editor lives in them, so renaming also needs a dialog
+function onRenameNode() {
+  renameTarget.value = contextNode.value
+  isRenameDialogOpen.value = true
+  closeNodeMenu()
+}
+
+function onRenameConfirm(label) {
+  if (renameTarget.value) {
+    updateNodeData(renameTarget.value.id, {
+      label: ensureUniqueLabel(label, flowStore.nodes, renameTarget.value.id)
+    })
+  }
+  renameTarget.value = null
 }
 
 // Setup keyboard shortcuts


### PR DESCRIPTION
# What

Nodes can now be renamed. Double-click a node's title in its header and it turns into an editable field: Enter confirms, Escape reverts, and leaving it empty keeps the previous name. Since node headers are hidden by default, the right-click menu also gains a **Rename** entry that opens a small dialog, so renaming works either way.

Names are unique per canvas: repeating one appends an incrementing number (`Scene`, `Scene 2`, `Scene 3`). That applies both when you rename and when nodes are born — two Prompt nodes are now `New Prompt` and `New Prompt 2` instead of two identical ones.

The name is saved in the flow `.json` and travels everywhere it matters for Batch Run: the table column headers, the Inputs/Outputs legend, the downloaded CSV headers and the files inside the results ZIP.

# Why

The node name is the only human-readable identifier the Batch Run panel has. `getBatchInputSpec` names each column after `node.data.label`, and `handleDownloadCsv` uses those same names as the CSV headers — so with two Prompt nodes marked as inputs you got two columns both called `New Prompt` and no way to tell them apart.

Worse, `mapHeaders` maps the CSV back by exact name using a `Map`: two homonymous inputs collapsed into one, the last one won, and the first silently never received its values. Uniqueness (`ensureUniqueLabel`, in the new `node-label.js`) is what makes the round-trip safe. It is deliberately **not** applied when importing a flow — a `.json` must load with exactly the names it was saved with, or a CSV downloaded earlier would stop matching.

All the editing logic lives in `BaseNode`, the single component that renders headers, so none of the nine node components changed. Serialization needed no change either: `flow-io` already exports `data` as a whole.

Two pre-existing bugs surfaced and are fixed here:

- **The header never showed the real node name.** VueFlow passes a top-level `label` down to every node component; being undeclared there, that `undefined` fell through `$attrs` into `BaseNode` and overrode the explicit binding, so every title read `Node`. Nobody noticed because headers are off by default. The title now comes from `data.label`.
- **`BaseNode` finally declares the `hideHeader` prop** that `CommentNode` had been passing to nothing.

# Tests

e2e tests and local.

43/43 Playwright tests pass — the 33 previous ones plus 8 new in `e2e/node-rename.spec.js` and 1 new in `e2e/batch-run.spec.js`. `npm run build` compiles clean.

The `setupBlankCanvas` helper now takes an optional `{ showNodeHeaders }` (headers are off by default in the app), and there is a new `renameNode` helper. Both are backwards compatible with the existing specs.

```bash
npx playwright test e2e/node-rename.spec.js
npx playwright test e2e/batch-run.spec.js
npm run test:e2e
```

## How to test

1. `npm run dev`, open the app and pick **Blank canvas**.
2. Settings (⚙️) → enable **Show node headers**.
3. Add a Prompt node, double-click its title, type a new name and press Enter. The title updates.
4. Double-click again, type something and press **Escape** — the old name comes back. Repeat with an empty name and blur: the old name stays.
5. While editing, press Backspace/Delete and Ctrl+C/Ctrl+V. The node must not be deleted or duplicated.
6. Drag the node by its header: it still moves.
7. Lock the canvas (padlock) and double-click a title: the canvas must not zoom.
8. Add a second Prompt node — it is called `New Prompt 2`. Rename both to the same name: the second becomes `<name> 2`.
9. Turn **Show node headers** off, right-click a node → **Rename**, confirm.
10. Export the flow, open the `.json` and check `nodes[].data.label`; re-import it and confirm the names survive.
11. Build Prompt → Prompt Template → Image Generator, rename the template and the generator, mark them as batch input/output and open **Batch Run**: the column headers and the Inputs/Outputs legend show the new names.
12. In the same panel, **Download CSV** — the headers carry the new names. Fill it in, import it back (`Imported N rows`) and run the batch. **Download all (.zip)** names the files after the nodes.