### PR TITLE
feat: add video generator node with p-video model

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1008,6 +1008,7 @@ A node's role lives in `node.data.batchRole` (`'input' | 'output'`), set from th
 | `input` | `prompt-template` | `data.variables` |
 | `output` | `image-generator` | `data.lastOutputSrc` |
 | `output` | `text-generator` | `data.generatedText` |
+| `output` | `video-generator` | `data.lastOutputVideoSrc` |
 
 `BaseNode.vue` renders the IN/OUT badge from `data.batchRole`, so no individual node component needed changes.
 

--- a/e2e/mocks/api.js
+++ b/e2e/mocks/api.js
@@ -9,6 +9,10 @@ export const FAKE_GENERATED_IMAGE_2 =
 // Text generation responses
 export const TEXT_GENERATION_RESPONSE = 'a green hillside with rolling clouds under a bright blue sky'
 
+// Minimal MP4 data URL (not playable, enough to travel through the app as a src)
+export const FAKE_GENERATED_VIDEO =
+  'data:video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDE='
+
 /**
  * Mock the GPT-5 text generation endpoint.
  * Optionally verify the request payload via `assertRequest`.
@@ -121,6 +125,30 @@ export async function mockGptImage1(page, { response = FAKE_GENERATED_IMAGE, ass
         id: 'img-pred-' + Date.now(),
         status: 'succeeded',
         output: [response],
+      }),
+    })
+  })
+}
+
+/**
+ * Mock the P-Video video generation endpoint.
+ * The real model returns a single URI, so `output` is a plain string here.
+ */
+export async function mockPVideo(page, { response = FAKE_GENERATED_VIDEO, assertRequest } = {}) {
+  await page.route('**/v1/models/prunaai/p-video/predictions', async (route) => {
+    const body = JSON.parse(route.request().postData())
+
+    if (assertRequest) {
+      assertRequest(body)
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'video-pred-' + Date.now(),
+        status: 'succeeded',
+        output: response,
       }),
     })
   })

