### PR TITLE
feat: copy and paste the whole selection with its input connections

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,7 @@ flora/
 │   ├── composables/
 │   │   ├── useFlowIO.js              # Import/export operations
 │   │   ├── useViewportControls.js    # Lock/unlock and fit view
-│   │   ├── useCopyPaste.js           # Copy/paste node operations
+│   │   ├── useCopyPaste.js           # Copy/paste the selected nodes
 │   │   ├── useNodeCreation.js        # Node creation helpers
 │   │   ├── useDragAndDrop.js         # Drag & drop logic
 │   │   ├── useGroupManagement.js     # Group/ungroup operations
@@ -123,13 +123,13 @@ const { findNode, onConnect, addEdges, viewport, onNodeDragStop, fitView } = use
 // Logic composables
 const { fileInput, handleExport, handleImport, onFileSelected } = useFlowIO(flowStore, { addEdges })
 const { isLocked, handleLockToggle, handleFitView } = useViewportControls(fitView)
-const { copiedNode, handleCopy, handlePaste } = useCopyPaste(flowStore, viewport, mousePosition)
+const { copiedNodes, handleCopy, handlePaste } = useCopyPaste(flowStore, viewport, mousePosition, { addEdges })
 const { createNodeAtPosition } = useNodeCreation(flowStore)
 
 // Complex composables
 const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore)
 const { handleGroup } = useGroupManagement(flowStore, onNodeDragStop)
-useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowStore })
+useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowStore })
 ```
 
 **Features:**
@@ -138,7 +138,7 @@ useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowSto
 - Real-time connection validation
 - Flow export/import
 - Viewport controls (lock, fit view)
-- Copy/paste nodes (Ctrl+C, Ctrl+V)
+- Copy/paste the selection, keeping its layout and input connections (Ctrl+C, Ctrl+V)
 - Group nodes (Ctrl+G)
 - Settings modal
 - Automatic group management
@@ -323,17 +323,24 @@ export function useViewportControls(fitView) {
 }
 ```
 
-**useCopyPaste.js** - Copy/paste node operations
+**useCopyPaste.js** - Copy/paste the whole selection
 ```javascript
-export function useCopyPaste(flowStore, viewport, mousePosition) {
-  const copiedNode = ref(null)
+export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
+  const copiedNodes = ref([])  // every selected node, group containers aside
+  const copiedEdges = ref([])  // the edges feeding them
 
   function handleCopy() { /* ... */ }
-  function handlePaste() { /* ... */ }
+  async function handlePaste() { /* ... */ }
 
-  return { copiedNode, handleCopy, handlePaste }
+  return { copiedNodes, handleCopy, handlePaste }
 }
 ```
+The paste anchors the bounding box of the snapshot at the mouse pointer, so the
+relative layout survives. Edges between copied nodes are rewired to the clones
+through an old-id → new-id map; input edges coming from outside the selection
+keep their original source. Outgoing edges are never cloned: targets merge every
+incoming edge, so a node the user did not copy would silently read two sources.
+Group containers are skipped and their children are pasted as top-level nodes.
 
 **useNodeCreation.js** - Node creation helpers
 ```javascript
@@ -372,7 +379,7 @@ export function useGroupManagement(flowStore, onNodeDragStop) {
 
 **useKeyboardShortcuts.js** - Global keyboard shortcuts
 ```javascript
