### PR TITLE
fix: hide the node toolbar when several nodes are selected

### DIFF
--- a/docs/CREATING-NODES.md
+++ b/docs/CREATING-NODES.md
@@ -161,8 +161,8 @@ For nodes with dynamic configuration:
 ```vue
 <template>
   <div>
-    <!-- Node Toolbar -->
-    <NodeToolbar :is-visible="selected" :position="Position.Top" :offset="10">
+    <!-- Node Toolbar: hides itself unless this node is the only one selected -->
+    <NodeToolbar :position="Position.Top" :offset="10">
       <div class="node-toolbar-content">
         <div class="toolbar-control">
           <label>Option:</label>
@@ -191,6 +191,10 @@ function onOptionChange(event) {
 }
 </script>
 ```
+
+Leave `is-visible` unset: without it `NodeToolbar` shows only when its node is the
+single selected node, so multi-selections do not pile up overlapping toolbars.
+Passing `:is-visible="selected"` would bring them all back.
 
 ---
 

--- a/e2e/node-toolbar.spec.js
+++ b/e2e/node-toolbar.spec.js
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+} from './helpers/canvas.js'
+
+// VueFlow picks the multi-selection key per platform, and on macOS Chromium a
+// Control+click would be delivered as a right click anyway
+const MULTI_SELECT_KEY = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+/**
+ * Plain click on the first node, modifier+click on the rest. Clicking the
+ * header keeps the pointer away from the textareas inside the node body.
+ */
+async function selectNodes(page, nodeLocators) {
+  for (const [index, node] of nodeLocators.entries()) {
+    await node.locator('.node-header').click(index === 0 ? {} : { modifiers: [MULTI_SELECT_KEY] })
+  }
+  await page.waitForTimeout(100)
+}
+
+test.describe('Node toolbar visibility', () => {
+  test('shows the toolbar for a single selected node', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Image Generator')
+    await positionNodes(page, [{ type: 'image-generator', x: 200, y: 160 }])
+
+    await selectNodes(page, [page.locator('.vue-flow__node-image-generator')])
+
+    await expect(page.locator('.vue-flow__node-toolbar')).toHaveCount(1)
+  })
+
+  test('hides every toolbar while several nodes are selected', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Image Generator')
+    await addNodeFromSidebar(page, 'Text Generator')
+    // Selecting a node elevates it, so leave room or its box swallows the
+    // clicks meant for the next header
+    await positionNodes(page, [
+      { type: 'image-generator', x: 100, y: 120 },
+      { type: 'text-generator', x: 620, y: 120 },
+    ])
+
+    await selectNodes(page, [
+      page.locator('.vue-flow__node-image-generator'),
+      page.locator('.vue-flow__node-text-generator'),
+    ])
+
+    await expect(page.locator('.vue-flow__node-toolbar')).toHaveCount(0)
+  })
+
+  test('brings the toolbar back when the selection shrinks to one node', async ({ page }) => {
+    await setupBlankCanvas(page, { showNodeHeaders: true })
+    await addNodeFromSidebar(page, 'Image Generator')
+    await addNodeFromSidebar(page, 'Text Generator')
+    await positionNodes(page, [
+      { type: 'image-generator', x: 100, y: 120 },
+      { type: 'text-generator', x: 620, y: 120 },
+    ])
+
+    const imageGenerator = page.locator('.vue-flow__node-image-generator')
+    await selectNodes(page, [
+      imageGenerator,
+      page.locator('.vue-flow__node-text-generator'),
+    ])
+    await expect(page.locator('.vue-flow__node-toolbar')).toHaveCount(0)
+
+    // Clicking an already selected node keeps the multi-selection, so the
+    // selection is cleared on the pane before picking a single node again
+    await page.locator('.vue-flow__pane').click({ position: { x: 950, y: 600 } })
+    await selectNodes(page, [imageGenerator])
+
+    await expect(page.locator('.vue-flow__node-toolbar')).toHaveCount(1)
+  })
+})

--- a/src/components/nodes/ImageGeneratorNode.vue
+++ b/src/components/nodes/ImageGeneratorNode.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <!-- Node Toolbar -->
-    <NodeToolbar :is-visible="selected" :position="Position.Top" :offset="10">
+    <!-- Node Toolbar: hides itself unless this node is the only one selected -->
+    <NodeToolbar :position="Position.Top" :offset="10">
     <div class="node-toolbar-content">
       <!-- Model Selector -->
       <div class="toolbar-control">

--- a/src/components/nodes/TextGeneratorNode.vue
+++ b/src/components/nodes/TextGeneratorNode.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <!-- Node Toolbar -->
-    <NodeToolbar :is-visible="selected" :position="Position.Top" :offset="10">
+    <!-- Node Toolbar: hides itself unless this node is the only one selected -->
+    <NodeToolbar :position="Position.Top" :offset="10">
       <div class="node-toolbar-content">
         <!-- Model Selector -->
         <div class="toolbar-control">

--- a/src/components/nodes/VideoGeneratorNode.vue
+++ b/src/components/nodes/VideoGeneratorNode.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <!-- Node Toolbar -->
-    <NodeToolbar :is-visible="selected" :position="Position.Top" :offset="10">
+    <!-- Node Toolbar: hides itself unless this node is the only one selected -->
+    <NodeToolbar :position="Position.Top" :offset="10">
       <div class="node-toolbar-content">
         <!-- Model Selector -->
         <div class="toolbar-control">


### PR DESCRIPTION
# What

Selecting several nodes at once no longer covers the canvas with toolbars. Until now, every generator node in a multi-selection popped up its own configuration bar (model selector, parameters), which overlapped the nodes and got in the way of moving, copying or grouping the selection.

Now the bar only appears when a single node is selected, which is the only case where editing its parameters makes sense.

# Why

`NodeToolbar` from `@vue-flow/node-toolbar` already implements this rule by default: it renders only when its node is the one and only selected node. `ImageGeneratorNode`, `TextGeneratorNode` and `VideoGeneratorNode` were overriding it by passing `:is-visible="selected"`, which is true for every node of a multi-selection.

The fix is to drop the prop and let the library decide, instead of reimplementing the rule ourselves. `docs/CREATING-NODES.md` was updated so the "Node with Toolbar" pattern no longer teaches the prop that caused it.

The selection highlight in `BaseNode` is untouched: selected nodes still show their border, so the multi-selection stays visible.

# Tests

e2e tests and local.

New spec `e2e/node-toolbar.spec.js` with three cases, plus the existing `generator-models.spec.js` and `video-node.spec.js` suites (which drive the toolbar) re-run to check nothing regressed.

## How to test

- [ ] `npm run dev` and open a blank canvas
- [ ] Add an **Image Generator** node, click it: the toolbar shows up above it
- [ ] Add a **Text Generator** node, click the first one and Cmd/Ctrl+click the second: no toolbar is shown for either
- [ ] Click on the empty canvas and then click a single node again: the toolbar comes back
- [ ] Repeat with the **Video Generator** node
- [ ] Automated: `npx playwright test e2e/node-toolbar.spec.js e2e/generator-models.spec.js e2e/video-node.spec.js`

Note: on macOS the multi-selection key is Cmd, not Ctrl.