--- a/e2e/video-node.spec.js
+++ b/e2e/video-node.spec.js
@@ -1,0 +1,292 @@
+import { test, expect } from '@playwright/test'
+import { FAKE_GENERATED_VIDEO, mockPVideo } from './mocks/api.js'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  connectNodes,
+  positionNodes,
+  uploadImageToNode,
+} from './helpers/canvas.js'
+
+/**
+ * Select the video node so its toolbar shows up.
+ * Clicking the prompt textarea would not select it (it stops mousedown), so the
+ * click lands on the preview area at the top of the node
+ */
+async function selectVideoNode(page, nodeLocator) {
+  const box = await nodeLocator.boundingBox()
+  if (!box) throw new Error('selectVideoNode: node has no bounding box')
+
+  await page.mouse.click(box.x + box.width / 2, box.y + 30)
+  await page.locator('#model-select').waitFor({ state: 'visible', timeout: 5000 })
+}
+
+/**
+ * Mark a node with a batch role through its right-click context menu.
+ */
+async function markBatchRole(page, nodeLocator, optionLabel) {
+  await nodeLocator.click({ button: 'right' })
+  const menu = page.locator('.node-context-menu')
+  await menu.waitFor({ state: 'visible', timeout: 3000 })
+  await menu.locator('.menu-text').filter({ hasText: optionLabel }).click()
+  await expect(menu).toBeHidden()
+}
+
+test.describe('Video Generator Node', () => {
+  test('generates a video from a prompt (text-to-video)', async ({ page }) => {
+    let received = null
+    await mockPVideo(page, { assertRequest: (body) => { received = body.input } })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Video Generator')
+
+    const videoNode = page.locator('.vue-flow__node-video-generator')
+    await expect(videoNode).toBeVisible()
+    await expect(videoNode.locator('.video-placeholder')).toBeVisible()
+
+    await videoNode.locator('textarea').fill('a paper plane gliding over a city')
+    await videoNode.getByRole('button', { name: 'Generate Video' }).click()
+
+    const video = videoNode.locator('.video-preview video')
+    await expect(video).toBeVisible({ timeout: 15000 })
+    await expect(video).toHaveAttribute('src', FAKE_GENERATED_VIDEO)
+
+    // Default parameters travel to the API, and text-to-video does send an
+    // aspect ratio (the model only ignores it when an input image is present)
+    expect(received.prompt).toBe('a paper plane gliding over a city')
+    expect(received.duration).toBe(5)
+    expect(received.resolution).toBe('720p')
+    expect(received.fps).toBe(24)
+    expect(received.draft).toBe(false)
+    expect(received.aspect_ratio).toBe('16:9')
+    expect(received.image).toBeUndefined()
+    expect(received.last_frame_image).toBeUndefined()
+  })
+
+  test('uses the connected images as first and last frame', async ({ page }) => {
+    let received = null
+    await mockPVideo(page, { assertRequest: (body) => { received = body.input } })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Video Generator')
+
+    const firstFrameNode = page.locator('.vue-flow__node-image').nth(0)
+    const lastFrameNode = page.locator('.vue-flow__node-image').nth(1)
+    const videoNode = page.locator('.vue-flow__node-video-generator')
+
+    await positionNodes(page, [
+      { type: 'image', x: 60, y: 60, nth: 0 },
+      { type: 'image', x: 60, y: 420, nth: 1 },
+      { type: 'video-generator', x: 620, y: 200 },
+    ])
+
+    await uploadImageToNode(page, firstFrameNode)
+    await uploadImageToNode(page, lastFrameNode)
+
+    // Wire only the last frame reference first (input-0), so the payload proves
+    // which handle feeds which field
+    await connectNodes(page, lastFrameNode, 'output-0', videoNode, 'input-0')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(1, { timeout: 5000 })
+
+    await expect(videoNode.locator('.frame-caption').filter({ hasText: 'Last' })).toBeVisible()
+    await expect(videoNode.locator('.frame-caption').filter({ hasText: 'First' })).toHaveCount(0)
+
+    await videoNode.locator('textarea').fill('the camera pushes in slowly')
+    await videoNode.getByRole('button', { name: 'Generate Video' }).click()
+    await expect(videoNode.locator('.video-preview video')).toBeVisible({ timeout: 15000 })
+
+    expect(received.last_frame_image).toMatch(/^data:image\//)
+    expect(received.image).toBeUndefined()
+
+    // Now add the first frame (input-1): image-to-video
+    await connectNodes(page, firstFrameNode, 'output-0', videoNode, 'input-1')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(2, { timeout: 5000 })
+
+    await expect(videoNode.locator('.frame-caption').filter({ hasText: 'First' })).toBeVisible()
+
+    received = null
+    await videoNode.getByRole('button', { name: 'Generate Video' }).click()
+    await expect.poll(() => received !== null, { timeout: 15000 }).toBe(true)
+
+    expect(received.image).toMatch(/^data:image\//)
+    expect(received.last_frame_image).toMatch(/^data:image\//)
+    // Ignored by the model when an input image is given, so it is not sent
+    expect(received.aspect_ratio).toBeUndefined()
+  })
+
+  test('toolbar options reach the API', async ({ page }) => {
+    let received = null
+    await mockPVideo(page, { assertRequest: (body) => { received = body.input } })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Video Generator')
+
+    const videoNode = page.locator('.vue-flow__node-video-generator')
+    await positionNodes(page, [{ type: 'video-generator', x: 400, y: 320 }])
+
+    await selectVideoNode(page, videoNode)
+
+    await page.locator('#control-duration').fill('8')
+    await page.locator('#control-aspect_ratio').selectOption('9:16')
+    await page.locator('#control-resolution').selectOption('1080p')
+    await page.locator('#control-fps').selectOption('48')
+    await page.locator('#control-draft').check()
+
+    // Click away to dismiss the toolbar before using the node body
+    await page.mouse.click(10, 10)
+
+    await videoNode.locator('textarea').fill('a vertical clip of falling confetti')
+    await videoNode.getByRole('button', { name: 'Generate Video' }).click()
+
+    await expect(videoNode.locator('.video-preview video')).toBeVisible({ timeout: 15000 })
+
+    expect(received.duration).toBe(8)
+    expect(received.aspect_ratio).toBe('9:16')
+    expect(received.resolution).toBe('1080p')
+    // Selects hand back strings; fps must stay numeric for the API
+    expect(received.fps).toBe(48)
+    expect(received.draft).toBe(true)
+  })
+
+  test('uses a connected prompt node', async ({ page }) => {
+    let received = null
+    await mockPVideo(page, { assertRequest: (body) => { received = body.input } })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Video Generator')
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    const videoNode = page.locator('.vue-flow__node-video-generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 60, y: 200 },
+      { type: 'video-generator', x: 620, y: 200 },
+    ])
+
+    await promptNode.locator('textarea').fill('a neon sign flickering in the rain')
+    await promptNode.locator('textarea').blur()
+    await page.waitForTimeout(200)
+
+    // input-2 is the prompt port
+    await connectNodes(page, promptNode, 'output-0', videoNode, 'input-2')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(1, { timeout: 5000 })
+
+    // The local textarea gives way to the connected prompt
+    await expect(videoNode.locator('.prompt-preview')).toContainText('a neon sign flickering')
+    await expect(videoNode.locator('textarea')).toHaveCount(0)
+
+    await videoNode.getByRole('button', { name: 'Generate Video' }).click()
+
+    await expect(videoNode.locator('.video-preview video')).toBeVisible({ timeout: 15000 })
+    expect(received.prompt).toBe('a neon sign flickering in the rain')
+  })
+
+  test('the video output cannot be wired into an image input', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Video Generator')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    const videoNode = page.locator('.vue-flow__node-video-generator')
+    const imageGenNode = page.locator('.vue-flow__node-image-generator')
+
+    await positionNodes(page, [
+      { type: 'video-generator', x: 60, y: 200 },
+      { type: 'image-generator', x: 640, y: 200 },
+    ])
+
+    // video → image is rejected by the port type validation
+    await connectNodes(page, videoNode, 'output-0', imageGenNode, 'input-0')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(0)
+
+    // ...and so is video → prompt
+    await connectNodes(page, videoNode, 'output-0', imageGenNode, 'input-1')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(0)
+  })
+
+  test('inlines a remote video so the flow can be saved', async ({ page }) => {
+    const remoteUrl = 'https://replicate.delivery/fake/output.mp4'
+
+    await mockPVideo(page, { response: remoteUrl })
+    await page.route(remoteUrl, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'video/mp4',
+        body: Buffer.from('fake-mp4-bytes'),
+      })
+    })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Video Generator')
+
+    const videoNode = page.locator('.vue-flow__node-video-generator')
+    await videoNode.locator('textarea').fill('a wave breaking in slow motion')
+    await videoNode.getByRole('button', { name: 'Generate Video' }).click()
+
+    const video = videoNode.locator('.video-preview video')
+    await expect(video).toBeVisible({ timeout: 15000 })
+
+    // Replicate URLs expire, so the node stores the bytes instead of the link
+    const src = await video.getAttribute('src')
+    expect(src.startsWith('data:video/mp4;base64,')).toBe(true)
+  })
+
+  test('can be marked as a batch output', async ({ page }) => {
+    const receivedPrompts = []
+    await mockPVideo(page, {
+      assertRequest: (body) => receivedPrompts.push(body.input.prompt),
+    })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Video Generator')
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    const videoNode = page.locator('.vue-flow__node-video-generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 60, y: 200 },
+      { type: 'video-generator', x: 620, y: 200 },
+    ])
+
+    await promptNode.locator('textarea').fill('a placeholder prompt')
+    await promptNode.locator('textarea').blur()
+    await page.waitForTimeout(200)
+
+    await connectNodes(page, promptNode, 'output-0', videoNode, 'input-2')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(1, { timeout: 5000 })
+
+    await markBatchRole(page, promptNode, 'Mark as batch input')
+    await markBatchRole(page, videoNode, 'Mark as batch output')
+
+    await expect(promptNode.locator('.batch-badge-input')).toHaveText('IN')
+    await expect(videoNode.locator('.batch-badge-output')).toHaveText('OUT')
+
+    await page.locator('button[title="Batch Run"]').click()
+    const modal = page.locator('.batch-content')
+    await expect(modal).toBeVisible()
+
+    await modal.locator('#run-count').fill('2')
+    const rows = modal.locator('.batch-table tbody tr')
+    await expect(rows).toHaveCount(2)
+
+    await rows.nth(0).locator('.col-input textarea').fill('a kite over the sea')
+    await rows.nth(1).locator('.col-input textarea').fill('a train crossing a bridge')
+
+    await modal.getByRole('button', { name: 'Run batch' }).click()
+
+    await expect(rows.nth(0).locator('.status-done')).toBeVisible({ timeout: 30000 })
+    await expect(rows.nth(1).locator('.status-done')).toBeVisible({ timeout: 30000 })
+
+    expect(receivedPrompts).toEqual(['a kite over the sea', 'a train crossing a bridge'])
+
+    // Each row holds its generated video, previewable at full size
+    await expect(rows.nth(0).locator('.col-output video')).toHaveAttribute('src', FAKE_GENERATED_VIDEO)
+    await expect(rows.nth(1).locator('.col-output video')).toHaveAttribute('src', FAKE_GENERATED_VIDEO)
+
+    await rows.nth(0).locator('.col-output video').click()
+    await expect(page.locator('.preview-modal video')).toBeVisible()
+  })
+})

--- a/src/components/base/BaseNode.vue
+++ b/src/components/base/BaseNode.vue
@@ -25,10 +25,10 @@
       :position="Position.Left"
       :style="{
         top: `${getHandlePosition(index, inputs.length)}%`,
-        background: getPortColor(input)
+        background: getPortColor(getPortType(input))
       }"
     >
-      <span class="handle-label handle-label-left">{{ input }}</span>
+      <span class="handle-label handle-label-left">{{ getPortLabel(input) }}</span>
     </Handle>
 
     <!-- Output Handles -->
@@ -40,10 +40,10 @@
       :position="Position.Right"
       :style="{
         top: `${getHandlePosition(index, outputs.length)}%`,
-        background: getPortColor(output)
+        background: getPortColor(getPortType(output))
       }"
     >
-      <span class="handle-label handle-label-right">{{ output }}</span>
+      <span class="handle-label handle-label-right">{{ getPortLabel(output) }}</span>
     </Handle>
 
     <!-- Execution Status Badge -->
