### PR TITLE
fix: spawn nodes at the cursor when picked from the context menu

### DIFF
--- a/src/composables/useContextMenu.js
+++ b/src/composables/useContextMenu.js
@@ -17,6 +17,9 @@ export function useContextMenu(isNodesMenuOpen) {
   const menuPosition = ref(null)
   const nodeMenuPosition = ref(null)
   const contextNode = ref(null)
+  // Screen coordinates where the menu was invoked, so nodes picked from it
+  // spawn under the cursor instead of at the center of the canvas
+  const menuOrigin = ref(null)
 
   /**
    * Calculate position that keeps menu within window boundaries
@@ -55,6 +58,7 @@ export function useContextMenu(isNodesMenuOpen) {
     const posY = clientY - rect.top
 
     menuPosition.value = calculateBoundedPosition(posX, posY, rect)
+    menuOrigin.value = { x: clientX, y: clientY }
     closeNodeMenu()
     isNodesMenuOpen.value = true
   }
@@ -86,6 +90,7 @@ export function useContextMenu(isNodesMenuOpen) {
     // Only one menu at a time
     isNodesMenuOpen.value = false
     menuPosition.value = null
+    menuOrigin.value = null
   }
 
   /**
@@ -93,6 +98,7 @@ export function useContextMenu(isNodesMenuOpen) {
    */
   function resetMenuPosition() {
     menuPosition.value = null
+    menuOrigin.value = null
   }
 
   /**
@@ -109,11 +115,13 @@ export function useContextMenu(isNodesMenuOpen) {
   function closeMenu() {
     isNodesMenuOpen.value = false
     menuPosition.value = null
+    menuOrigin.value = null
     closeNodeMenu()
   }
 
   return {
     menuPosition,
+    menuOrigin,
     nodeMenuPosition,
     contextNode,
     openNodesMenuAt,

--- a/src/composables/useDragAndDrop.js
+++ b/src/composables/useDragAndDrop.js
@@ -9,9 +9,26 @@ import { createNode, NODE_TYPES, getNodeIOConfig } from '@/lib/node-shapes'
 import { ensureUniqueLabel } from '@/lib/node-label'
 import { loadFlowFromFile } from '@/lib/flow-io'
 
-export function useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, vueFlowHelpers = {}, onMenuClose = null) {
+// Rough node size, used to drop the new node centered on the pointer
+const NODE_HALF_WIDTH = 75
+const NODE_HALF_HEIGHT = 50
+
+export function useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, vueFlowHelpers = {}, onMenuClose = null, menuOrigin = null) {
   let draggedNodeType = null
   let isDragging = false
+
+  /**
+   * Convert screen coordinates into canvas coordinates, centering the node there
+   * @param {number} clientX - Screen X coordinate
+   * @param {number} clientY - Screen Y coordinate
+   * @param {DOMRect} rect - Canvas wrapper bounds
+   */
+  function toCenteredCanvasPosition(clientX, clientY, rect) {
+    return {
+      x: (clientX - rect.left - viewport.value.x) / viewport.value.zoom - NODE_HALF_WIDTH,
+      y: (clientY - rect.top - viewport.value.y) / viewport.value.zoom - NODE_HALF_HEIGHT
+    }
+  }
 
   /**
    * Handle drag start from sidebar
@@ -23,7 +40,8 @@ export function useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, 
   }
 
   /**
-   * Create node at viewport center when clicking (not dragging)
+   * Create node when clicking (not dragging): at the point where the context menu
+   * was opened, or at the viewport center when the menu was opened as a sidebar
    */
   function onNodeItemClick(nodeType) {
     // Small delay to check if drag started
@@ -39,16 +57,13 @@ export function useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, 
 
       const rect = canvasWrapper.getBoundingClientRect()
 
-      // Calculate center of viewport in canvas coordinates
-      const centerX = rect.width / 2
-      const centerY = rect.height / 2
+      // Right-click opens the menu at the pointer, so spawn the node there.
+      // Without an origin (sidebar mode) fall back to the center of the viewport
+      const origin = menuOrigin?.value ?? null
+      const spawnX = origin ? origin.x : rect.left + rect.width / 2
+      const spawnY = origin ? origin.y : rect.top + rect.height / 2
 
-      const position = {
-        x: (centerX - viewport.value.x) / viewport.value.zoom - 75, // Center node (width ~150px)
-        y: (centerY - viewport.value.y) / viewport.value.zoom - 50   // Center node (height ~100px)
-      }
-
-      createNodeAtPosition(nodeType, position)
+      createNodeAtPosition(nodeType, toCenteredCanvasPosition(spawnX, spawnY, rect))
       isNodesMenuOpen.value = false
       if (onMenuClose) onMenuClose()
     }, 100)