-export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowStore }) {
+export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowStore }) {
   function handleKeyDown(event) { /* ... */ }
 
   onMounted(() => window.addEventListener('keydown', handleKeyDown))

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,7 +153,7 @@ src/
 ├── composables/                   # Reusable logic
 │   ├── useFlowIO.js              # Import/export operations
 │   ├── useViewportControls.js    # Lock/unlock and fit view
-│   ├── useCopyPaste.js           # Copy/paste nodes
+│   ├── useCopyPaste.js           # Copy/paste the selection
 │   ├── useNodeCreation.js        # Node creation helpers
 │   ├── useDragAndDrop.js         # Drag & drop logic
 │   ├── useGroupManagement.js     # Group/ungroup operations

--- a/e2e/copy-paste.spec.js
+++ b/e2e/copy-paste.spec.js
@@ -1,0 +1,315 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+  connectNodesProgrammatic,
+} from './helpers/canvas.js'
+
+/**
+ * Ids, selection flags and positions are not in the DOM: read them from the
+ * store, the same access positionNodes uses.
+ */
+async function readGraph(page) {
+  return page.evaluate(() => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    return {
+      nodes: flowStore.nodes.map(n => ({
+        id: n.id,
+        type: n.type,
+        label: n.data?.label,
+        selected: !!n.selected,
+        parentNode: n.parentNode || null,
+        x: n.position.x,
+        y: n.position.y,
+      })),
+      edges: flowStore.edges.map(e => ({
+        source: e.source,
+        target: e.target,
+        sourceHandle: e.sourceHandle,
+        targetHandle: e.targetHandle,
+      })),
+    }
+  })
+}
+
+/**
+ * Plain click on the first node, Ctrl+click on the rest (the canvas uses
+ * Control/Meta as its multi-selection key). The header is the only spot
+ * guaranteed not to focus a textarea, so headers must be visible.
+ */
+async function selectNodes(page, nodeLocators) {
+  for (const [index, node] of nodeLocators.entries()) {
+    await node.locator('.node-header').click(index === 0 ? {} : { modifiers: ['Control'] })
+  }
+  await page.waitForTimeout(100)
+}
+
+/** Mark nodes as selected in the store, for selections a click cannot express */
+async function selectNodesProgrammatic(page, matchers) {
+  await page.evaluate((specs) => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    flowStore.nodes.forEach(n => { n.selected = false })
+    for (const { type, nth } of specs) {
+      const matching = flowStore.nodes.filter(n => n.type === type)
+      const node = matching[nth || 0]
+      if (node) node.selected = true
+    }
+  }, matchers)
+  await page.waitForTimeout(100)
+}
+
+/** Ctrl+C, park the pointer over an empty spot, Ctrl+V */
+async function copyAndPasteAt(page, x, y) {
+  await page.evaluate(() => document.activeElement?.blur())
+  await page.keyboard.press('Control+c')
+  // handlePaste places the batch at the last position the mouse reported
+  await page.mouse.move(x, y)
+  await page.keyboard.press('Control+v')
+  await page.waitForTimeout(400)
+}
+
+test.describe('Copy/paste the selection', () => {
+  test('pastes a single selected node', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 200, y: 160 }])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await selectNodes(page, [promptNode])
+    await copyAndPasteAt(page, 700, 500)
+
+    await expect(promptNode).toHaveCount(2)
+    const { nodes } = await readGraph(page)
+    expect(nodes.map(n => n.label)).toEqual(['New Prompt', 'New Prompt 2'])
+  })
+
+  test('pastes every selected node', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Prompt')
+    // Selecting a node elevates it, so leave room or its box swallows the
+    // clicks meant for the next header
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 100, y: 100 },
+      { type: 'image', nth: 0, x: 560, y: 100 },
+      { type: 'prompt', nth: 1, x: 100, y: 430 },
+    ])
+
+    await selectNodes(page, [
+      page.locator('.vue-flow__node-prompt').nth(0),
+      page.locator('.vue-flow__node-image').nth(0),
+      page.locator('.vue-flow__node-prompt').nth(1),
+    ])
+    await copyAndPasteAt(page, 850, 520)
+
+    const { nodes } = await readGraph(page)
+    expect(nodes).toHaveLength(6)
+    expect(nodes.filter(n => n.type === 'prompt')).toHaveLength(4)
+    expect(nodes.filter(n => n.type === 'image')).toHaveLength(2)
+    // Labels stay unique even though the copies are created in one pass
+    expect(new Set(nodes.map(n => n.label)).size).toBe(6)
+  })
+
+  test('keeps the relative layout of the copied nodes', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 100, y: 100 },
+      { type: 'prompt', nth: 1, x: 400, y: 260 },
+    ])
+
+    await selectNodes(page, [
+      page.locator('.vue-flow__node-prompt').nth(0),
+      page.locator('.vue-flow__node-prompt').nth(1),
+    ])
+    await copyAndPasteAt(page, 800, 480)
+
+    const { nodes } = await readGraph(page)
+    const pasted = nodes.slice(2)
+    expect(pasted).toHaveLength(2)
+    expect(pasted[1].x - pasted[0].x).toBeCloseTo(300, 0)
+    expect(pasted[1].y - pasted[0].y).toBeCloseTo(160, 0)
+  })
+
+  test('rewires connections between the pasted nodes', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Image Generator')
+    await positionNodes(page, [
+      { type: 'prompt', x: 120, y: 140 },
+      { type: 'image-generator', x: 480, y: 140 },
+    ])
+    await connectNodesProgrammatic(page, [{
+      sourceType: 'prompt', sourceHandle: 'output-0',
+      targetType: 'image-generator', targetHandle: 'input-1',
+    }])
+
+    const before = await readGraph(page)
+    await selectNodes(page, [
+      page.locator('.vue-flow__node-prompt'),
+      page.locator('.vue-flow__node-image-generator'),
+    ])
+    await copyAndPasteAt(page, 820, 520)
+
+    const { nodes, edges } = await readGraph(page)
+    expect(edges).toHaveLength(2)
+
+    const pastedIds = new Set(nodes.slice(2).map(n => n.id))
+    const newEdge = edges.find(e => !before.edges.some(o => o.source === e.source && o.target === e.target))
+    // Both ends land on the clones, not on the originals
+    expect(pastedIds.has(newEdge.source)).toBe(true)
+    expect(pastedIds.has(newEdge.target)).toBe(true)
+    expect(newEdge.sourceHandle).toBe('output-0')
+    expect(newEdge.targetHandle).toBe('input-1')
+  })
+
+  test('keeps external inputs pointing at the original source', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Image Generator')
+    await positionNodes(page, [
+      { type: 'image', x: 120, y: 140 },
+      { type: 'image-generator', x: 480, y: 140 },
+    ])
+    await connectNodesProgrammatic(page, [{
+      sourceType: 'image', sourceHandle: 'output-0',
+      targetType: 'image-generator', targetHandle: 'input-0',
+    }])
+
+    const before = await readGraph(page)
+    const imageId = before.nodes.find(n => n.type === 'image').id
+
+    // Only the consumer is copied: its feed must survive
+    await selectNodes(page, [page.locator('.vue-flow__node-image-generator')])
+    await copyAndPasteAt(page, 820, 520)
+
+    const { nodes, edges } = await readGraph(page)
+    expect(edges).toHaveLength(2)
+
+    const pastedGenerator = nodes.filter(n => n.type === 'image-generator')[1]
+    const newEdge = edges.find(e => e.target === pastedGenerator.id)
+    expect(newEdge.source).toBe(imageId)
+    expect(newEdge.targetHandle).toBe('input-0')
+  })
+
+  test('does not duplicate outgoing connections', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Image Generator')
+    await positionNodes(page, [
+      { type: 'image', x: 120, y: 140 },
+      { type: 'image-generator', x: 480, y: 140 },
+    ])
+    await connectNodesProgrammatic(page, [{
+      sourceType: 'image', sourceHandle: 'output-0',
+      targetType: 'image-generator', targetHandle: 'input-0',
+    }])
+
+    const before = await readGraph(page)
+    const generatorId = before.nodes.find(n => n.type === 'image-generator').id
+
+    // Copying a producer must not make the untouched consumer read two sources
+    await selectNodes(page, [page.locator('.vue-flow__node-image')])
+    await copyAndPasteAt(page, 820, 520)
+
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(1)
+    expect(edges.filter(e => e.target === generatorId)).toHaveLength(1)
+  })
+
+  test('leaves the pasted nodes selected and the originals unselected', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 120, y: 120 },
+      { type: 'prompt', nth: 1, x: 420, y: 120 },
+    ])
+
+    await selectNodes(page, [
+      page.locator('.vue-flow__node-prompt').nth(0),
+      page.locator('.vue-flow__node-prompt').nth(1),
+    ])
+    await copyAndPasteAt(page, 800, 500)
+
+    const { nodes } = await readGraph(page)
+    expect(nodes.filter(n => n.selected).map(n => n.id)).toEqual(nodes.slice(2).map(n => n.id))
+  })
+
+  test('chained paste keeps producing fresh nodes', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 120, y: 120 },
+      { type: 'prompt', nth: 1, x: 420, y: 120 },
+    ])
+
+    await selectNodes(page, [
+      page.locator('.vue-flow__node-prompt').nth(0),
+      page.locator('.vue-flow__node-prompt').nth(1),
+    ])
+    await copyAndPasteAt(page, 760, 460)
+
+    // The clones are selected now, so a second Ctrl+C/Ctrl+V copies them
+    await copyAndPasteAt(page, 300, 620)
+
+    const { nodes } = await readGraph(page)
+    expect(nodes).toHaveLength(6)
+    expect(new Set(nodes.map(n => n.id)).size).toBe(6)
+    expect(new Set(nodes.map(n => n.label)).size).toBe(6)
+  })
+
+  test('pastes nothing when there is no selection', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 200, y: 160 }])
+
+    // Clicking the pane clears the selection
+    await page.locator('.vue-flow__pane').click({ position: { x: 900, y: 550 } })
+    await page.waitForTimeout(100)
+    await copyAndPasteAt(page, 900, 550)
+
+    await expect(page.locator('.vue-flow__node-prompt')).toHaveCount(1)
+  })
+
+  test('skips group containers', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 200, y: 200 },
+      { type: 'prompt', nth: 1, x: 500, y: 200 },
+    ])
+
+    await selectNodes(page, [
+      page.locator('.vue-flow__node-prompt').nth(0),
+      page.locator('.vue-flow__node-prompt').nth(1),
+    ])
+    await page.keyboard.press('Control+g')
+    await page.waitForTimeout(300)
+    await expect(page.locator('.vue-flow__node-group')).toHaveCount(1)
+
+    // handleGroup clears the selection, and clicking the container is brittle
+    await selectNodesProgrammatic(page, [
+      { type: 'prompt', nth: 0 },
+      { type: 'prompt', nth: 1 },
+      { type: 'group', nth: 0 },
+    ])
+    await copyAndPasteAt(page, 850, 560)
+
+    const { nodes } = await readGraph(page)
+    // Two prompts cloned, the container left alone
+    expect(nodes.filter(n => n.type === 'prompt')).toHaveLength(4)
+    expect(nodes.filter(n => n.type === 'group')).toHaveLength(1)
+    // Clones are top-level, pasted at their absolute position
+    const pastedPrompts = nodes.filter(n => n.type === 'prompt').slice(2)
+    expect(pastedPrompts.every(n => n.parentNode === null)).toBe(true)
+    expect(pastedPrompts[1].x - pastedPrompts[0].x).toBeCloseTo(300, 0)
+  })
+})