@@ -253,6 +253,27 @@ function getHandlePosition(index, total) {
 }
 
 /**
+ * Port type of an entry in `inputs`/`outputs`
+ * Ports are plain PORT_TYPES strings, or `{ type, label }` when a node has
+ * several ports of the same type and the handle labels need to tell them apart
+ * @param {string|Object} port
+ * @returns {string} PORT_TYPE
+ */
+function getPortType(port) {
+  return typeof port === 'string' ? port : port.type
+}
+
+/**
+ * Text shown next to a handle. Defaults to the port type
+ * @param {string|Object} port
+ * @returns {string}
+ */
+function getPortLabel(port) {
+  if (typeof port === 'string') return port
+  return port.label || port.type
+}
+
+/**
  * Get color for port type using Flora design tokens
  */
 function getPortColor(portType) {
@@ -260,7 +281,8 @@ function getPortColor(portType) {
     image: 'var(--flora-color-port-image)',
     prompt: 'var(--flora-color-port-prompt)',
     text: 'var(--flora-color-port-text)',
-    number: 'var(--flora-color-port-number)'
+    number: 'var(--flora-color-port-number)',
+    video: 'var(--flora-color-port-video)'
   }
   return colorMap[portType] || 'var(--flora-color-border-strong)'
 }

--- a/src/components/batch/BatchRunModal.vue
+++ b/src/components/batch/BatchRunModal.vue
@@ -250,8 +250,17 @@
                     :src="run.outputs[node.id].value"
                     class="cell-thumb output-thumb"
                     alt="Output"
-                    @click="previewImage = run.outputs[node.id].value"
+                    @click="openPreview(run.outputs[node.id])"
                   />
+                  <video
+                    v-else-if="run.outputs[node.id].kind === BATCH_VALUE_KINDS.VIDEO"
+                    :src="run.outputs[node.id].value"
+                    class="cell-thumb output-thumb"
+                    muted
+                    playsinline
+                    preload="metadata"
+                    @click="openPreview(run.outputs[node.id])"
+                  ></video>
                   <div v-else class="output-text">
                     {{ run.outputs[node.id].value }}
                   </div>
@@ -286,15 +295,23 @@
 
   <!-- Output preview -->
   <BaseModal
-    v-if="previewImage"
+    v-if="preview"
     :model-value="true"
     :show-header="false"
     :show-footer="false"
     size="xl"
-    @update:model-value="previewImage = null"
+    @update:model-value="preview = null"
   >
     <div class="preview-modal">
-      <img :src="previewImage" alt="Output preview" />
+      <video
+        v-if="preview.kind === BATCH_VALUE_KINDS.VIDEO"
+        :src="preview.value"
+        controls
+        autoplay
+        loop
+        playsinline
+      ></video>
+      <img v-else :src="preview.value" alt="Output preview" />
     </div>
   </BaseModal>
 </template>
@@ -315,6 +332,7 @@ import {
   getBatchInputSpec,
   getBatchInputInitialValue,
   getMissingVariables,
+  isBinaryValueKind,
   reachesAnyNode,
   resolveUpstreamPromptNode
 } from '@/lib/batch-io'
@@ -344,7 +362,8 @@ const flowStore = useFlowStore()
 const batchStore = useBatchStore()
 
 const runCount = ref(3)
-const previewImage = ref(null)
+// Output cell opened in the large preview modal: { kind, value }
+const preview = ref(null)
 const csvInput = ref(null)
 const imagesInput = ref(null)
 const csvMessage = ref('')
