### PR TITLE
feat: add GPT Image 2 as image generation model

### DIFF
--- a/src/services/models/gpt-image-2.js
+++ b/src/services/models/gpt-image-2.js
@@ -1,0 +1,210 @@
+/**
+ * OpenAI GPT IMAGE 2 Model Configuration
+ * Model: openai/gpt-image-2
+ */
+
+import { useSettingsStore } from '@/stores/settings'
+
+export const GPT_IMAGE_2 = {
+  id: 'gpt-image-2',
+  name: 'GPT Image 2',
+  owner: 'openai',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/openai/gpt-image-2/predictions',
+
+  /**
+   * Default parameters for the model
+   */
+  defaults: {
+    aspect_ratio: '1:1',
+    number_of_images: 1,
+    quality: 'auto',
+    background: 'auto',
+    output_compression: 90,
+    output_format: 'webp',
+    moderation: 'auto'
+  },
+
+  /**
+   * UI Schema - defines controls for the navbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'gpt-image-2',
+    label: 'GPT Image 2',
+    controls: [
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: ['1:1', '3:2', '2:3'],
+        default: '1:1'
+      },
+      {
+        key: 'quality',
+        label: 'Quality',
+        type: 'select',
+        enum: ['low', 'medium', 'high', 'auto'],
+        default: 'auto'
+      },
+      {
+        key: 'background',
+        label: 'Background',
+        type: 'select',
+        enum: ['auto', 'transparent', 'opaque'],
+        default: 'auto'
+      },
+      {
+        key: 'output_format',
+        label: 'Output Format',
+        type: 'select',
+        enum: ['webp', 'png', 'jpeg'],
+        default: 'webp'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    aspect_ratio: ['1:1', '3:2', '2:3'],
+    quality: ['low', 'medium', 'high', 'auto'],
+    background: ['auto', 'transparent', 'opaque'],
+    moderation: ['auto', 'low'],
+    output_format: ['png', 'jpeg', 'webp']
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {Array<string>} [options.imageInput] - Input images
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    const input = {
+      prompt: prompt.trim(),
+      aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
+      number_of_images: params.number_of_images || this.defaults.number_of_images,
+      quality: params.quality || this.defaults.quality,
+      background: params.background || this.defaults.background,
+      output_compression: params.output_compression || this.defaults.output_compression,
+      output_format: params.output_format || this.defaults.output_format,
+      moderation: params.moderation || this.defaults.moderation
+    }
+
+    // OpenAI API key is optional: when provided, OpenAI bills the user directly,
+    // otherwise the request runs through Replicate's own credentials
+    const settingsStore = useSettingsStore()
+    const openaiApiKey = settingsStore.getOpenaiApiKey()
+
+    if (openaiApiKey) {
+      input.openai_api_key = openaiApiKey
+    }
+
+    // Add input images if provided
+    if (imageInput.length > 0) {
+      input.input_images = imageInput
+    }
+
+    // Add optional user_id if provided
+    if (params.user_id) {
+      input.user_id = params.user_id
+    }
+
+    return input
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    const validated = {}
+
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.quality && !this.validValues.quality.includes(params.quality)) {
+      throw new Error(`Invalid quality. Must be one of: ${this.validValues.quality.join(', ')}`)
+    }
+
+    if (params.background && !this.validValues.background.includes(params.background)) {
+      throw new Error(`Invalid background. Must be one of: ${this.validValues.background.join(', ')}`)
+    }
+
+    if (params.moderation && !this.validValues.moderation.includes(params.moderation)) {
+      throw new Error(`Invalid moderation. Must be one of: ${this.validValues.moderation.join(', ')}`)
+    }
+
+    if (params.output_format && !this.validValues.output_format.includes(params.output_format)) {
+      throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
+    }
+
+    if (params.number_of_images !== undefined) {
+      const num = parseInt(params.number_of_images)
+      if (isNaN(num) || num < 1 || num > 10) {
+        throw new Error('number_of_images must be between 1 and 10')
+      }
+      validated.number_of_images = num
+    }
+
+    if (params.output_compression !== undefined) {
+      const comp = parseInt(params.output_compression)
+      if (isNaN(comp) || comp < 0 || comp > 100) {
+        throw new Error('output_compression must be between 0 and 100')
+      }
+      validated.output_compression = comp
+    }
+
+    return {
+      aspect_ratio: params.aspect_ratio,
+      quality: params.quality,
+      background: params.background,
+      moderation: params.moderation,
+      output_format: params.output_format,
+      number_of_images: validated.number_of_images,
+      output_compression: validated.output_compression,
+      user_id: params.user_id
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // Output is an array of image URLs
+    const imageUrls = Array.isArray(response.output)
+      ? response.output
+      : [response.output]
+
+    // Return the first image URL (for compatibility with existing code)
+    // But also include all URLs in the response
+    return {
+      imageUrl: imageUrls[0],
+      imageUrls: imageUrls,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default GPT_IMAGE_2

--- a/src/services/replicate.js
+++ b/src/services/replicate.js
@@ -7,6 +7,7 @@ import NANO_BANANA_PRO from './models/nano-banana-pro'
 import SEEDREAM_4 from './models/seedream-4'
 import LANG_SEGMENT_ANYTHING from './models/lang-segment-anything'
 import GPT_IMAGE_1 from './models/gpt-image-1'
+import GPT_IMAGE_2 from './models/gpt-image-2'
 import GPT_5 from './models/gpt-5'
 import GEMINI_2_5_FLASH from './models/gemini-2.5-flash'
 import { useSettingsStore } from '@/stores/settings'
@@ -19,6 +20,7 @@ const MODELS = {
   'seedream-4': SEEDREAM_4,
   'lang-segment-anything': LANG_SEGMENT_ANYTHING,
   'gpt-image-1': GPT_IMAGE_1,
+  'gpt-image-2': GPT_IMAGE_2,
   'gpt-5': GPT_5,
   'gemini-2.5-flash': GEMINI_2_5_FLASH,
   'default': NANO_BANANA_PRO


### PR DESCRIPTION
# What

Adds **GPT Image 2** (OpenAI) as a new image generation model on the canvas. It shows up in the model selector of the Image Generator node alongside Nano Banana Pro, Seedream 4 and GPT Image 1, and can be used both for generating images from a prompt and for editing/composing from connected input images.

Once selected, the node exposes its own controls: aspect ratio (`1:1`, `3:2`, `2:3`), quality (`low`, `medium`, `high`, `auto`), background (`auto`, `transparent`, `opaque`) and output format (`webp`, `png`, `jpeg`).

# Why

GPT Image 2 is OpenAI's current image model on Replicate, with better instruction following and text rendering than GPT Image 1, so it makes sense to have it available in the flows.

It is added following the same pattern as the other models: a new config file `src/services/models/gpt-image-2.js` exporting `GPT_IMAGE_2` with `defaults`, `uiSchema`, `validValues`, `buildInput`, `validateParams` and `parseResponse`, registered in the `MODELS` registry of `src/services/replicate.js`. Because the config declares `category: 'image'`, the `ImageGeneratorNode` picks it up automatically through `listModels('image')` and renders its controls from the `uiSchema` — no changes needed in the node or the canvas.

Two things worth noting for review:

- **The OpenAI API key is optional here**, unlike GPT Image 1 which fails without it. `buildInput` only adds `openai_api_key` to the payload when the user has configured it in Settings; otherwise the prediction runs with Replicate credentials. This matches the model schema and avoids blocking users who do not have an OpenAI key.
- **`input_fidelity` is not part of this model's schema**, so it is not included even though GPT Image 1 has it.

# Tests

Local testing.

## How to test

1. `npm run dev` and open the app.
2. (Optional) Open Settings and set the OpenAI API key — the model must also work with it empty. A Replicate API key is required in both cases.
3. Add an **Image Generator** node to the canvas.
4. Open its model selector and check that **GPT Image 2** is listed.
5. Select it and confirm the controls appear: Aspect Ratio, Quality, Background, Output Format, with defaults `1:1`, `auto`, `auto`, `webp`.
6. Connect a Prompt node (or type a prompt in the node), generate, and confirm the image is returned and rendered.
7. Change Aspect Ratio to `3:2` and generate again — the resulting image proportions should change.
8. Connect one or more Image nodes as input, prompt an edit (e.g. "make it look like a watercolor painting") and confirm the input images are taken into account.
9. Switch to another model (e.g. Nano Banana Pro) and back to GPT Image 2 to confirm the params reset to the model defaults.
10. Save the flow to `.json`, reload it and confirm the node keeps GPT Image 2 and its params.