--- a/src/composables/useCopyPaste.js
+++ b/src/composables/useCopyPaste.js
@@ -1,97 +1,162 @@
 /**
  * Composable for Copy/Paste operations
- * Handles copying and pasting nodes
+ * Copies the whole selection and pastes it back keeping the relative layout,
+ * the connections between the copied nodes and their upstream feeds
  */
 
 import { ref, nextTick } from 'vue'
-import { createNode, getNodeIOConfig } from '@/lib/node-shapes'
+import { createNode, getNodeIOConfig, NODE_TYPES } from '@/lib/node-shapes'
 import { ensureUniqueLabel } from '@/lib/node-label'
 
+/**
+ * Short random suffix so two ids minted in the same millisecond differ
+ * @returns {string}
+ */
+function randomSuffix() {
+  return Math.random().toString(36).slice(2, 7)
+}
+
 export function useCopyPaste(flowStore, viewport, mousePosition, { addEdges }) {
-  const copiedNode = ref(null)
+  // Snapshot of the selection, plain and serializable, taken at copy time
+  const copiedNodes = ref([])
+  // Edges feeding the snapshot; their source may be inside it or outside
+  const copiedEdges = ref([])
 
   /**
-   * Copy selected node
+   * Absolute canvas position of a node: children of a group store their
+   * position relative to it, and groups cannot nest, so one hop is enough
    */
-  function handleCopy() {
-    const selectedNode = flowStore.nodes.find(n => n.selected)
-    if (selectedNode) {
-      // Create a deep copy immediately to capture current state
-      copiedNode.value = {
-        ...selectedNode,
-        data: JSON.parse(JSON.stringify(selectedNode.data)),
-        _inputEdges: flowStore.edges
-          .filter(e => e.target === selectedNode.id)
-          .map(e => ({
-            source: e.source,
-            sourceHandle: e.sourceHandle || null,
-            targetHandle: e.targetHandle || null
-          }))
-      }
-      console.log('Node copied:', selectedNode.type, 'with data:', copiedNode.value.data)
+  function toAbsolutePosition(node) {
+    const parent = node.parentNode
+      ? flowStore.nodes.find(n => n.id === node.parentNode)
+      : null
+
+    if (!parent) return { x: node.position.x, y: node.position.y }
+
+    return {
+      x: parent.position.x + node.position.x,
+      y: parent.position.y + node.position.y
     }
   }
 
   /**
-   * Paste copied node at mouse position
+   * Copy every selected node plus the edges that feed them.
+   * Group containers are skipped: their size lives in `style`, which the node
+   * schema drops, so the copy would be an invisible empty box
+   */
+  function handleCopy() {
+    const selected = flowStore.nodes.filter(
+      node => node.selected && node.type !== NODE_TYPES.GROUP
+    )
+
+    // Only the schema fields: the store holds VueFlow graph nodes, and their
+    // internals (dimensions, handleBounds, computedPosition) must not be cloned
+    copiedNodes.value = selected.map(node => ({
+      id: node.id,
+      type: node.type,
+      position: toAbsolutePosition(node),
+      data: JSON.parse(JSON.stringify(node.data ?? {}))
+    }))
+
+    const copiedIds = new Set(copiedNodes.value.map(node => node.id))
+
+    // Incoming edges only. Cloning an outgoing edge would rewire a node the
+    // user did not copy: targets merge every incoming edge, so the original
+    // consumer would silently start reading two sources
+    copiedEdges.value = flowStore.edges
+      .filter(edge => copiedIds.has(edge.target))
+      .map(edge => ({
+        source: edge.source,
+        target: edge.target,
+        sourceHandle: edge.sourceHandle || null,
+        targetHandle: edge.targetHandle || null
+      }))
+
+    console.log(`Copied ${copiedNodes.value.length} node(s), ${copiedEdges.value.length} incoming edge(s)`)
+  }
+
+  /**
+   * Paste the snapshot with its top-left corner at the mouse pointer
    */
   async function handlePaste() {
-    if (!copiedNode.value) return
+    if (copiedNodes.value.length === 0) return
 
-    // Calculate position at mouse, accounting for zoom and pan
-    const position = {
+    // Pointer in canvas coordinates (undo pan and zoom)
+    const pointer = {
       x: (mousePosition.value.x - viewport.value.x) / viewport.value.zoom,
       y: (mousePosition.value.y - viewport.value.y) / viewport.value.zoom
     }
 
-    // Get IO configuration for this node type
-    const ioConfig = getNodeIOConfig(copiedNode.value.type)
+    // Anchor the bounding box of the snapshot at the pointer, so every node
+    // keeps its offset to the others
+    const originX = Math.min(...copiedNodes.value.map(node => node.position.x))
+    const originY = Math.min(...copiedNodes.value.map(node => node.position.y))
 
-    // Use already cloned data from handleCopy
-    const clonedData = JSON.parse(JSON.stringify(copiedNode.value.data))
+    const stamp = Date.now()
+    const idMap = new Map()
+    const pastedNodes = []
 
-    // The copy cannot reuse the original name: it would collapse both nodes into
-    // a single batch column
-    if (clonedData.label) {
-      clonedData.label = ensureUniqueLabel(clonedData.label, flowStore.nodes)
-    }
+    copiedNodes.value.forEach((snapshot, index) => {
+      const data = JSON.parse(JSON.stringify(snapshot.data))
 
-    // Create new node with same type and data
-    const newNode = createNode(
-      `node_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`,
-      copiedNode.value.type,
-      position,
-      clonedData,
-      ioConfig
-    )
+      // Labels name the batch columns, so a copy cannot reuse one. The pending
+      // nodes count too: they are not in the store yet
+      if (data.label) {
+        data.label = ensureUniqueLabel(data.label, [...flowStore.nodes, ...pastedNodes])
+      }
 
-    // Add to store
-    flowStore.nodes.push(newNode)
+      const newNode = createNode(
+        `node_${stamp}_${index}_${randomSuffix()}`,
+        snapshot.type,
+        {
+          x: pointer.x + (snapshot.position.x - originX),
+          y: pointer.y + (snapshot.position.y - originY)
+        },
+        data,
+        getNodeIOConfig(snapshot.type)
+      )
 
-    // Wait for VueFlow to process the new node before adding edges
+      // The paste leaves its result selected, ready to be dragged or pasted
+      // again. VueFlow keeps this flag when the node enters the graph
+      newNode.selected = true
+
+      idMap.set(snapshot.id, newNode.id)
+      pastedNodes.push(newNode)
+    })
+
+    // Only the fresh copy stays selected
+    flowStore.nodes.forEach(node => {
+      if (node.selected) node.selected = false
+    })
+
+    flowStore.nodes.push(...pastedNodes)
+
+    // Wait for VueFlow to process the new nodes before adding edges
     await nextTick()
 
-    // Recreate input edges pointing to the new node
-    const inputEdges = copiedNode.value._inputEdges || []
-    const newEdges = inputEdges
-      .filter(edgeTemplate => flowStore.nodes.some(n => n.id === edgeTemplate.source))
-      .map((edgeTemplate, index) => ({
-        id: `edge_${Date.now()}_${index}_${Math.random().toString(36).substr(2, 5)}`,
-        source: edgeTemplate.source,
-        target: newNode.id,
-        sourceHandle: edgeTemplate.sourceHandle,
-        targetHandle: edgeTemplate.targetHandle
+    const newEdges = copiedEdges.value
+      // An edge coming from outside the selection keeps its original source,
+      // unless that node is gone by now
+      .filter(template =>
+        idMap.has(template.source) || flowStore.nodes.some(node => node.id === template.source)
+      )
+      .map((template, index) => ({
+        id: `edge_${stamp}_${index}_${randomSuffix()}`,
+        source: idMap.get(template.source) || template.source,
+        target: idMap.get(template.target),
+        sourceHandle: template.sourceHandle,
+        targetHandle: template.targetHandle
       }))
 
     if (newEdges.length > 0) {
       addEdges(newEdges)
     }
 
-    console.log('Node pasted:', newNode.type, 'with data:', clonedData)
+    console.log(`Pasted ${pastedNodes.length} node(s), ${newEdges.length} edge(s)`)
   }
 
   return {
-    copiedNode,
+    copiedNodes,
     handleCopy,
     handlePaste
   }

--- a/src/composables/useKeyboardShortcuts.js
+++ b/src/composables/useKeyboardShortcuts.js
@@ -1,11 +1,12 @@
 /**
  * Composable for Keyboard Shortcuts
  * Handles global keyboard shortcuts (Ctrl+C, Ctrl+V, Ctrl+G)
+ * Copy and paste act on the whole selection, see useCopyPaste
  */
 
 import { onMounted, onUnmounted } from 'vue'
 
-export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowStore }) {
+export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowStore }) {
   /**
    * Handle keyboard shortcuts
    */
@@ -19,21 +20,19 @@ export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, cop
     // Check for Ctrl+C or Cmd+C (Mac)
     if ((event.ctrlKey || event.metaKey) && event.key === 'c') {
       if (!isEditableField) {
-        const selectedNode = flowStore.nodes.find(n => n.selected)
-        if (selectedNode) {
+        // With nothing selected let the native text copy through: handleCopy
+        // flushes the clipboard so a later Ctrl+V does not paste a stale copy
+        if (flowStore.nodes.some(n => n.selected)) {
           event.preventDefault()
-          handleCopy()
-        } else {
-          // No node selected - flush copied node so it doesn't interfere with text paste
-          copiedNode.value = null
         }
+        handleCopy()
       }
     }
 
     // Check for Ctrl+V or Cmd+V (Mac)
     if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
-      // Only paste node if not in editable field and we have a copied node
-      if (!isEditableField && copiedNode.value) {
+      // Only paste nodes if not in editable field and the clipboard has some
+      if (!isEditableField && copiedNodes.value.length > 0) {
         event.preventDefault()
         handlePaste()
       }

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -191,7 +191,7 @@ function toggleNodesMenu() {
   }
 }
 const { isLocked, handleLockToggle, handleFitView } = useViewportControls(fitView)
-const { copiedNode, handleCopy, handlePaste } = useCopyPaste(flowStore, viewport, mousePosition, { addEdges })
+const { copiedNodes, handleCopy, handlePaste } = useCopyPaste(flowStore, viewport, mousePosition, { addEdges })
 const { createNodeAtPosition } = useNodeCreation(flowStore)
 const {
   menuPosition,
@@ -252,7 +252,7 @@ function onRenameConfirm(label) {
 }
 
 // Setup keyboard shortcuts
-useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNode, flowStore })
+useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowStore })
 
 // Register connection handler - use addEdges directly
 onConnect((params) => {


### PR DESCRIPTION
## What

`Ctrl+C` used to keep only **one** node: `handleCopy` looked the selection up with `find`, so with several nodes selected it kept whichever came first in the array. It now snapshots **every** selected node, and `Ctrl+V` pastes the batch anchored at the pointer, so the **relative layout survives**.

## Connections

- **Between copied nodes** — rewired to the clones through an old-id → new-id `Map`, so the pasted subgraph is wired to itself.
- **External inputs** (source outside the selection) — kept on the original source, filtering out any that no longer exists.
- **Outgoing edges** — still not copied, on purpose. Consumers merge *every* incoming edge (`ImageGeneratorNode.vue:233`), so cloning an output would silently make a node the user never copied read from two sources. Copying has to be inert on the existing graph.

## Other decisions

- **Group containers are skipped**: their size lives in `style`, which `createNode` drops, so the clone would be an invisible empty box. Children *are* copied, but land as top-level nodes at their absolute position — `onNodeDragStop` re-adopts them as soon as they are dragged into a group.
- **The clones stay selected** and the originals get unselected, so the batch can be dragged as one or pasted again right away.

## Notes on the implementation

- The snapshot is now built field by field instead of `{...selectedNode}`, which was copying the VueFlow `GraphNode` internals (`dimensions`, `handleBounds`, `computedPosition`) into the reactive ref — now multiplied by N.
- Unique labels use an accumulator `[...flowStore.nodes, ...pastedNodes]`: `ensureUniqueLabel` builds its taken-label set at call time, and VueFlow replaces the store array on sync, so the batch is published with a single `push`.
- IDs are `stamp + index + random suffix`. The index gives intra-batch uniqueness; the random part avoids clashing with the bare `node_${Date.now()}` used elsewhere.
- Selection is set by mutating `selected` rather than `addSelectedNodes()`: during `Ctrl+V` the Control key is held, `multiSelectionActive` is `true`, and that API would only *add*, leaving the originals selected.

## Testing

- New `e2e/copy-paste.spec.js` — 10 cases: single node, every selected node, relative layout, internal edges rewired, external inputs kept, no duplicated outputs, clones selected, chained paste, empty selection, group containers skipped.
- `npx playwright test` → **54/54 green**, including the keyboard-safety regression test in `node-rename.spec.js`.
- `npm run build` → OK.

## Known cosmetic limitation

Mutating `selected` by hand does not update VueFlow's `nodesSelectionActive`, so the multi-selection rectangle does not show up until the user interacts. The nodes are visibly highlighted and block dragging works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)