@@ -365,6 +384,14 @@ const isOpen = computed({
 
 const inputNodes = computed(() => getBatchNodes(flowStore.nodes, BATCH_ROLES.INPUT))
 const outputNodes = computed(() => getBatchNodes(flowStore.nodes, BATCH_ROLES.OUTPUT))
+
+/**
+ * Open an output cell in the large preview modal
+ * @param {Object} output - Cell from run.outputs: { kind, value }
+ */
+function openPreview(output) {
+  preview.value = { kind: output.kind, value: output.value }
+}
 
 const inputSpecs = computed(() =>
   inputNodes.value.map(node => {
@@ -936,7 +963,7 @@ function handleDownloadZip() {
 
       const base = sanitizeFilename(output.label || nodeId)
 
-      if (output.kind === BATCH_VALUE_KINDS.IMAGE) {
+      if (isBinaryValueKind(output.kind)) {
         try {
           const { bytes, mimeType } = dataUrlToBytes(output.value)
           const filename = `${base}${extensionForMimeType(mimeType)}`
@@ -1256,11 +1283,13 @@ function handleDownloadZip() {
 }
 
 .cell-thumb {
+  display: block;
   width: 80px;
   height: 80px;
   object-fit: cover;
   border-radius: var(--flora-radius-sm);
   border: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+  background: var(--flora-color-bg-tertiary);
 }
 
 .output-thumb {
@@ -1328,7 +1357,8 @@ function handleDownloadZip() {
   padding: var(--flora-space-4);
 }
 
-.preview-modal img {
+.preview-modal img,
+.preview-modal video {
   max-width: 100%;
   max-height: 80vh;
   object-fit: contain;

--- a/src/components/canvas/NodesSidebar.vue
+++ b/src/components/canvas/NodesSidebar.vue
@@ -112,7 +112,8 @@ const emit = defineEmits(['drag-start', 'node-click', 'connect-option'])
 const aiNodes = computed(() =>
   props.nodes.filter(n =>
     n.type === NODE_TYPES.IMAGE_GENERATOR ||
-    n.type === NODE_TYPES.TEXT_GENERATOR
+    n.type === NODE_TYPES.TEXT_GENERATOR ||
+    n.type === NODE_TYPES.VIDEO_GENERATOR
   )
 )
 
@@ -141,6 +142,7 @@ function getNodeIcon(type) {
     [NODE_TYPES.DIFF]: '🔍',
     [NODE_TYPES.COMPARE]: '⚖️',
     [NODE_TYPES.TEXT_GENERATOR]: '💬',
+    [NODE_TYPES.VIDEO_GENERATOR]: '🎬',
     [NODE_TYPES.PROMPT_TEMPLATE]: '📋',
     [NODE_TYPES.DRAW]: '🖌️',
     [NODE_TYPES.COMMENT]: '🗒️'

--- a/src/components/nodes/VideoGeneratorNode.vue
+++ b/src/components/nodes/VideoGeneratorNode.vue
@@ -1,0 +1,621 @@
+<template>
+  <div>
+    <!-- Node Toolbar -->
+    <NodeToolbar :is-visible="selected" :position="Position.Top" :offset="10">
+      <div class="node-toolbar-content">
+        <!-- Model Selector -->
+        <div class="toolbar-control">
+          <BaseLabel variant="toolbar" for="model-select">Model:</BaseLabel>
+          <BaseSelect
+            id="model-select"
+            size="sm"
+            :model-value="currentModel"
+            :disabled="availableModels.length <= 1"
+            @change="onModelChange"
+          >
+            <option
+              v-for="modelId in availableModels"
+              :key="modelId"
+              :value="modelId"
+            >
+              {{ getModelLabel(modelId) }}
+            </option>
+          </BaseSelect>
+        </div>
+
+        <!-- Dynamic Controls from uiSchema -->
+        <div
+          v-for="control in controls"
+          :key="control.key"
+          class="toolbar-control"
+        >
+          <BaseLabel variant="toolbar" :for="`control-${control.key}`">{{ control.label }}:</BaseLabel>
+
+          <!-- Select Control -->
+          <BaseSelect
+            v-if="control.type === 'select'"
+            :id="`control-${control.key}`"
+            size="sm"
+            :model-value="getParamValue(control.key, control.default)"
+            @change="onParamChange(control.key, castParamValue(control, $event.target.value))"
+          >
+            <option
+              v-for="option in control.enum"
+              :key="option"
+              :value="option"
+            >
+              {{ option }}
+            </option>
+          </BaseSelect>
+
+          <!-- Number Input -->
+          <BaseInput
+            v-else-if="control.type === 'number'"
+            :id="`control-${control.key}`"
+            type="number"
+            size="sm"
+            :model-value="getParamValue(control.key, control.default)"
+            :min="control.min"
+            :max="control.max"
+            @input="onParamChange(control.key, $event.target.value ? parseInt($event.target.value) : null)"
+          />
+
+          <!-- Checkbox -->
+          <BaseCheckbox
+            v-else-if="control.type === 'checkbox'"
+            :id="`control-${control.key}`"
+            :model-value="getParamValue(control.key, control.default)"
+            @change="onParamChange(control.key, $event.target.checked)"
+          />
+        </div>
+      </div>
+    </NodeToolbar>
+
+    <BaseNode
+      :id="id"
+      :type="type"
+      :data="nodeData"
+      :label="nodeData.label"
+      :inputs="inputPorts"
+      :outputs="['video']"
+      :loading="isGenerating"
+      :error="nodeData.error"
+      icon="🎬"
+      :selected="selected"
+      :execution-status="executionStatus"
+      @action:run="handleGenerate"
+    >
+      <div class="video-generator-node-content">
+        <!-- Connected frame images -->
+        <div v-if="firstFrameImage || lastFrameImage" class="connected-images">
+          <div class="section-label">Frames:</div>
+          <div class="frames-grid">
+            <div v-if="firstFrameImage" class="frame">
+              <img :src="firstFrameImage" alt="First frame" />
+              <span class="frame-caption">First</span>
+            </div>
+            <div v-if="lastFrameImage" class="frame">
+              <img :src="lastFrameImage" alt="Last frame" />
+              <span class="frame-caption">Last</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Generated video preview -->
+        <div v-if="nodeData.lastOutputVideoSrc" class="video-preview nodrag">
+          <video
+            :src="nodeData.lastOutputVideoSrc"
+            controls
+            loop
+            playsinline
+            @mousedown.stop
+          ></video>
+          <BaseButton variant="primary" size="sm" @click="showVideoPreview = true">
+            Open preview
+          </BaseButton>
+        </div>
+        <div v-else class="video-placeholder">
+          <span class="placeholder-icon">🎬</span>
+          <p>{{ isGenerating ? 'Generating video...' : 'No video generated' }}</p>
+        </div>
+
+        <!-- Prompt input (hidden if there's a connected prompt) -->
+        <div v-if="!connectedPrompt" class="prompt-section">
+          <BaseLabel for="prompt">Prompt:</BaseLabel>
+          <BaseTextarea
+            id="prompt"
+            v-model="localPrompt"
+            placeholder="Describe the video you want to generate..."
+            :rows="3"
+            @blur="updatePrompt"
+            @mousedown.stop
+          />
+        </div>
+
+        <!-- Show connected prompt info -->
+        <div v-else class="connected-prompt-info">
+          <div class="section-label">📝 Using connected prompt</div>
+          <div class="prompt-preview">{{ connectedPrompt }}</div>
+        </div>
+
+        <!-- Generate button -->
+        <div class="generate-section">
+          <BaseButton
+            variant="primary"
+            size="md"
+            :disabled="isGenerating || (!connectedPrompt && !localPrompt.trim())"
+            @click="handleGenerate"
+          >
+            {{ isGenerating ? 'Generating...' : 'Generate Video' }}
+          </BaseButton>
+          <div v-if="firstFrameImage" class="input-info">
+            Image-to-video{{ lastFrameImage ? ' with last frame reference' : '' }}
+          </div>
+        </div>
+      </div>
+    </BaseNode>
+
+    <!-- Video Preview Modal -->
+    <BaseModal
+      v-model="showVideoPreview"
+      :show-header="false"
+      :show-footer="false"
+      size="xl"
+    >
+      <div class="video-preview-modal">
+        <video :src="nodeData.lastOutputVideoSrc" controls autoplay loop playsinline></video>
+      </div>
+    </BaseModal>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useNode, useVueFlow, Position } from '@vue-flow/core'
+import { NodeToolbar } from '@vue-flow/node-toolbar'
+import { useFlowStore } from '@/stores/flow'
+import BaseNode from '@/components/base/BaseNode.vue'
+import BaseButton from '@/components/ui/BaseButton.vue'
+import BaseTextarea from '@/components/ui/BaseTextarea.vue'
+import BaseSelect from '@/components/ui/BaseSelect.vue'
+import BaseInput from '@/components/ui/BaseInput.vue'
+import BaseLabel from '@/components/ui/BaseLabel.vue'
+import BaseCheckbox from '@/components/ui/BaseCheckbox.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import replicateService from '@/services/replicate'
+import { getEdgePortType } from '@/lib/connection'
+import { PORT_TYPES } from '@/lib/node-shapes'
+import nodeRegistry from '@/lib/node-registry'
+import { convertUrlToBase64, isHttpUrl } from '@/lib/image-utils'
+import { useWorkflowEvents } from '@/composables/useWorkflowEvents'
+
+const DEFAULT_MODEL = 'p-video'
+
+/**
+ * Handles of the two image inputs. Both carry PORT_TYPES.IMAGE, so the handle
+ * id is what tells the first frame apart from the last frame reference
+ */
+const LAST_FRAME_HANDLE = 'input-0'
+const FIRST_FRAME_HANDLE = 'input-1'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  type: {
+    type: String,
+    required: true
+  },
+  data: {
+    type: Object,
+    required: true
+  },
+  selected: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const flowStore = useFlowStore()
+const localPrompt = ref(props.data.prompt || '')
+const isGenerating = ref(false)
+const showVideoPreview = ref(false)
+
+// Workflow execution integration
+const { onExecutionRequested, executionStatus } = useWorkflowEvents(props.id)
+
+// Register handler for workflow execution
+onExecutionRequested(async () => {
+  await handleGenerate()
+})
+
+// VueFlow composables
+const { node } = useNode()
+const { updateNodeData } = useVueFlow()
+
+// Get the current node data from useNode composable
+const nodeData = computed(() => node.data)
+
+// Handle labels: two image ports need to be distinguishable on the canvas
+const inputPorts = [
+  { type: PORT_TYPES.IMAGE, label: 'last frame' },
+  { type: PORT_TYPES.IMAGE, label: 'image' },
+  { type: PORT_TYPES.PROMPT }
+]
+
+/**
+ * Read the image coming into one of this node's image handles
+ * @param {string} handleId - Target handle id
+ * @returns {string|null} Image src or null when nothing is connected
+ */
+function readImageOnHandle(handleId) {
+  const edge = flowStore.edges.find(
+    e => e.target === props.id && e.targetHandle === handleId
+  )
+  if (!edge) return null
+
+  const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
+  if (portType !== PORT_TYPES.IMAGE) return null
+
+  const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
+  if (!sourceNode || !sourceNode.data) return null
+
+  return sourceNode.data.src || sourceNode.data.lastOutputSrc || null
+}
+
+// First frame of the video (image-to-video)
+const firstFrameImage = computed(() => readImageOnHandle(FIRST_FRAME_HANDLE))
+
+// Reference image for the last frame
+const lastFrameImage = computed(() => readImageOnHandle(LAST_FRAME_HANDLE))
+
+// Get connected prompt from upstream nodes (uses PORT_TYPE instead of node type)
+const connectedPrompt = computed(() => {
+  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
+
+  for (const edge of incomingEdges) {
+    // Check if this edge connects a PROMPT port
+    const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
+    if (portType !== PORT_TYPES.PROMPT) continue
+
+    const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
+    if (sourceNode && sourceNode.data?.prompt) {
+      return sourceNode.data.prompt
+    }
+  }
+
+  return null
+})
+
+// Toolbar controls - Available models (only video generation models)
+const availableModels = computed(() => replicateService.listModels('video'))
+
+// Current model from node data
+const currentModel = computed(() => nodeData.value.model || DEFAULT_MODEL)
+
+// Get UI schema for current model
+const uiSchema = computed(() => {
+  if (!currentModel.value) return null
+  return replicateService.getModelUiSchema(currentModel.value)
+})
+
+// Controls to render
+const controls = computed(() => uiSchema.value?.controls || [])
+
+// Get model label from uiSchema
+function getModelLabel(modelId) {
+  const schema = replicateService.getModelUiSchema(modelId)
+  return schema?.label || modelId
+}
+
+// Get current parameter value
+function getParamValue(key, defaultValue) {
+  return nodeData.value.params?.[key] ?? defaultValue
+}
+
+/**
+ * Selects always hand back strings; numeric enums (fps) must stay numeric so
+ * the value survives serialization and reaches the API as a number
+ */
+function castParamValue(control, rawValue) {
+  if (typeof control.default !== 'number') return rawValue
+
+  const parsed = Number(rawValue)
+  return Number.isNaN(parsed) ? rawValue : parsed
+}
+
+// Handle model change
+function onModelChange(event) {
+  const newModel = event.target.value
+  const defaults = replicateService.getModelDefaults(newModel)
+
+  updateNodeData(props.id, {
+    model: newModel,
+    params: defaults
+  })
+}
+
+// Handle parameter change
+function onParamChange(key, value) {
+  const currentParams = nodeData.value.params || {}
+
+  updateNodeData(props.id, {
+    params: {
+      ...currentParams,
+      [key]: value
+    }
+  })
+}
+
+// Watch for external changes to prompt
+watch(() => nodeData.value.prompt, (newPrompt) => {
+  if (newPrompt !== localPrompt.value) {
+    localPrompt.value = newPrompt
+  }
+})
+
+function updatePrompt() {
+  if (localPrompt.value !== nodeData.value.prompt) {
+    updateNodeData(props.id, {
+      prompt: localPrompt.value
+    })
+  }
+}
+
+/**
+ * Only HTTP URLs and data URLs can be sent to the API
+ */
+function isUsableImageSrc(src) {
+  if (!src) return false
+  return isHttpUrl(src) || src.startsWith('data:')
+}
+
+async function handleGenerate() {
+  // Use connected prompt if available, otherwise use local textarea prompt
+  const promptToUse = connectedPrompt.value || localPrompt.value
+
+  // Already generating - skip
+  if (isGenerating.value) return
+
+  // No prompt available - throw error so workflow executor knows this node failed
+  if (!promptToUse.trim()) {
+    throw new Error('No prompt available. Connect a prompt node or enter a prompt.')
+  }
+
+  isGenerating.value = true
+
+  try {
+    // Update prompt before generating
+    updateNodeData(props.id, {
+      prompt: promptToUse
+    })
+
+    const imageSrc = isUsableImageSrc(firstFrameImage.value) ? firstFrameImage.value : null
+    const lastFrame = isUsableImageSrc(lastFrameImage.value) ? lastFrameImage.value : null
+
+    // Get model and params from node data
+    const model = nodeData.value.model || DEFAULT_MODEL
+    const params = nodeData.value.params || {}
+
+    // Call Replicate API
+    const result = await replicateService.generateVideo({
+      prompt: promptToUse,
+      imageSrc,
+      lastFrameImage: lastFrame,
+      model,
+      params
+    })
+
+    // Convert video URL to base64 for persistence: Replicate output URLs are
+    // short-lived and flows are saved as standalone JSON files
+    let videoData = result.videoUrl
+    if (isHttpUrl(result.videoUrl)) {
+      console.log('Converting Replicate video URL to base64 for persistence...')
+      try {
+        videoData = await convertUrlToBase64(result.videoUrl)
+        console.log('Video converted to base64 successfully')
+      } catch (error) {
+        console.warn('Failed to convert video to base64, using original URL:', error)
+        // Fallback to original URL if conversion fails
+        videoData = result.videoUrl
+      }
+    }
+
+    // Update node with generated video
+    updateNodeData(props.id, {
+      prompt: promptToUse,
+      lastOutputVideoSrc: videoData,
+      model: result.model,
+      generationId: result.id,
+      // Keep existing model params - don't overwrite them
+      params: nodeData.value.params || {},
+      // Store generation metadata separately
+      generationMetadata: {
+        usedFirstFrame: !!imageSrc,
+        usedLastFrame: !!lastFrame
+      }
+    })
+  } catch (error) {
+    console.error('Error generating video:', error)
+
+    // Show error to user
+    updateNodeData(props.id, {
+      error: error.message || 'Failed to generate video'
+    })
+
+    // Clear error after 5 seconds
+    setTimeout(() => {
+      updateNodeData(props.id, {
+        error: null
+      })
+    }, 5000)
+  } finally {
+    isGenerating.value = false
+  }
+}
+</script>
+
+<style scoped>
+.video-generator-node-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-3);
+  min-width: 280px;
+}
+
+.connected-images {
+  padding: var(--flora-space-2);
+  background: var(--flora-color-bg-tertiary);
+  border-radius: var(--flora-radius-md);
+  border: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+}
+
+.section-label {
+  font-size: var(--flora-font-size-xs);
+  font-weight: var(--flora-font-weight-semibold);
+  color: var(--flora-color-text-tertiary);
+  margin-bottom: var(--flora-space-2);
+}
+
+.frames-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  gap: var(--flora-space-2);
+}
+
+.frame {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-1);
+  align-items: center;
+}
+
+.frame img {
+  width: 100%;
+  height: 60px;
+  object-fit: cover;
+  border-radius: var(--flora-radius-md);
+  border: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+}
+
+.frame-caption {
+  font-size: var(--flora-font-size-xs);
+  color: var(--flora-color-text-tertiary);
+}
+
+.video-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-2);
+}
+
+.video-preview video {
+  width: 100%;
+  max-height: 220px;
+  border-radius: var(--flora-radius-md);
+  border: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+  background: var(--flora-color-bg-tertiary);
+}
+
+.video-placeholder {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--flora-color-bg-tertiary);
+  border: var(--flora-border-width-medium) dashed var(--flora-color-border-default);
+  border-radius: var(--flora-radius-md);
+  color: var(--flora-color-text-tertiary);
+}
+
+.placeholder-icon {
+  font-size: var(--flora-font-size-3xl);
+  margin-bottom: var(--flora-space-2);
+}
+
+.video-placeholder p {
+  margin: 0;
+  font-size: var(--flora-font-size-sm);
+}
+
+.prompt-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-2);
+}
+
+.connected-prompt-info {
+  padding: var(--flora-space-2);
+  background: var(--flora-color-info-bg);
+  border-radius: var(--flora-radius-md);
+  border: var(--flora-border-width-thin) solid var(--flora-color-info-border);
+}
+
+.prompt-preview {
+  font-size: var(--flora-font-size-sm);
+  color: var(--flora-color-text-primary);
+  margin-top: var(--flora-space-1);
+  padding: var(--flora-space-2);
+  background: var(--flora-color-surface);
+  border-radius: var(--flora-radius-sm);
+  max-width: 280px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.generate-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-2);
+}
+
+.input-info {
+  font-size: var(--flora-font-size-xs);
+  color: var(--flora-color-text-tertiary);
+  text-align: center;
+  padding: var(--flora-space-2);
+  background: var(--flora-color-info-bg);
+  border-radius: var(--flora-radius-md);
+  font-weight: var(--flora-font-weight-medium);
+}
+
+/* Node Toolbar Styles */
+.node-toolbar-content {
+  display: flex;
+  gap: var(--flora-space-4);
+  padding: var(--flora-space-3);
+  background: var(--flora-color-surface);
+  border: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+  border-radius: var(--flora-radius-md);
+  box-shadow: var(--flora-shadow-lg);
+  max-width: 800px;
+  flex-wrap: wrap;
+}
+
+.toolbar-control {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-1);
+  min-width: 120px;
+}
+
+/* Video Preview Modal */
+.video-preview-modal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 500px;
+  padding: var(--flora-space-4);
+}
+
+.video-preview-modal video {
+  max-width: 100%;
+  max-height: 80vh;
+  border-radius: var(--flora-radius-md);
+}
+</style>

--- a/src/composables/useNodeCreation.js
+++ b/src/composables/useNodeCreation.js
@@ -44,6 +44,13 @@ export function useNodeCreation(flowStore) {
       data.params = replicateService.getModelDefaults('gpt-5')
     }
 
+    // Add prompt field and model params for video generator nodes
+    if (nodeType === NODE_TYPES.VIDEO_GENERATOR) {
+      data.prompt = ''
+      data.model = 'p-video'
+      data.params = replicateService.getModelDefaults('p-video')
+    }
+
     // Add prompt field for prompt nodes
     if (nodeType === NODE_TYPES.PROMPT) {
       data.prompt = ''

--- a/src/lib/batch-io.js
+++ b/src/lib/batch-io.js
@@ -31,7 +31,8 @@ const BATCH_INPUT_TYPES = [
  */
 const BATCH_OUTPUT_TYPES = [
   NODE_TYPES.IMAGE_GENERATOR,
-  NODE_TYPES.TEXT_GENERATOR
+  NODE_TYPES.TEXT_GENERATOR,
+  NODE_TYPES.VIDEO_GENERATOR
 ]
 
 /**
@@ -40,7 +41,21 @@ const BATCH_OUTPUT_TYPES = [
 export const BATCH_VALUE_KINDS = {
   TEXT: 'text',
   IMAGE: 'image',
+  VIDEO: 'video',
   VARIABLES: 'variables'
+}
+
+/**
+ * Kinds whose value is a data URL, packaged as a binary file on export
+ */
+const BINARY_VALUE_KINDS = [BATCH_VALUE_KINDS.IMAGE, BATCH_VALUE_KINDS.VIDEO]
+
+/**
+ * @param {string} kind - BATCH_VALUE_KINDS value
+ * @returns {boolean}
+ */
+export function isBinaryValueKind(kind) {
+  return BINARY_VALUE_KINDS.includes(kind)
 }
 
 /**
@@ -253,6 +268,10 @@ export function buildBatchOutputResetPatch(node) {
     return { generatedText: null, prompt: '', error: null }
   }
 
+  if (node.type === NODE_TYPES.VIDEO_GENERATOR) {
+    return { lastOutputVideoSrc: null, error: null }
+  }
+
   return { lastOutputSrc: null, error: null }
 }
 
@@ -266,6 +285,14 @@ export function readBatchOutput(node) {
     return {
       kind: BATCH_VALUE_KINDS.TEXT,
       value: node.data?.generatedText || null,
+      error: node.data?.error || null
+    }
+  }
+
+  if (node.type === NODE_TYPES.VIDEO_GENERATOR) {
+    return {
+      kind: BATCH_VALUE_KINDS.VIDEO,
+      value: node.data?.lastOutputVideoSrc || null,
       error: node.data?.error || null
     }
   }

--- a/src/lib/image-utils.js
+++ b/src/lib/image-utils.js
@@ -9,15 +9,26 @@
  * @returns {Promise<string>} Base64 data URL
  */
 export async function convertImageUrlToBase64(imageUrl) {
+  return convertUrlToBase64(imageUrl)
+}
+
+/**
+ * Convert any media URL to a base64 data URL
+ * Model outputs live on short-lived Replicate URLs, so they are inlined before
+ * being stored in node data: exported flows are plain JSON and must stand alone
+ * @param {string} url - HTTP/HTTPS URL of the file
+ * @returns {Promise<string>} Base64 data URL
+ */
+export async function convertUrlToBase64(url) {
   try {
-    // Fetch the image
-    const response = await fetch(imageUrl)
+    // Fetch the file
+    const response = await fetch(url)
 
     if (!response.ok) {
-      throw new Error(`Failed to fetch image: ${response.status} ${response.statusText}`)
+      throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`)
     }
 
-    // Get the image as a blob
+    // Get the file as a blob
     const blob = await response.blob()
 
     // Convert blob to base64 using FileReader
@@ -29,13 +40,13 @@ export async function convertImageUrlToBase64(imageUrl) {
       }
 
       reader.onerror = () => {
-        reject(new Error('Failed to convert image to base64'))
+        reject(new Error('Failed to convert file to base64'))
       }
 
       reader.readAsDataURL(blob)
     })
   } catch (error) {
-    console.error('Error converting image URL to base64:', error)
+    console.error('Error converting URL to base64:', error)
     throw error
   }
 }

--- a/src/lib/node-shapes.js
+++ b/src/lib/node-shapes.js
@@ -10,6 +10,7 @@ export const NODE_TYPES = {
   DIFF: 'diff',
   COMPARE: 'compare',
   TEXT_GENERATOR: 'text-generator',
+  VIDEO_GENERATOR: 'video-generator',
   GROUP: 'group',
   COMMENT: 'comment'
 }
@@ -19,7 +20,8 @@ export const NODE_TYPES = {
  */
 export const PORT_TYPES = {
   IMAGE: 'image',
-  PROMPT: 'prompt'
+  PROMPT: 'prompt',
+  VIDEO: 'video'
 }
 
 /**
@@ -111,6 +113,11 @@ const NODE_IO_CONFIG = {
   [NODE_TYPES.TEXT_GENERATOR]: {
     inputs: [PORT_TYPES.IMAGE, PORT_TYPES.PROMPT],
     outputs: [PORT_TYPES.PROMPT]
+  },
+  // Two image inputs: the last frame reference and the first frame (image)
+  [NODE_TYPES.VIDEO_GENERATOR]: {
+    inputs: [PORT_TYPES.IMAGE, PORT_TYPES.IMAGE, PORT_TYPES.PROMPT],
+    outputs: [PORT_TYPES.VIDEO]
   },
   [NODE_TYPES.GROUP]: {
     inputs: [],

--- a/src/lib/register-nodes.js
+++ b/src/lib/register-nodes.js
@@ -13,6 +13,7 @@ import DrawNode from '@/components/nodes/DrawNode.vue'
 import DiffNode from '@/components/nodes/DiffNode.vue'
 import ImageCompareNode from '@/components/nodes/ImageCompareNode.vue'
 import TextGeneratorNode from '@/components/nodes/TextGeneratorNode.vue'
+import VideoGeneratorNode from '@/components/nodes/VideoGeneratorNode.vue'
 import GroupNode from '@/components/nodes/GroupNode.vue'
 import CommentNode from '@/components/nodes/CommentNode.vue'
 
@@ -129,6 +130,20 @@ export function registerAllNodes() {
     config: {
       category: 'Generator',
       color: '#E91E63'
+    }
+  })
+
+  // Register Video Generator Node
+  nodeRegistry.registerNode({
+    type: NODE_TYPES.VIDEO_GENERATOR,
+    label: 'Video Generator',
+    description: 'Generate videos using AI from a prompt, a first frame and an optional last frame',
+    inputs: [PORT_TYPES.IMAGE, PORT_TYPES.IMAGE, PORT_TYPES.PROMPT],
+    outputs: [PORT_TYPES.VIDEO],
+    component: VideoGeneratorNode,
+    config: {
+      category: 'Generator',
+      color: '#EC4899'
     }
   })
 

--- a/src/lib/zip.js
+++ b/src/lib/zip.js
@@ -101,10 +101,18 @@ export function extensionForMimeType(mimeType) {
     'image/jpg': '.jpg',
     'image/webp': '.webp',
     'image/gif': '.gif',
-    'image/svg+xml': '.svg'
+    'image/svg+xml': '.svg',
+    'video/mp4': '.mp4',
+    'video/webm': '.webm',
+    'video/quicktime': '.mov'
   }
 
-  return extensions[mimeType] || '.png'
+  if (extensions[mimeType]) {
+    return extensions[mimeType]
+  }
+
+  // An unmapped video must not end up named .png
+  return mimeType?.startsWith('video/') ? '.mp4' : '.png'
 }
 
 /**

--- a/src/services/models/p-video.js
+++ b/src/services/models/p-video.js
@@ -1,0 +1,202 @@
+/**
+ * PrunaAI P-Video Model Configuration
+ * Model: prunaai/p-video
+ */
+
+export const P_VIDEO = {
+  id: 'p-video',
+  name: 'P-Video',
+  owner: 'prunaai',
+  version: 'latest',
+  category: 'video', // Model category: video generation
+  endpointPath: '/v1/models/prunaai/p-video/predictions',
+
+  /**
+   * Default parameters for the model
+   */
+  defaults: {
+    duration: 5,
+    aspect_ratio: '16:9',
+    resolution: '720p',
+    fps: 24,
+    draft: false,
+    prompt_upsampling: true,
+    save_audio: true
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'p-video',
+    label: 'P-Video',
+    controls: [
+      {
+        key: 'duration',
+        label: 'Duration (s)',
+        type: 'number',
+        min: 1,
+        max: 20,
+        default: 5
+      },
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: ['16:9', '9:16', '4:3', '3:4', '3:2', '2:3', '1:1'],
+        default: '16:9'
+      },
+      {
+        key: 'resolution',
+        label: 'Resolution',
+        type: 'select',
+        enum: ['720p', '1080p'],
+        default: '720p'
+      },
+      {
+        key: 'fps',
+        label: 'FPS',
+        type: 'select',
+        enum: [24, 48],
+        default: 24
+      },
+      {
+        key: 'draft',
+        label: 'Draft',
+        type: 'checkbox',
+        default: false
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    aspect_ratio: ['16:9', '9:16', '4:3', '3:4', '3:2', '2:3', '1:1'],
+    resolution: ['720p', '1080p'],
+    fps: [24, 48]
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description of the video
+   * @param {Array<string>} [options.imageInput] - First frame image (only the first entry is used)
+   * @param {string} [options.lastFrameImage] - Reference image for the last frame
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], lastFrameImage = null, params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    const input = {
+      prompt: prompt.trim(),
+      duration: params.duration ?? this.defaults.duration,
+      resolution: params.resolution || this.defaults.resolution,
+      fps: params.fps ?? this.defaults.fps,
+      draft: params.draft !== undefined ? params.draft : this.defaults.draft,
+      prompt_upsampling: params.prompt_upsampling !== undefined
+        ? params.prompt_upsampling
+        : this.defaults.prompt_upsampling,
+      save_audio: params.save_audio !== undefined ? params.save_audio : this.defaults.save_audio
+    }
+
+    // The model takes a single image as the video's first frame
+    if (imageInput.length > 0) {
+      input.image = imageInput[0]
+    }
+
+    if (lastFrameImage) {
+      input.last_frame_image = lastFrameImage
+    }
+
+    // aspect_ratio is ignored by the model when an input image is provided,
+    // so it is only sent for text-to-video generations
+    if (!input.image) {
+      input.aspect_ratio = params.aspect_ratio || this.defaults.aspect_ratio
+    }
+
+    // Optional seed for reproducible generations
+    if (params.seed !== undefined && params.seed !== null && params.seed !== '') {
+      input.seed = parseInt(params.seed)
+    }
+
+    return input
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * The toolbar selects hand back strings, so numeric params are coerced here
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    const validated = {}
+
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.resolution && !this.validValues.resolution.includes(params.resolution)) {
+      throw new Error(`Invalid resolution. Must be one of: ${this.validValues.resolution.join(', ')}`)
+    }
+
+    if (params.fps !== undefined && params.fps !== null) {
+      const fps = parseInt(params.fps)
+      if (!this.validValues.fps.includes(fps)) {
+        throw new Error(`Invalid fps. Must be one of: ${this.validValues.fps.join(', ')}`)
+      }
+      validated.fps = fps
+    }
+
+    if (params.duration !== undefined && params.duration !== null) {
+      const duration = parseInt(params.duration)
+      if (isNaN(duration) || duration < 1 || duration > 20) {
+        throw new Error('duration must be between 1 and 20 seconds')
+      }
+      validated.duration = duration
+    }
+
+    return {
+      duration: validated.duration,
+      aspect_ratio: params.aspect_ratio,
+      resolution: params.resolution,
+      fps: validated.fps,
+      draft: params.draft,
+      prompt_upsampling: params.prompt_upsampling,
+      save_audio: params.save_audio,
+      seed: params.seed
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The model outputs a single video URI, but tolerate an array response
+    const videoUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      videoUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default P_VIDEO

--- a/src/services/replicate.js
+++ b/src/services/replicate.js
@@ -10,6 +10,7 @@ import GPT_IMAGE_1 from './models/gpt-image-1'
 import GPT_IMAGE_2 from './models/gpt-image-2'
 import GPT_5 from './models/gpt-5'
 import GEMINI_2_5_FLASH from './models/gemini-2.5-flash'
+import P_VIDEO from './models/p-video'
 import { useSettingsStore } from '@/stores/settings'
 
 /**
@@ -23,6 +24,7 @@ const MODELS = {
   'gpt-image-2': GPT_IMAGE_2,
   'gpt-5': GPT_5,
   'gemini-2.5-flash': GEMINI_2_5_FLASH,
+  'p-video': P_VIDEO,
   'default': NANO_BANANA_PRO
 }
 
@@ -282,6 +284,82 @@ class ReplicateService {
   }
 
   /**
+   * Generate video using Replicate API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {string} [options.imageSrc] - First frame image
+   * @param {string} [options.lastFrameImage] - Last frame reference image
+   * @param {string} [options.model] - Model ID to use (default: p-video)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Promise<Object>} Generated video result
+   */
+  async generateVideo(options) {
+    const {
+      prompt,
+      imageSrc = null,
+      lastFrameImage = null,
+      model: modelId = 'p-video',
+      params = {}
+    } = options
+
+    // Validate inputs
+    if (!prompt) {
+      throw new Error('Prompt is required')
+    }
+
+    // Get model configuration
+    const model = this.getModel(modelId)
+
+    // Prepare image input
+    let imageInput = []
+    if (imageSrc) {
+      imageInput = Array.isArray(imageSrc) ? imageSrc : [imageSrc]
+    }
+
+    console.log('Replicate service - preparing video generation:')
+    console.log('  Prompt:', prompt.substring(0, 50) + '...')
+    console.log('  First frame image:', imageInput.length > 0 ? 'yes' : 'no')
+    console.log('  Last frame image:', lastFrameImage ? 'yes' : 'no')
+
+    // Validate and build input
+    const validatedParams = model.validateParams(params)
+    const input = model.buildInput({
+      prompt,
+      imageInput,
+      lastFrameImage,
+      params: validatedParams
+    })
+
+    console.log('  API input payload:', {
+      prompt: input.prompt?.substring(0, 50) + '...',
+      has_image: !!input.image,
+      has_last_frame_image: !!input.last_frame_image,
+      duration: input.duration,
+      resolution: input.resolution,
+      fps: input.fps,
+      draft: input.draft,
+      ...(input.aspect_ratio && { aspect_ratio: input.aspect_ratio })
+    })
+
+    // Check for API token. Unlike images there is no mock video to fall back to
+    const token = this.getApiToken()
+    if (!token) {
+      throw new Error('No Replicate API token found. Please configure it in Settings.')
+    }
+
+    // Build complete endpoint URL
+    const endpoint = this.config.apiUrl + model.endpointPath
+
+    // Make API call
+    try {
+      const response = await this._callApi(endpoint, input, token, model)
+      return model.parseResponse(response)
+    } catch (error) {
+      throw this._handleError(error)
+    }
+  }
+
+  /**
    * Transform Replicate API URL to use local proxy
    * @param {string} url - Original Replicate API URL
    * @returns {string} Transformed URL for local proxy
@@ -447,7 +525,7 @@ class ReplicateService {
    */
   _handleError(error) {
     if (error.message.includes('timeout')) {
-      return new Error('Image generation timed out. Please try again.')
+      return new Error('Generation timed out. Please try again.')
     }
 
     if (error.message.includes('401') || error.message.includes('403')) {

--- a/src/services/workflow-executor.js
+++ b/src/services/workflow-executor.js
@@ -49,6 +49,10 @@ function shouldExecuteNode(node) {
       // Execute if no generated text
       return !node.data?.generatedText
 
+    case NODE_TYPES.VIDEO_GENERATOR:
+      // Execute if no generated video
+      return !node.data?.lastOutputVideoSrc
+
     case NODE_TYPES.PROMPT:
       // Prompt nodes are "complete" if they have prompt text
       // They don't need execution - they're input nodes
@@ -335,7 +339,9 @@ class WorkflowExecutor {
 
         // If forceRerun is enabled, execute all generator nodes regardless of current state
         if (this.options.forceRerun) {
-          const isGeneratorNode = node.type === NODE_TYPES.IMAGE_GENERATOR || node.type === NODE_TYPES.TEXT_GENERATOR
+          const isGeneratorNode = node.type === NODE_TYPES.IMAGE_GENERATOR ||
+            node.type === NODE_TYPES.TEXT_GENERATOR ||
+            node.type === NODE_TYPES.VIDEO_GENERATOR
           if (isGeneratorNode) {
             console.log(`[WorkflowExecutor] Force re-running node ${node.id}`)
             return true

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -75,6 +75,7 @@
   --flora-color-port-prompt: #3b82f6;   /* blue */
   --flora-color-port-text: #8b5cf6;     /* purple */
   --flora-color-port-number: #f59e0b;   /* amber */
+  --flora-color-port-video: #ec4899;    /* pink */
 
   /* ========================================
      SPACING


### PR DESCRIPTION
# What

Adds a new **Video Generator** node to the canvas, so a flow can end in a video instead of only images or text.

The node takes a prompt and, optionally, two images: one as the **first frame** of the video and one as a **last frame** reference. Everything else is configured from the toolbar that appears when the node is selected: duration, aspect ratio, resolution, FPS and draft mode (a much cheaper and faster low-quality preview, useful while iterating on a prompt). The generated video plays inside the node and can be opened full size.

It also plugs into the existing **Batch Run** panel: a video node can be marked as batch output, each row shows its video, and the ZIP download includes the `.mp4` files next to the usual results manifest.

# Why

Flora already covered image and text generation but had no way to produce motion, which is the natural next step for the product (product animation, social clips, talking avatars). The chosen model is `prunaai/p-video`, fast enough for interactive use (~10s for a 5s 720p clip) and with a single endpoint for text-to-video and image-to-video.

Implementation notes worth knowing when reviewing:

- A new `video` port type was introduced. Beyond colouring the handle, having an output is what makes the node executable by `workflow-executor` (nodes without outputs are treated as terminal and skipped), and it leaves the door open for future nodes that consume video.
- The node has **two image inputs of the same port type**, so they are told apart by handle id (`input-0` last frame, `input-1` image) rather than by the source node. `BaseNode` now accepts ports as `{ type, label }` so both handles can be labelled on the canvas; plain strings keep working, so no other node changed.
- The model lives in `src/services/models/p-video.js` following the existing per-model contract (`defaults`, `uiSchema`, `buildInput`, `validateParams`, `parseResponse`), and `replicateService.generateVideo()` mirrors `generateImage()`/`generateText()`. `aspect_ratio` is only sent for text-to-video, since the model ignores it when an input image is present.
- The result is inlined as base64 like generated images do, because Replicate output URLs are short-lived and flows are saved as standalone `.json`. Trade-off: flows with videos are heavy.
- Batch support is generic: `batch-io.js` gained a `video` value kind and an `isBinaryValueKind()` helper shared with images, so `batch-executor.js` needed no changes.

# Tests

e2e tests and local.

Added `e2e/video-node.spec.js` (7 specs) plus a `mockPVideo()` route mock in `e2e/mocks/api.js`, following the existing Playwright conventions. They cover:

- text-to-video, asserting the default payload (`duration` 5, `720p`, 24 fps, draft off, `aspect_ratio` sent)
- handle routing of the two image inputs: with only `input-0` wired the payload carries `last_frame_image` and no `image`; adding `input-1` produces both, and `aspect_ratio` is then dropped
- toolbar parameters reaching the API, including `fps` staying numeric after coming out of a `<select>`
- a connected Prompt node replacing the local textarea
- port validation: the `video` output is rejected by image and prompt inputs
- persistence: a remote `replicate.delivery` output is inlined as a `data:video/mp4;base64,...`
- batch: marking the node as batch output, running 2 rows and previewing each resulting video

Full suite green: **51 passed** (44 pre-existing + 7 new), so the shared changes to `BaseNode`, `BatchRunModal`, `batch-io.js` and `zip.js` did not regress anything.

Not covered automatically: the contents of the batch ZIP (there is no ZIP-inspection precedent in the suite), so the `.mp4` naming was checked manually.

## How to test

1. `npm run test:e2e` (or `npx playwright test e2e/video-node.spec.js`) to run the automated checks.

Manual pass:

2. `npm run dev`, and set a Replicate API token in Settings.
3. Open the nodes menu → **AI** section → **Video Generator** (🎬). Check it can also be created by dragging it in and by dropping a connection on the empty canvas.
4. Select the node and confirm the toolbar shows: Model, Duration, Aspect Ratio, Resolution, FPS and Draft.
5. **Text-to-video**: type a prompt, tick **Draft** (cheap run) and hit *Generate Video*. The video should play inside the node and *Open preview* should show it full size.
6. **Image-to-video**: connect an Image node to the `image` handle (second from the top) and generate again. The frame appears as a thumbnail labelled *First*.
7. **Last frame**: connect a second Image node to the `last frame` handle (top one) and confirm it shows as *Last*. Two edges between the same pair of nodes are not allowed, so use two different Image nodes.
8. Run the whole flow with the **Run** button in the workflow controls and confirm the node executes and shows the completed badge.
9. **Batch**: right-click the video node → *Mark as batch output*, mark a Prompt node as batch input, open Batch Run, fill a couple of rows and run. Then *Download ZIP* and confirm it contains `.mp4` files plus `results.json`.
10. Export the flow to JSON, reload the page, import it back and confirm the video still plays (it is stored as base64, not as an expiring URL).