@@ -119,10 +134,7 @@ export function useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, 
     const rect = canvasWrapper.getBoundingClientRect()
 
     // Calculate position relative to canvas, accounting for zoom and pan
-    const position = {
-      x: (event.clientX - rect.left - viewport.value.x) / viewport.value.zoom - 75, // Center node (width ~150px)
-      y: (event.clientY - rect.top - viewport.value.y) / viewport.value.zoom - 50   // Center node (height ~100px)
-    }
+    const position = toCenteredCanvasPosition(event.clientX, event.clientY, rect)
 
     // Check if dropping a file
     const files = event.dataTransfer.files

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -195,6 +195,7 @@ const { copiedNode, handleCopy, handlePaste } = useCopyPaste(flowStore, viewport
 const { createNodeAtPosition } = useNodeCreation(flowStore)
 const {
   menuPosition,
+  menuOrigin,
   nodeMenuPosition,
   contextNode,
   openNodesMenuAt,
@@ -214,7 +215,7 @@ const {
   createNodeFromConnection,
   cancelPendingConnection
 } = useConnectionDrop(flowStore, createNodeAtPosition, screenToFlowCoordinate, { addEdges }, openNodesMenuAt, closeMenu)
-const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, { addEdges }, closeNodesMenu)
+const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, { addEdges }, closeNodesMenu, menuOrigin)
 const { handleGroup } = useGroupManagement(flowStore, onNodeDragStop)
 
 // Register right-click handlers for context menus


### PR DESCRIPTION
# What

When you right-clicked on an empty area of the canvas and picked a node from the menu, the node appeared in the middle of the canvas instead of where you clicked. Now the node spawns right under the cursor, exactly where the menu was opened.

Picking a node from the regular sidebar (the floating menu button) keeps spawning it at the center of the viewport, as before.

# Why

The click handler of the nodes menu (`onNodeItemClick` in `useDragAndDrop`) always computed the center of the viewport, because it had no idea the menu had been opened at a specific pointer position.

`useContextMenu` now keeps a `menuOrigin` with the screen coordinates where the menu was invoked, and clears it when the menu goes back to sidebar mode or gets closed. `onNodeItemClick` uses that origin when present, and falls back to the viewport center otherwise.

While at it, the screen-to-canvas conversion is now a single helper (`toCenteredCanvasPosition`) shared with the drag & drop path, so both spawn the node centered on the pointer with the same offsets instead of repeating the magic numbers.

# Tests

Local testing (`npm run dev`) and production build (`npm run build`). No e2e tests in the repo.

## How to test

1. Run `npm run dev` and open the canvas.
2. Right-click on an empty area near a corner of the canvas and click any node in the menu → the node must appear under the cursor, not in the center.
3. Repeat after panning and zooming the canvas (zoom in and zoom out) → the node must still land under the cursor.
4. Open the nodes menu from the floating menu button (left toolbar) and click a node → it must still spawn at the center of the viewport.
5. Drag a node from the menu and drop it anywhere → it must land at the drop point, as before.
6. Drag a connection from a node handle and release it over empty canvas, then pick a compatible node → it must appear next to the drop point and stay wired to the origin handle.
