### PR TITLE
feat: arrange the canvas by dependency with an auto layout button

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -377,7 +377,10 @@ topology.
 
 Groups are collapsed into single items. The content of each group is arranged first,
 because the resulting box is the slot the outer layout has to reserve for it, padding
-and minimum size included. Edges are redrawn between the blocks that actually get
+and minimum size included. Whether that content is arranged at all is up to the
+**Arrange the content of groups** setting: with it off, which is the default, a group
+keeps its size and its children keep their positions relative to it, and only the box
+itself is moved. Edges are redrawn between the blocks that actually get
 placed, so an edge in or out of a group becomes an edge of the group itself. That
 collapsing can turn an acyclic flow into a cyclic one (a node outside a group sitting
 between two of its children), and nothing in the app forbids a real cycle either, so a
@@ -484,13 +487,19 @@ The settings store (`useSettingsStore`) maintains app configuration:
 
 ```javascript
 {
-  showNodeHeaders: ref(false),  // Show/hide node headers
+  showNodeHeaders: ref(false),           // Show/hide node headers
+  skipSaveDialog: ref(false),            // Export with the default filename
+  autoLayoutGroupContents: ref(false),   // Let the auto layout rearrange groups inside
 
   // Actions
   toggleNodeHeaders(),
-  setNodeHeaders(value)
+  setNodeHeaders(value),
+  setSkipSaveDialog(value),
+  setAutoLayoutGroupContents(value)
 }
 ```
+Everything here is persisted to `localStorage` under `flora-settings`, API keys
+included.
 
 ### Why so simple?
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,7 +144,7 @@ useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, can
 - Viewport controls (lock, fit view)
 - Copy/paste the selection, keeping its layout and input connections (Ctrl+C, Ctrl+V)
 - Group nodes (Ctrl+G)
-- Auto layout: arrange every node by dependency, undoable with Ctrl+Z
+- Auto layout: arrange every node by dependency, undoable with Ctrl+Z (beta, off by default)
 - Settings modal
 - Automatic group management
 
@@ -367,6 +367,9 @@ export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
   return { canUndoLayout, handleAutoLayout, undoAutoLayout }
 }
 ```
+The feature is in beta: the button only shows up once **Settings → Beta → Auto Layout**
+is enabled, which is what `FloatingMenu` reads through its `showAutoLayout` prop.
+
 The arrangement itself lives in `src/lib/auto-layout.js`, which is pure and takes no
 Vue dependency. Columns come from the `levels` of `topologicalSort()`: that layering
 already places a node right after its last dependency, which is exactly its column in a
@@ -489,12 +492,14 @@ The settings store (`useSettingsStore`) maintains app configuration:
 {
   showNodeHeaders: ref(false),           // Show/hide node headers
   skipSaveDialog: ref(false),            // Export with the default filename
+  betaAutoLayout: ref(false),            // Show the Auto Layout button
   autoLayoutGroupContents: ref(false),   // Let the auto layout rearrange groups inside
 
   // Actions
   toggleNodeHeaders(),
   setNodeHeaders(value),
   setSkipSaveDialog(value),
+  setBetaAutoLayout(value),
   setAutoLayoutGroupContents(value)
 }
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,6 +44,7 @@ flora/
 │   │   ├── useNodeCreation.js        # Node creation helpers
 │   │   ├── useDragAndDrop.js         # Drag & drop logic
 │   │   ├── useGroupManagement.js     # Group/ungroup operations
+│   │   ├── useAutoLayout.js          # Arrange the canvas by dependency
 │   │   └── useKeyboardShortcuts.js   # Global keyboard shortcuts
 │   ├── views/
 │   │   └── FlowCanvasView.vue        # Main app canvas (~177 lines)
@@ -57,6 +58,7 @@ flora/
 │   │   ├── connection.js             # Connection validation
 │   │   ├── flow-io.js                # Flow export/import
 │   │   ├── group-membership.js       # Which nodes belong to a group
+│   │   ├── auto-layout.js            # Dependency based node arrangement
 │   │   ├── batch-io.js               # Batch input/output roles and IO
 │   │   ├── prompt-template.js        # Shared {{VARIABLE}} handling
 │   │   └── zip.js                    # ZIP writer for batch results
@@ -130,7 +132,8 @@ const { createNodeAtPosition } = useNodeCreation(flowStore)
 // Complex composables
 const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore)
 const { handleGroup } = useGroupManagement(flowStore, onNodeDragStop)
-useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowStore })
+const { handleAutoLayout, undoAutoLayout, canUndoLayout } = useAutoLayout(flowStore, { applyNodeChanges, fitView })
+useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, canUndoLayout, copiedNodes, flowStore })
 ```
 
 **Features:**
@@ -141,6 +144,7 @@ useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowSt
 - Viewport controls (lock, fit view)
 - Copy/paste the selection, keeping its layout and input connections (Ctrl+C, Ctrl+V)
 - Group nodes (Ctrl+G)
+- Auto layout: arrange every node by dependency, undoable with Ctrl+Z
 - Settings modal
 - Automatic group management
 
@@ -351,6 +355,45 @@ export function useNodeCreation(flowStore) {
   return { createNodeAtPosition }
 }
 ```
+
+**useAutoLayout.js** - Arrange the canvas by dependency
+```javascript
+export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
+  const snapshot = ref(null)  // positions and group sizes before the last layout
+
+  async function handleAutoLayout() { /* ... */ }
+  async function undoAutoLayout() { /* ... */ }
+
+  return { canUndoLayout, handleAutoLayout, undoAutoLayout }
+}
+```
+The arrangement itself lives in `src/lib/auto-layout.js`, which is pure and takes no
+Vue dependency. Columns come from the `levels` of `topologicalSort()`: that layering
+already places a node right after its last dependency, which is exactly its column in a
+left to right layout. Within a column the order is seeded with the Y the user is already
+looking at and then refined with barycenter sweeps over ranks, never pixels — node
+heights span 150 to 700px and a pixel barycenter swings with them instead of with the
+topology.
+
+Groups are collapsed into single items. The content of each group is arranged first,
+because the resulting box is the slot the outer layout has to reserve for it, padding
+and minimum size included. Edges are redrawn between the blocks that actually get
+placed, so an edge in or out of a group becomes an edge of the group itself. That
+collapsing can turn an acyclic flow into a cyclic one (a node outside a group sitting
+between two of its children), and nothing in the app forbids a real cycle either, so a
+DFS drops the back edges before layering — for the layout only, the flow keeps them.
+
+Two invariants hold the result together. Every box the layout places is disjoint from
+the others, which is what keeps `syncGroupMembership()` from adopting a node that only
+looks like it belongs to a group. And the arrangement is idempotent: running it twice
+changes nothing, since the seed is the current Y and the result is anchored on the
+top-left corner the canvas already occupied.
+
+Comment nodes are annotations rather than part of the flow, so a loose one keeps its
+place; it is only nudged if a group happened to land on top of it. Comments inside a
+group are arranged with the rest of its content. Since the repo has no history and a
+layout discards every manual placement, the composable keeps a one step snapshot that
+`Ctrl+Z` restores.
 
 ### Complex Composables
 

--- a/e2e/auto-layout.spec.js
+++ b/e2e/auto-layout.spec.js
@@ -155,38 +155,67 @@ test.describe('Auto layout ordering', () => {
 })
 
 /**
- * Two prompt nodes wrapped in a group, plus a free Image feeding the first one.
+ * A Prompt and a Text Generator wrapped in a group, fed by a free Image sitting
+ * far to the right, so the layout has to pull the whole group across.
  * Grouping needs the headers visible: they are the only spot on a node that does
  * not focus a textarea.
  */
-async function setupGroupedFlow(page) {
-  await setupBlankCanvas(page, { showNodeHeaders: true })
+async function setupGroupedFlow(page, { autoLayoutGroupContents = false } = {}) {
+  await setupBlankCanvas(page, { showNodeHeaders: true, autoLayoutGroupContents })
   await addNodeFromSidebar(page, 'Prompt')
-  await addNodeFromSidebar(page, 'Prompt')
+  await addNodeFromSidebar(page, 'Text Generator')
   await addNodeFromSidebar(page, 'Image')
 
   await positionNodes(page, [
-    { type: 'prompt', nth: 0, x: 300, y: 200 },
-    { type: 'prompt', nth: 1, x: 300, y: 500 },
-    { type: 'image', x: 1200, y: 800 },
+    { type: 'prompt', x: 300, y: 200 },
+    { type: 'text-generator', x: 300, y: 560 },
+    { type: 'image', x: 1500, y: 900 },
   ])
 
-  const prompts = page.locator('.vue-flow__node-prompt')
-  await prompts.nth(0).locator('.node-header').click()
-  await prompts.nth(1).locator('.node-header').click({ modifiers: [MODIFIER] })
+  await page.locator('.vue-flow__node-prompt .node-header').click()
+  await page.locator('.vue-flow__node-text-generator .node-header').click({ modifiers: [MODIFIER] })
   await page.keyboard.press(`${MODIFIER}+g`)
   await page.waitForTimeout(300)
 
   await expect(page.locator('.vue-flow__node-group')).toHaveCount(1)
 
   await connectNodesProgrammatic(page, [
-    { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'prompt', targetHandle: 'input-0', sourceNth: 0, targetNth: 1 },
+    { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+    { sourceType: 'image', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-0' },
   ])
 }
 
 test.describe('Auto layout with groups', () => {
-  test('keeps the group around its content and sizes it to fit', async ({ page }) => {
+  test('moves the group but leaves its content alone by default', async ({ page }) => {
     await setupGroupedFlow(page)
+
+    const before = await readNodes(page)
+    const groupBefore = firstOfType(before, 'group')
+    const childrenBefore = before.filter(n => n.parentNode === groupBefore.id)
+    expect(childrenBefore).toHaveLength(2)
+
+    await autoLayout(page)
+
+    const after = await readNodes(page)
+    const groupAfter = firstOfType(after, 'group')
+
+    // The box travels with the flow...
+    expect([groupAfter.x, groupAfter.y]).not.toEqual([groupBefore.x, groupBefore.y])
+
+    // ...carrying its content untouched, at the very same size
+    expect(groupAfter.width).toBe(groupBefore.width)
+    expect(groupAfter.height).toBe(groupBefore.height)
+
+    for (const child of childrenBefore) {
+      const moved = after.find(n => n.id === child.id)
+      expect(moved.parentNode).toBe(groupAfter.id)
+      expect(moved.relativeX).toBe(child.relativeX)
+      expect(moved.relativeY).toBe(child.relativeY)
+    }
+  })
+
+  test('arranges the content and resizes the group when the setting is on', async ({ page }) => {
+    await setupGroupedFlow(page, { autoLayoutGroupContents: true })
     await autoLayout(page)
 
     const nodes = await readNodes(page)

--- a/e2e/auto-layout.spec.js
+++ b/e2e/auto-layout.spec.js
@@ -41,15 +41,33 @@ async function readNodes(page) {
 const ofType = (nodes, type) => nodes.filter(n => n.type === type)
 const firstOfType = (nodes, type) => ofType(nodes, type)[0]
 
+const AUTO_LAYOUT_BUTTON = 'button[title="Auto Layout (beta)"]'
+
+/** The feature is in beta, so every spec has to opt into it */
+const setupCanvas = (page, options = {}) =>
+  setupBlankCanvas(page, { ...options, betaAutoLayout: true })
+
 async function autoLayout(page) {
-  await page.locator('button[title="Auto Layout"]').click()
+  await page.locator(AUTO_LAYOUT_BUTTON).click()
   // the button ends with a fitView animation of 300ms
   await page.waitForTimeout(700)
 }
 
+test.describe('Auto layout beta flag', () => {
+  test('hides the button until the beta is enabled', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await expect(page.locator(AUTO_LAYOUT_BUTTON)).toHaveCount(0)
+  })
+
+  test('shows the button once the beta is enabled', async ({ page }) => {
+    await setupCanvas(page)
+    await expect(page.locator(AUTO_LAYOUT_BUTTON)).toBeVisible()
+  })
+})
+
 test.describe('Auto layout ordering', () => {
   test('lines up a chain left to right, whatever order it was placed in', async ({ page }) => {
-    await setupBlankCanvas(page)
+    await setupCanvas(page)
     await addNodeFromSidebar(page, 'Prompt')
     await addNodeFromSidebar(page, 'Text Generator')
     await addNodeFromSidebar(page, 'Image Generator')
@@ -77,7 +95,7 @@ test.describe('Auto layout ordering', () => {
   })
 
   test('puts two sources in the same column, ahead of what they feed', async ({ page }) => {
-    await setupBlankCanvas(page)
+    await setupCanvas(page)
     await addNodeFromSidebar(page, 'Image')
     await addNodeFromSidebar(page, 'Prompt')
     await addNodeFromSidebar(page, 'Image Generator')
@@ -107,7 +125,7 @@ test.describe('Auto layout ordering', () => {
   })
 
   test('running it twice changes nothing', async ({ page }) => {
-    await setupBlankCanvas(page)
+    await setupCanvas(page)
     await addNodeFromSidebar(page, 'Prompt')
     await addNodeFromSidebar(page, 'Text Generator')
     await addNodeFromSidebar(page, 'Image Generator')
@@ -132,7 +150,7 @@ test.describe('Auto layout ordering', () => {
   })
 
   test('leaves a loose comment where the user put it', async ({ page }) => {
-    await setupBlankCanvas(page)
+    await setupCanvas(page)
     await addNodeFromSidebar(page, 'Prompt')
     await addNodeFromSidebar(page, 'Text Generator')
     await addNodeFromSidebar(page, 'Comment')
@@ -161,7 +179,7 @@ test.describe('Auto layout ordering', () => {
  * not focus a textarea.
  */
 async function setupGroupedFlow(page, { autoLayoutGroupContents = false } = {}) {
-  await setupBlankCanvas(page, { showNodeHeaders: true, autoLayoutGroupContents })
+  await setupCanvas(page, { showNodeHeaders: true, autoLayoutGroupContents })
   await addNodeFromSidebar(page, 'Prompt')
   await addNodeFromSidebar(page, 'Text Generator')
   await addNodeFromSidebar(page, 'Image')
@@ -286,7 +304,7 @@ test.describe('Auto layout with groups', () => {
 
 test.describe('Auto layout undo', () => {
   test('Ctrl+Z puts every node back where it was', async ({ page }) => {
-    await setupBlankCanvas(page)
+    await setupCanvas(page)
     await addNodeFromSidebar(page, 'Prompt')
     await addNodeFromSidebar(page, 'Text Generator')
     await addNodeFromSidebar(page, 'Image Generator')

--- a/e2e/auto-layout.spec.js
+++ b/e2e/auto-layout.spec.js
@@ -1,0 +1,287 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+  connectNodesProgrammatic,
+} from './helpers/canvas.js'
+
+// VueFlow picks the multi-selection key per platform, and the same modifier is
+// the undo key
+const MODIFIER = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+/**
+ * Every node with its size and its absolute position: children of a group store
+ * a position relative to it, and groups cannot nest, so one hop is enough.
+ */
+async function readNodes(page) {
+  return page.evaluate(() => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    const byId = new Map(flowStore.nodes.map(n => [n.id, n]))
+
+    return flowStore.nodes.map(n => {
+      const parent = n.parentNode ? byId.get(n.parentNode) : null
+
+      return {
+        id: n.id,
+        type: n.type,
+        parentNode: n.parentNode || null,
+        x: parent ? parent.position.x + n.position.x : n.position.x,
+        y: parent ? parent.position.y + n.position.y : n.position.y,
+        relativeX: n.position.x,
+        relativeY: n.position.y,
+        width: n.dimensions?.width || parseInt(n.style?.width) || 0,
+        height: n.dimensions?.height || parseInt(n.style?.height) || 0,
+      }
+    })
+  })
+}
+
+const ofType = (nodes, type) => nodes.filter(n => n.type === type)
+const firstOfType = (nodes, type) => ofType(nodes, type)[0]
+
+async function autoLayout(page) {
+  await page.locator('button[title="Auto Layout"]').click()
+  // the button ends with a fitView animation of 300ms
+  await page.waitForTimeout(700)
+}
+
+test.describe('Auto layout ordering', () => {
+  test('lines up a chain left to right, whatever order it was placed in', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Text Generator')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    // Deliberately backwards: the last node of the chain sits furthest left
+    await positionNodes(page, [
+      { type: 'image-generator', x: 100, y: 500 },
+      { type: 'text-generator', x: 700, y: 100 },
+      { type: 'prompt', x: 1300, y: 900 },
+    ])
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+      { sourceType: 'text-generator', sourceHandle: 'output-0', targetType: 'image-generator', targetHandle: 'input-1' },
+    ])
+
+    await autoLayout(page)
+
+    const nodes = await readNodes(page)
+    const prompt = firstOfType(nodes, 'prompt')
+    const text = firstOfType(nodes, 'text-generator')
+    const image = firstOfType(nodes, 'image-generator')
+
+    expect(prompt.x + prompt.width).toBeLessThanOrEqual(text.x)
+    expect(text.x + text.width).toBeLessThanOrEqual(image.x)
+  })
+
+  test('puts two sources in the same column, ahead of what they feed', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    await positionNodes(page, [
+      { type: 'image', x: 900, y: 100 },
+      { type: 'prompt', x: 200, y: 700 },
+      { type: 'image-generator', x: 500, y: 200 },
+    ])
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'image', sourceHandle: 'output-0', targetType: 'image-generator', targetHandle: 'input-0' },
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'image-generator', targetHandle: 'input-1' },
+    ])
+
+    await autoLayout(page)
+
+    const nodes = await readNodes(page)
+    const image = firstOfType(nodes, 'image')
+    const prompt = firstOfType(nodes, 'prompt')
+    const generator = firstOfType(nodes, 'image-generator')
+
+    // Both sources have no dependency, so they share the first column
+    expect(image.x).toBe(prompt.x)
+    expect(generator.x).toBeGreaterThan(image.x)
+    // ...and they do not sit on top of each other
+    expect(Math.abs(image.y - prompt.y)).toBeGreaterThan(0)
+  })
+
+  test('running it twice changes nothing', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Text Generator')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 800, y: 60 },
+      { type: 'text-generator', x: 120, y: 640 },
+      { type: 'image-generator', x: 1400, y: 260 },
+    ])
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+      { sourceType: 'text-generator', sourceHandle: 'output-0', targetType: 'image-generator', targetHandle: 'input-1' },
+    ])
+
+    await autoLayout(page)
+    const first = await readNodes(page)
+
+    await autoLayout(page)
+    const second = await readNodes(page)
+
+    expect(second.map(n => [n.id, n.x, n.y])).toEqual(first.map(n => [n.id, n.x, n.y]))
+  })
+
+  test('leaves a loose comment where the user put it', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Text Generator')
+    await addNodeFromSidebar(page, 'Comment')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 600, y: 100 },
+      { type: 'text-generator', x: 200, y: 100 },
+      { type: 'comment', x: 300, y: 1400 },
+    ])
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+    ])
+
+    await autoLayout(page)
+
+    const comment = firstOfType(await readNodes(page), 'comment')
+    expect(comment.x).toBe(300)
+    expect(comment.y).toBe(1400)
+  })
+})
+
+/**
+ * Two prompt nodes wrapped in a group, plus a free Image feeding the first one.
+ * Grouping needs the headers visible: they are the only spot on a node that does
+ * not focus a textarea.
+ */
+async function setupGroupedFlow(page) {
+  await setupBlankCanvas(page, { showNodeHeaders: true })
+  await addNodeFromSidebar(page, 'Prompt')
+  await addNodeFromSidebar(page, 'Prompt')
+  await addNodeFromSidebar(page, 'Image')
+
+  await positionNodes(page, [
+    { type: 'prompt', nth: 0, x: 300, y: 200 },
+    { type: 'prompt', nth: 1, x: 300, y: 500 },
+    { type: 'image', x: 1200, y: 800 },
+  ])
+
+  const prompts = page.locator('.vue-flow__node-prompt')
+  await prompts.nth(0).locator('.node-header').click()
+  await prompts.nth(1).locator('.node-header').click({ modifiers: [MODIFIER] })
+  await page.keyboard.press(`${MODIFIER}+g`)
+  await page.waitForTimeout(300)
+
+  await expect(page.locator('.vue-flow__node-group')).toHaveCount(1)
+
+  await connectNodesProgrammatic(page, [
+    { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'prompt', targetHandle: 'input-0', sourceNth: 0, targetNth: 1 },
+  ])
+}
+
+test.describe('Auto layout with groups', () => {
+  test('keeps the group around its content and sizes it to fit', async ({ page }) => {
+    await setupGroupedFlow(page)
+    await autoLayout(page)
+
+    const nodes = await readNodes(page)
+    const group = firstOfType(nodes, 'group')
+    const children = nodes.filter(n => n.parentNode === group.id)
+
+    expect(children).toHaveLength(2)
+
+    // Children are inset by the group padding, in coordinates relative to it
+    for (const child of children) {
+      expect(child.relativeX).toBeGreaterThanOrEqual(40)
+      expect(child.relativeY).toBeGreaterThanOrEqual(40)
+      expect(child.relativeX + child.width).toBeLessThanOrEqual(group.width - 40)
+      expect(child.relativeY + child.height).toBeLessThanOrEqual(group.height - 40)
+    }
+
+    // The box is the content plus one padding on each side, not a pixel more
+    const right = Math.max(...children.map(c => c.relativeX + c.width))
+    const bottom = Math.max(...children.map(c => c.relativeY + c.height))
+    expect(group.width).toBe(right + 40)
+    expect(group.height).toBe(bottom + 40)
+  })
+
+  test('never leaves a free node inside a group', async ({ page }) => {
+    await setupGroupedFlow(page)
+    await autoLayout(page)
+
+    const nodes = await readNodes(page)
+    const groups = ofType(nodes, 'group')
+    expect(groups.length).toBeGreaterThan(0)
+
+    for (const node of nodes) {
+      if (node.parentNode || node.type === 'group') continue
+
+      const centerX = node.x + node.width / 2
+      const centerY = node.y + node.height / 2
+
+      for (const group of groups) {
+        const inside =
+          centerX >= group.x && centerX <= group.x + group.width &&
+          centerY >= group.y && centerY <= group.y + group.height
+
+        expect(inside, `${node.id} ended up inside ${group.id}`).toBe(false)
+      }
+    }
+  })
+
+  test('a free node dragged after the layout is not adopted by a group', async ({ page }) => {
+    await setupGroupedFlow(page)
+    await autoLayout(page)
+
+    const before = firstOfType(await readNodes(page), 'image')
+    expect(before.parentNode).toBeNull()
+
+    // Nudging a node is what triggers the membership check on drag stop
+    const header = page.locator('.vue-flow__node-image .node-header')
+    const box = await header.boundingBox()
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width / 2 + 15, box.y + box.height / 2 + 15, { steps: 5 })
+    await page.mouse.up()
+    await page.waitForTimeout(300)
+
+    const after = firstOfType(await readNodes(page), 'image')
+    expect(after.parentNode).toBeNull()
+  })
+})
+
+test.describe('Auto layout undo', () => {
+  test('Ctrl+Z puts every node back where it was', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Text Generator')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 940, y: 120 },
+      { type: 'text-generator', x: 260, y: 620 },
+      { type: 'image-generator', x: 1500, y: 320 },
+    ])
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+      { sourceType: 'text-generator', sourceHandle: 'output-0', targetType: 'image-generator', targetHandle: 'input-1' },
+    ])
+
+    const before = await readNodes(page)
+
+    await autoLayout(page)
+    const laidOut = await readNodes(page)
+    expect(laidOut.map(n => [n.x, n.y])).not.toEqual(before.map(n => [n.x, n.y]))
+
+    await page.keyboard.press(`${MODIFIER}+z`)
+    await page.waitForTimeout(700)
+
+    const restored = await readNodes(page)
+    expect(restored.map(n => [n.id, n.x, n.y])).toEqual(before.map(n => [n.id, n.x, n.y]))
+  })
+})

--- a/e2e/helpers/canvas.js
+++ b/e2e/helpers/canvas.js
@@ -9,17 +9,24 @@ export const TEST_IMAGE_PATH = path.resolve(import.meta.dirname, '../assets/back
  * @param {Object} [options]
  * @param {boolean} [options.showNodeHeaders=false] - Node headers are off by
  *        default in the app, and the rename editor lives in them
+ * @param {boolean} [options.betaAutoLayout=false] - The Auto Layout button is a
+ *        beta feature, hidden until it is switched on in the settings
  * @param {boolean} [options.autoLayoutGroupContents=false] - Off by default in
  *        the app too: the auto layout only moves groups, it does not rearrange
  *        what is inside them
  */
-export async function setupBlankCanvas(page, { showNodeHeaders = false, autoLayoutGroupContents = false } = {}) {
+export async function setupBlankCanvas(page, {
+  showNodeHeaders = false,
+  betaAutoLayout = false,
+  autoLayoutGroupContents = false,
+} = {}) {
   await page.addInitScript((settings) => {
     localStorage.setItem('flora-settings', JSON.stringify(settings))
   }, {
     replicateApiKey: 'test-api-key-fake',
     openaiApiKey: 'test-openai-key-fake',
     showNodeHeaders,
+    betaAutoLayout,
     autoLayoutGroupContents,
   })
   await page.goto('/')

--- a/e2e/helpers/canvas.js
+++ b/e2e/helpers/canvas.js
@@ -9,14 +9,18 @@ export const TEST_IMAGE_PATH = path.resolve(import.meta.dirname, '../assets/back
  * @param {Object} [options]
  * @param {boolean} [options.showNodeHeaders=false] - Node headers are off by
  *        default in the app, and the rename editor lives in them
+ * @param {boolean} [options.autoLayoutGroupContents=false] - Off by default in
+ *        the app too: the auto layout only moves groups, it does not rearrange
+ *        what is inside them
  */
-export async function setupBlankCanvas(page, { showNodeHeaders = false } = {}) {
+export async function setupBlankCanvas(page, { showNodeHeaders = false, autoLayoutGroupContents = false } = {}) {
   await page.addInitScript((settings) => {
     localStorage.setItem('flora-settings', JSON.stringify(settings))
   }, {
     replicateApiKey: 'test-api-key-fake',
     openaiApiKey: 'test-openai-key-fake',
     showNodeHeaders,
+    autoLayoutGroupContents,
   })
   await page.goto('/')
   await page.getByText('Blank canvas').click()

--- a/src/assets/auto-layout.svg
+++ b/src/assets/auto-layout.svg
@@ -1,0 +1,9 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="8" width="7.5" height="9" rx="1.5" fill="#323544"/>
+<rect x="15.5" y="2" width="7.5" height="7.5" rx="1.5" fill="#323544"/>
+<rect x="15.5" y="15.5" width="7.5" height="7.5" rx="1.5" fill="#323544"/>
+<rect x="9.5" y="11.75" width="3.75" height="1.5" fill="#323544"/>
+<rect x="11.75" y="5" width="1.5" height="15" fill="#323544"/>
+<rect x="11.75" y="5" width="4.5" height="1.5" fill="#323544"/>
+<rect x="11.75" y="18.5" width="4.5" height="1.5" fill="#323544"/>
+</svg>

--- a/src/components/canvas/FloatingMenu.vue
+++ b/src/components/canvas/FloatingMenu.vue
@@ -52,12 +52,14 @@
     >
       <img :src="ReframeIcon" alt="Fit View" />
     </button>
-    <!-- Rearranging every node is a mass move, so the lock has to cover it too -->
+    <!-- Beta, so it only shows up once enabled in the settings. Rearranging
+         every node is a mass move, so the lock has to cover it too -->
     <button
+      v-if="showAutoLayout"
       class="menu-icon-button"
       :disabled="isLocked"
       @click="emit('auto-layout')"
-      title="Auto Layout"
+      title="Auto Layout (beta)"
     >
       <img :src="AutoLayoutIcon" alt="Auto Layout" />
     </button>
@@ -92,6 +94,10 @@ defineProps({
   isNodesMenuOpen: {
     type: Boolean,
     required: true
+  },
+  showAutoLayout: {
+    type: Boolean,
+    default: false
   }
 })
 

--- a/src/components/canvas/FloatingMenu.vue
+++ b/src/components/canvas/FloatingMenu.vue
@@ -52,6 +52,15 @@
     >
       <img :src="ReframeIcon" alt="Fit View" />
     </button>
+    <!-- Rearranging every node is a mass move, so the lock has to cover it too -->
+    <button
+      class="menu-icon-button"
+      :disabled="isLocked"
+      @click="emit('auto-layout')"
+      title="Auto Layout"
+    >
+      <img :src="AutoLayoutIcon" alt="Auto Layout" />
+    </button>
 
     <!-- Separator -->
     <div class="menu-separator"></div>
@@ -71,6 +80,7 @@
 import LockIcon from '@/assets/lock.svg'
 import UnlockIcon from '@/assets/unlock.svg'
 import ReframeIcon from '@/assets/reframe.svg'
+import AutoLayoutIcon from '@/assets/auto-layout.svg'
 import GearIcon from '@/assets/gear.svg'
 import BatchIcon from '@/assets/batch.svg'
 
@@ -92,6 +102,7 @@ const emit = defineEmits([
   'open-batch',
   'lock-toggle',
   'fit-view',
+  'auto-layout',
   'open-settings'
 ])
 </script>
@@ -148,6 +159,16 @@ const emit = defineEmits([
 
 .menu-icon-button:active {
   transform: scale(0.95);
+}
+
+.menu-icon-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.menu-icon-button:disabled:hover {
+  background: var(--flora-color-surface);
+  transform: none;
 }
 
 .menu-icon-button.active {

--- a/src/components/canvas/SettingsModal.vue
+++ b/src/components/canvas/SettingsModal.vue
@@ -37,6 +37,22 @@
         </div>
       </div>
 
+      <!-- Auto Layout Section -->
+      <div class="settings-section">
+        <h3 class="settings-section-title">Auto Layout</h3>
+        <div class="settings-option">
+          <BaseCheckbox
+            id="auto-layout-group-contents"
+            v-model="settingsStore.autoLayoutGroupContents"
+            label="Arrange the content of groups"
+          />
+          <p class="settings-option-description">
+            Rearrange the nodes inside each group too, and resize the group to fit them.
+            Off by default: only the group as a whole is moved
+          </p>
+        </div>
+      </div>
+
       <!-- API Keys Section -->
       <div class="settings-section">
         <h3 class="settings-section-title">API Keys</h3>

--- a/src/components/canvas/SettingsModal.vue
+++ b/src/components/canvas/SettingsModal.vue
@@ -37,8 +37,24 @@
         </div>
       </div>
 
-      <!-- Auto Layout Section -->
+      <!-- Beta Section -->
       <div class="settings-section">
+        <h3 class="settings-section-title">Beta</h3>
+        <div class="settings-option">
+          <BaseCheckbox
+            id="beta-auto-layout"
+            v-model="settingsStore.betaAutoLayout"
+            label="Auto Layout"
+          />
+          <p class="settings-option-description">
+            Show the Auto Layout button, which rearranges every node by dependency.
+            Still in beta, so it is hidden until you turn it on
+          </p>
+        </div>
+      </div>
+
+      <!-- Auto Layout Section, only worth showing once the beta is on -->
+      <div v-if="settingsStore.betaAutoLayout" class="settings-section">
         <h3 class="settings-section-title">Auto Layout</h3>
         <div class="settings-option">
           <BaseCheckbox

--- a/src/composables/useAutoLayout.js
+++ b/src/composables/useAutoLayout.js
@@ -8,8 +8,11 @@ import { computed, nextTick, ref } from 'vue'
 import { computeAutoLayout } from '@/lib/auto-layout'
 import { getGroupSize, isCenterInsideGroup } from '@/lib/group-membership'
 import { NODE_TYPES } from '@/lib/node-shapes'
+import { useSettingsStore } from '@/stores/settings'
 
 export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
+  const settingsStore = useSettingsStore()
+
   // Positions and group sizes as they were right before the last layout
   const snapshot = ref(null)
 
@@ -63,7 +66,9 @@ export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
       size: node.type === NODE_TYPES.GROUP ? getGroupSize(node) : null
     }))
 
-    const { positions, groupSizes } = computeAutoLayout(flowStore.nodes, flowStore.edges)
+    const { positions, groupSizes } = computeAutoLayout(flowStore.nodes, flowStore.edges, {
+      layoutGroupContents: settingsStore.autoLayoutGroupContents
+    })
     if (!positions.size) return
 
     resizeGroups(groupSizes)

--- a/src/composables/useAutoLayout.js
+++ b/src/composables/useAutoLayout.js
@@ -1,0 +1,117 @@
+/**
+ * Composable for Auto Layout
+ * Rearranges the canvas by dependency and offers a one step undo, since the
+ * repo has no history and a layout throws away every manual placement
+ */
+
+import { computed, nextTick, ref } from 'vue'
+import { computeAutoLayout } from '@/lib/auto-layout'
+import { getGroupSize, isCenterInsideGroup } from '@/lib/group-membership'
+import { NODE_TYPES } from '@/lib/node-shapes'
+
+export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
+  // Positions and group sizes as they were right before the last layout
+  const snapshot = ref(null)
+
+  const canUndoLayout = computed(() => snapshot.value !== null)
+
+  /**
+   * Group sizes live in `style` because that is what the JSON keeps. Writing
+   * them as a dimensions change updates `dimensions` and `style` at once, the
+   * same path NodeResizer takes.
+   */
+  function resizeGroups(sizes) {
+    const ids = new Set(flowStore.nodes.map(node => node.id))
+    const changes = [...sizes]
+      .filter(([id]) => ids.has(id))
+      .map(([id, dimensions]) => ({ id, type: 'dimensions', dimensions, updateStyle: true }))
+
+    if (changes.length) applyNodeChanges(changes)
+  }
+
+  /**
+   * A node whose center ends up inside a group would be adopted by
+   * `syncGroupMembership` on the next drag, and would silently start travelling
+   * with that group. The layout keeps every box apart, so this only fires on a
+   * regression.
+   */
+  function warnOnStrayNodes() {
+    const groups = flowStore.nodes.filter(node => node.type === NODE_TYPES.GROUP)
+    if (!groups.length) return
+
+    for (const node of flowStore.nodes) {
+      if (node.parentNode || node.type === NODE_TYPES.GROUP) continue
+
+      for (const group of groups) {
+        if (isCenterInsideGroup(node.position, node, group)) {
+          console.warn(`[AutoLayout] ${node.id} sits inside ${group.id} and will be adopted`)
+        }
+      }
+    }
+  }
+
+  async function handleAutoLayout() {
+    if (flowStore.nodes.length < 2) return
+
+    // Sizes are measured by a ResizeObserver, so let any pending render land
+    // before reading them
+    await nextTick()
+
+    const previous = flowStore.nodes.map(node => ({
+      id: node.id,
+      position: { ...node.position },
+      size: node.type === NODE_TYPES.GROUP ? getGroupSize(node) : null
+    }))
+
+    const { positions, groupSizes } = computeAutoLayout(flowStore.nodes, flowStore.edges)
+    if (!positions.size) return
+
+    resizeGroups(groupSizes)
+
+    for (const node of flowStore.nodes) {
+      const position = positions.get(node.id)
+      if (position) node.position = { x: position.x, y: position.y }
+
+      // A selection left over from before would turn the next drag into a mass
+      // move, which is the one thing that could undo the arrangement
+      if (node.selected) node.selected = false
+    }
+
+    snapshot.value = previous
+
+    if (import.meta.env.DEV) warnOnStrayNodes()
+
+    await nextTick()
+    fitView({ duration: 300, padding: 0.2 })
+  }
+
+  /**
+   * Put every node back where it was before the last layout. Nodes added or
+   * removed since then are skipped rather than resurrected.
+   */
+  async function undoAutoLayout() {
+    if (!snapshot.value) return
+
+    const previous = snapshot.value
+    snapshot.value = null
+
+    resizeGroups(new Map(
+      previous.filter(entry => entry.size).map(entry => [entry.id, entry.size])
+    ))
+
+    const byId = new Map(flowStore.nodes.map(node => [node.id, node]))
+    for (const entry of previous) {
+      const node = byId.get(entry.id)
+      if (node) node.position = { ...entry.position }
+    }
+
+    await nextTick()
+    fitView({ duration: 300, padding: 0.2 })
+  }
+
+  return {
+    canUndoLayout,
+    handleAutoLayout,
+    undoAutoLayout
+  }
+}

--- a/src/composables/useKeyboardShortcuts.js
+++ b/src/composables/useKeyboardShortcuts.js
@@ -1,12 +1,13 @@
 /**
  * Composable for Keyboard Shortcuts
- * Handles global keyboard shortcuts (Ctrl+C, Ctrl+V, Ctrl+G)
+ * Handles global keyboard shortcuts (Ctrl+C, Ctrl+V, Ctrl+G, Ctrl+Z)
  * Copy and paste act on the whole selection, see useCopyPaste
+ * Ctrl+Z only reverts an auto layout, see useAutoLayout
  */
 
 import { onMounted, onUnmounted } from 'vue'
 
-export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowStore }) {
+export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, canUndoLayout, copiedNodes, flowStore }) {
   /**
    * Handle keyboard shortcuts
    */
@@ -42,6 +43,16 @@ export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, cop
     if ((event.ctrlKey || event.metaKey) && event.key === 'g') {
       event.preventDefault()
       handleGroup()
+    }
+
+    // Check for Ctrl+Z or Cmd+Z (Mac) - Undo the last auto layout.
+    // Nothing else in the app is undoable, so with no layout to revert the key
+    // is left alone and the browser keeps its own undo
+    if ((event.ctrlKey || event.metaKey) && event.key === 'z') {
+      if (!isEditableField && canUndoLayout.value) {
+        event.preventDefault()
+        undoAutoLayout()
+      }
     }
   }
 

--- a/src/lib/auto-layout.js
+++ b/src/lib/auto-layout.js
@@ -1,0 +1,528 @@
+/**
+ * Auto layout
+ *
+ * Arranges the canvas by dependency: sources on the left, and every node to the
+ * right of whatever feeds it. Groups are laid out as blocks — their content is
+ * arranged first, and the resulting box takes part in the outer layout as a
+ * single item, so a group never overlaps anything around it.
+ *
+ * The layering comes from `topologicalSort`, which already assigns a node to the
+ * level right after its last dependency. That level is the column.
+ */
+
+import { topologicalSort } from './graph-utils'
+import { NODE_TYPES } from './node-shapes'
+import { getGroupSize, getNodeSize } from './group-membership'
+
+export const AUTO_LAYOUT_DEFAULTS = {
+  hGap: 140,           // below ~100px the bezier edges flatten against the handles
+  vGap: 60,
+  groupPadding: 40,    // same padding handleGroup uses, and it clears the group label
+  groupMinWidth: 200,  // the NodeResizer minimums of GroupNode
+  groupMinHeight: 150,
+  bandGap: 80,
+  bandMaxWidth: 1200,
+  sweeps: 4
+}
+
+const WHITE = 0
+const GRAY = 1
+const BLACK = 2
+
+/**
+ * Drop the edges the layout cannot use: the ones pointing outside the set, self
+ * edges, and duplicates.
+ *
+ * Deduplicating is not cosmetic. `buildDependencyGraph` keeps its adjacency in a
+ * Set but counts one in-degree per edge, so two parallel edges leave the target
+ * stuck above zero and `topologicalSort` silently drops it and everything
+ * downstream. The UI blocks duplicates, an imported JSON does not.
+ */
+function sanitizeEdges(ids, edges) {
+  const seen = new Set()
+  const clean = []
+
+  for (const edge of edges) {
+    if (!ids.has(edge.source) || !ids.has(edge.target)) continue
+    if (edge.source === edge.target) continue
+
+    const key = `${edge.source}|${edge.target}`
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    clean.push({ source: edge.source, target: edge.target })
+  }
+
+  return clean
+}
+
+/**
+ * Return the edges of a spanning DFS with the back edges removed, so the rest of
+ * the layout can assume a DAG.
+ *
+ * Nothing in the app forbids a cycle: `validateConnection` only blocks self and
+ * duplicate connections. Feeding a cycle to Kahn's algorithm loses the cycle
+ * *and* everything downstream of it, which would pile the whole canvas into one
+ * column. The dropped edges only disappear from the layout — the flow keeps
+ * them, and they end up drawn right to left.
+ */
+function breakCycles(items, edges) {
+  const successors = new Map(items.map(item => [item.id, []]))
+  const inDegree = new Map(items.map(item => [item.id, 0]))
+
+  for (const edge of edges) {
+    successors.get(edge.source).push(edge.target)
+    inDegree.set(edge.target, inDegree.get(edge.target) + 1)
+  }
+
+  // Walking from the sources first keeps forward edges from being mistaken for
+  // back edges just because the traversal started in the middle of a chain
+  const roots = items
+    .map((item, index) => ({ id: item.id, index }))
+    .sort((a, b) => {
+      const rootA = inDegree.get(a.id) === 0 ? 0 : 1
+      const rootB = inDegree.get(b.id) === 0 ? 0 : 1
+      return rootA - rootB || a.index - b.index
+    })
+
+  const color = new Map(items.map(item => [item.id, WHITE]))
+  const kept = []
+
+  for (const root of roots) {
+    if (color.get(root.id) !== WHITE) continue
+
+    // Iterative: a long enough chain would overflow a recursive DFS
+    color.set(root.id, GRAY)
+    const stack = [{ id: root.id, next: 0 }]
+
+    while (stack.length) {
+      const frame = stack[stack.length - 1]
+      const children = successors.get(frame.id)
+
+      if (frame.next >= children.length) {
+        color.set(frame.id, BLACK)
+        stack.pop()
+        continue
+      }
+
+      const child = children[frame.next++]
+
+      // A gray child means we looped back into the current path
+      if (color.get(child) === GRAY) continue
+
+      kept.push({ source: frame.id, target: child })
+
+      if (color.get(child) === WHITE) {
+        color.set(child, GRAY)
+        stack.push({ id: child, next: 0 })
+      }
+    }
+  }
+
+  return kept
+}
+
+function median(values) {
+  if (!values.length) return 0
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+
+  return sorted.length % 2
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+function boundsOf(items, positions) {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+
+  for (const item of items) {
+    const position = positions.get(item.id)
+    if (!position) continue
+
+    minX = Math.min(minX, position.x)
+    minY = Math.min(minY, position.y)
+    maxX = Math.max(maxX, position.x + item.width)
+    maxY = Math.max(maxY, position.y + item.height)
+  }
+
+  if (minX === Infinity) return null
+
+  return { minX, minY, maxX, maxY }
+}
+
+/**
+ * Lay out one graph left to right. Used for the whole canvas and, on its own,
+ * for the content of each group.
+ *
+ * @param {Array<{id: string, width: number, height: number, seedX: number, seedY: number}>} items
+ * @param {Array<{source: string, target: string}>} edges
+ * @returns {{ positions: Map<string, {x: number, y: number}>, width: number, height: number }}
+ *          positions are top-left corners, normalized so the bounding box starts at (0, 0)
+ */
+export function layoutSubgraph(items, edges, opts = {}) {
+  const options = { ...AUTO_LAYOUT_DEFAULTS, ...opts }
+  const positions = new Map()
+
+  if (!items.length) return { positions, width: 0, height: 0 }
+
+  const byId = new Map(items.map(item => [item.id, item]))
+  const order = new Map(items.map((item, index) => [item.id, index]))
+
+  const clean = sanitizeEdges(new Set(byId.keys()), edges)
+  const dag = breakCycles(items, clean)
+
+  const predecessors = new Map(items.map(item => [item.id, []]))
+  const successors = new Map(items.map(item => [item.id, []]))
+  for (const edge of dag) {
+    successors.get(edge.source).push(edge.target)
+    predecessors.get(edge.target).push(edge.source)
+  }
+
+  // Nodes nothing connects to (comments, leftovers) would inflate the first
+  // column and push the real graph aside, so they get their own band below
+  const connectedIds = new Set()
+  for (const edge of clean) {
+    connectedIds.add(edge.source)
+    connectedIds.add(edge.target)
+  }
+  const connected = items.filter(item => connectedIds.has(item.id))
+  const isolated = items.filter(item => !connectedIds.has(item.id))
+
+  const { levels } = topologicalSort(connected, dag)
+  const columns = levels.map(level => level.map(id => byId.get(id)))
+
+  // Safety net: with the cycles already broken nothing should be left over
+  const placed = new Set(columns.flat().map(item => item.id))
+  const missing = connected.filter(item => !placed.has(item.id))
+  if (missing.length) columns.push(missing)
+
+  // Seed the order with what the user is already looking at, so the arrangement
+  // stays recognizable and running the layout twice changes nothing
+  const bySeed = (a, b) => a.seedY - b.seedY || a.seedX - b.seedX || order.get(a.id) - order.get(b.id)
+  for (const column of columns) column.sort(bySeed)
+
+  const rank = new Map()
+  const reindex = () => {
+    for (const column of columns) {
+      column.forEach((item, index) => rank.set(item.id, index))
+    }
+  }
+  reindex()
+
+  // Barycenter sweeps. One forward pass would leave the first column in creation
+  // order, and that is where most of the crossings come from; the backward pass
+  // is what carries the consumers' order back to the sources.
+  for (let sweep = 0; sweep < options.sweeps; sweep++) {
+    const goingDown = sweep % 2 === 0
+    const indexes = columns.map((_, index) => index)
+    const range = goingDown ? indexes.slice(1) : indexes.slice(0, -1).reverse()
+    const neighbours = goingDown ? predecessors : successors
+
+    for (const index of range) {
+      const column = columns[index]
+      const keys = new Map()
+
+      for (const item of column) {
+        const related = neighbours.get(item.id)
+        // Ranks, never pixels: node heights span 150 to 700px and a pixel
+        // barycenter swings with them instead of with the topology
+        keys.set(item.id, related.length
+          ? related.reduce((sum, id) => sum + rank.get(id), 0) / related.length
+          : rank.get(item.id))
+      }
+
+      column.sort((a, b) => keys.get(a.id) - keys.get(b.id) || rank.get(a.id) - rank.get(b.id))
+      reindex()
+    }
+  }
+
+  // A column is as wide as its widest node, which is what lets hGap be a
+  // constant even though nodes range from 200 to 450+ px
+  const columnX = []
+  let x = 0
+  for (const column of columns) {
+    columnX.push(x)
+    x += Math.max(...column.map(item => item.width)) + options.hGap
+  }
+
+  // Left to right: longest-path layering puts every predecessor in an earlier
+  // column, so by the time a node is placed its inputs already have a position
+  const centerY = new Map()
+  for (const [index, column] of columns.entries()) {
+    const desired = column.map(item => {
+      const related = predecessors.get(item.id).filter(id => centerY.has(id))
+      if (!related.length) return null
+      return related.reduce((sum, id) => sum + centerY.get(id), 0) / related.length
+    })
+
+    const tops = []
+    let previousBottom = null
+
+    for (const [position, item] of column.entries()) {
+      let top = desired[position] !== null
+        ? desired[position] - item.height / 2
+        : previousBottom !== null ? previousBottom + options.vGap : 0
+
+      // Stacking wins over the barycenter: overlapping nodes are worse than a
+      // node sitting slightly off its inputs
+      if (previousBottom !== null) top = Math.max(top, previousBottom + options.vGap)
+
+      tops.push(top)
+      previousBottom = top + item.height
+    }
+
+    // Sliding the column as a block keeps both the order and the gaps. Median
+    // and not mean, or one very tall node drags the whole column with it
+    const drift = []
+    for (const [position, item] of column.entries()) {
+      if (desired[position] !== null) drift.push(desired[position] - (tops[position] + item.height / 2))
+    }
+    const shift = median(drift)
+
+    for (const [position, item] of column.entries()) {
+      const top = tops[position] + shift
+      positions.set(item.id, { x: columnX[index], y: top })
+      centerY.set(item.id, top + item.height / 2)
+    }
+  }
+
+  if (isolated.length) {
+    const main = boundsOf(connected, positions)
+    const startX = main ? main.minX : 0
+    const bandWidth = Math.max(main ? main.maxX - main.minX : 0, options.bandMaxWidth)
+
+    let bandX = startX
+    let bandY = main ? main.maxY + options.bandGap : 0
+    let rowHeight = 0
+
+    for (const item of [...isolated].sort(bySeed)) {
+      if (bandX > startX && bandX + item.width > startX + bandWidth) {
+        bandX = startX
+        bandY += rowHeight + options.vGap
+        rowHeight = 0
+      }
+
+      positions.set(item.id, { x: bandX, y: bandY })
+      bandX += item.width + options.hGap
+      rowHeight = Math.max(rowHeight, item.height)
+    }
+  }
+
+  const bounds = boundsOf(items, positions)
+  for (const [id, position] of positions) {
+    positions.set(id, {
+      x: Math.round(position.x - bounds.minX),
+      y: Math.round(position.y - bounds.minY)
+    })
+  }
+
+  return {
+    positions,
+    width: Math.round(bounds.maxX - bounds.minX),
+    height: Math.round(bounds.maxY - bounds.minY)
+  }
+}
+
+function clampGroupSize(size, options) {
+  return {
+    width: Math.max(Math.round(size.width), options.groupMinWidth),
+    height: Math.max(Math.round(size.height), options.groupMinHeight)
+  }
+}
+
+function toItem(node) {
+  const { width, height } = getNodeSize(node)
+
+  return {
+    id: node.id,
+    width,
+    height,
+    seedX: node.position.x,
+    seedY: node.position.y
+  }
+}
+
+/**
+ * Move a node the shortest distance that takes its center out of a rectangle.
+ * Group membership is decided by the center, so one pixel past the edge is
+ * enough.
+ */
+function pushOutOfRect(position, size, rectPosition, rectSize) {
+  const centerX = position.x + size.width / 2
+  const centerY = position.y + size.height / 2
+  const left = rectPosition.x
+  const right = rectPosition.x + rectSize.width
+  const top = rectPosition.y
+  const bottom = rectPosition.y + rectSize.height
+
+  if (centerX < left || centerX > right || centerY < top || centerY > bottom) return position
+
+  const exits = [
+    { dx: left - 1 - centerX, dy: 0 },
+    { dx: right + 1 - centerX, dy: 0 },
+    { dx: 0, dy: top - 1 - centerY },
+    { dx: 0, dy: bottom + 1 - centerY }
+  ]
+  const nearest = exits.reduce((best, exit) =>
+    Math.abs(exit.dx) + Math.abs(exit.dy) < Math.abs(best.dx) + Math.abs(best.dy) ? exit : best
+  )
+
+  return {
+    x: Math.round(position.x + nearest.dx),
+    y: Math.round(position.y + nearest.dy)
+  }
+}
+
+/**
+ * Work out where every node should sit.
+ *
+ * The returned positions are in the space VueFlow expects in `node.position`:
+ * **relative to the group for its children, absolute for everything else**.
+ *
+ * @param {Array} nodes VueFlow nodes, read only
+ * @param {Array} edges
+ * @returns {{ positions: Map<string, {x: number, y: number}>,
+ *             groupSizes: Map<string, {width: number, height: number}> }}
+ */
+export function computeAutoLayout(nodes, edges, opts = {}) {
+  const options = { ...AUTO_LAYOUT_DEFAULTS, ...opts }
+  const positions = new Map()
+  const groupSizes = new Map()
+
+  const byId = new Map(nodes.map(node => [node.id, node]))
+  const groups = nodes.filter(node => node.type === NODE_TYPES.GROUP)
+  const groupIds = new Set(groups.map(group => group.id))
+
+  // A parentNode pointing at a group that is gone makes the node free. VueFlow
+  // already warns about it; the layout reads the model, it does not repair it
+  const parentOf = node => (node.parentNode && groupIds.has(node.parentNode) ? node.parentNode : null)
+
+  // The content of each group comes first: its box is the slot the outer layout
+  // has to reserve, padding and minimum size included
+  const interiors = new Map()
+  for (const group of groups) {
+    const children = nodes.filter(node => parentOf(node) === group.id)
+
+    if (!children.length) {
+      // Nothing to arrange, so keep whatever size the user gave it
+      interiors.set(group.id, {
+        size: clampGroupSize(getGroupSize(group), options),
+        positions: new Map(),
+        resized: false
+      })
+      continue
+    }
+
+    const childIds = new Set(children.map(child => child.id))
+    const inner = layoutSubgraph(
+      children.map(toItem),
+      edges.filter(edge => childIds.has(edge.source) && childIds.has(edge.target)),
+      options
+    )
+
+    interiors.set(group.id, {
+      size: clampGroupSize({
+        width: inner.width + options.groupPadding * 2,
+        height: inner.height + options.groupPadding * 2
+      }, options),
+      positions: inner.positions,
+      resized: true
+    })
+  }
+
+  // Comments are annotations, not part of the flow: they keep their place
+  const isMovable = node =>
+    node.type !== NODE_TYPES.GROUP &&
+    node.type !== NODE_TYPES.COMMENT &&
+    !parentOf(node)
+
+  const freeNodes = nodes.filter(isMovable)
+  const items = [
+    ...freeNodes.map(toItem),
+    ...groups.map(group => ({
+      id: group.id,
+      ...interiors.get(group.id).size,
+      seedX: group.position.x,
+      seedY: group.position.y
+    }))
+  ]
+
+  if (!items.length) return { positions, groupSizes }
+
+  // Every edge is redrawn between the blocks the layout actually places, so an
+  // edge in or out of a group becomes an edge of the group itself
+  const itemIds = new Set(items.map(item => item.id))
+  const representativeOf = id => {
+    const node = byId.get(id)
+    return node ? parentOf(node) || id : null
+  }
+
+  const outerEdges = []
+  for (const edge of edges) {
+    const source = representativeOf(edge.source)
+    const target = representativeOf(edge.target)
+
+    if (!source || !target || source === target) continue
+    if (!itemIds.has(source) || !itemIds.has(target)) continue
+
+    outerEdges.push({ source, target })
+  }
+
+  const outer = layoutSubgraph(items, outerEdges, options)
+
+  // Anchor the result on the top-left corner the canvas already occupied, so the
+  // arrangement changes but the flow does not jump across the viewport
+  const anchor = items.reduce((corner, item) => ({
+    x: Math.min(corner.x, item.seedX),
+    y: Math.min(corner.y, item.seedY)
+  }), { x: Infinity, y: Infinity })
+
+  for (const item of items) {
+    const position = outer.positions.get(item.id)
+    positions.set(item.id, {
+      x: position.x + anchor.x,
+      y: position.y + anchor.y
+    })
+
+    if (!groupIds.has(item.id)) continue
+
+    const interior = interiors.get(item.id)
+    if (interior.resized) groupSizes.set(item.id, interior.size)
+
+    // Children stay relative to their group, offset by the padding
+    for (const [childId, childPosition] of interior.positions) {
+      positions.set(childId, {
+        x: childPosition.x + options.groupPadding,
+        y: childPosition.y + options.groupPadding
+      })
+    }
+  }
+
+  // A group may have landed on top of a comment. Left alone, the next drag would
+  // hand the comment over to that group and it would start travelling with it
+  for (const node of nodes) {
+    if (node.type !== NODE_TYPES.COMMENT || parentOf(node)) continue
+
+    const size = getNodeSize(node)
+    let position = { x: node.position.x, y: node.position.y }
+
+    for (const group of groups) {
+      position = pushOutOfRect(
+        position,
+        size,
+        positions.get(group.id) || group.position,
+        groupSizes.get(group.id) || getGroupSize(group)
+      )
+    }
+
+    if (position.x !== node.position.x || position.y !== node.position.y) {
+      positions.set(node.id, position)
+    }
+  }
+
+  return { positions, groupSizes }
+}

--- a/src/lib/auto-layout.js
+++ b/src/lib/auto-layout.js
@@ -4,7 +4,9 @@
  * Arranges the canvas by dependency: sources on the left, and every node to the
  * right of whatever feeds it. Groups are laid out as blocks — their content is
  * arranged first, and the resulting box takes part in the outer layout as a
- * single item, so a group never overlaps anything around it.
+ * single item, so a group never overlaps anything around it. With
+ * `layoutGroupContents` off the content is left untouched and the box keeps its
+ * size; only the group itself moves.
  *
  * The layering comes from `topologicalSort`, which already assigns a node to the
  * level right after its last dependency. That level is the column.
@@ -22,7 +24,10 @@ export const AUTO_LAYOUT_DEFAULTS = {
   groupMinHeight: 150,
   bandGap: 80,
   bandMaxWidth: 1200,
-  sweeps: 4
+  sweeps: 4,
+  // Arrange what is inside each group and resize the box to fit it. Turned off
+  // by the canvas, which only moves groups around, see the Auto Layout setting
+  layoutGroupContents: true
 }
 
 const WHITE = 0
@@ -407,8 +412,9 @@ export function computeAutoLayout(nodes, edges, opts = {}) {
   for (const group of groups) {
     const children = nodes.filter(node => parentOf(node) === group.id)
 
-    if (!children.length) {
-      // Nothing to arrange, so keep whatever size the user gave it
+    // Nothing to arrange, or the caller only wants the box moved: keep the size
+    // the user gave it, and its children keep their positions relative to it
+    if (!children.length || !options.layoutGroupContents) {
       interiors.set(group.id, {
         size: clampGroupSize(getGroupSize(group), options),
         positions: new Map(),

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -40,6 +40,10 @@ export const useSettingsStore = defineStore('settings', () => {
   const showNodeHeaders = ref(persisted.showNodeHeaders ?? false)
   const skipSaveDialog = ref(persisted.skipSaveDialog ?? false)
 
+  // Off by default: a group is usually arranged the way its author wanted, and
+  // the auto layout only moves the box around
+  const autoLayoutGroupContents = ref(persisted.autoLayoutGroupContents ?? false)
+
   // API Keys Settings
   const replicateApiKey = ref(persisted.replicateApiKey ?? '')
   const openaiApiKey = ref(persisted.openaiApiKey ?? '')
@@ -49,6 +53,7 @@ export const useSettingsStore = defineStore('settings', () => {
     () => ({
       showNodeHeaders: showNodeHeaders.value,
       skipSaveDialog: skipSaveDialog.value,
+      autoLayoutGroupContents: autoLayoutGroupContents.value,
       replicateApiKey: replicateApiKey.value,
       openaiApiKey: openaiApiKey.value
     }),
@@ -69,6 +74,10 @@ export const useSettingsStore = defineStore('settings', () => {
 
   function setSkipSaveDialog(value) {
     skipSaveDialog.value = value
+  }
+
+  function setAutoLayoutGroupContents(value) {
+    autoLayoutGroupContents.value = value
   }
 
   // API Keys Actions
@@ -106,6 +115,7 @@ export const useSettingsStore = defineStore('settings', () => {
     // State
     showNodeHeaders,
     skipSaveDialog,
+    autoLayoutGroupContents,
     replicateApiKey,
     openaiApiKey,
 
@@ -113,6 +123,7 @@ export const useSettingsStore = defineStore('settings', () => {
     toggleNodeHeaders,
     setNodeHeaders,
     setSkipSaveDialog,
+    setAutoLayoutGroupContents,
     setReplicateApiKey,
     setOpenaiApiKey,
     getReplicateApiKey,

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -40,6 +40,9 @@ export const useSettingsStore = defineStore('settings', () => {
   const showNodeHeaders = ref(persisted.showNodeHeaders ?? false)
   const skipSaveDialog = ref(persisted.skipSaveDialog ?? false)
 
+  // Beta features, hidden until the user opts in
+  const betaAutoLayout = ref(persisted.betaAutoLayout ?? false)
+
   // Off by default: a group is usually arranged the way its author wanted, and
   // the auto layout only moves the box around
   const autoLayoutGroupContents = ref(persisted.autoLayoutGroupContents ?? false)
@@ -53,6 +56,7 @@ export const useSettingsStore = defineStore('settings', () => {
     () => ({
       showNodeHeaders: showNodeHeaders.value,
       skipSaveDialog: skipSaveDialog.value,
+      betaAutoLayout: betaAutoLayout.value,
       autoLayoutGroupContents: autoLayoutGroupContents.value,
       replicateApiKey: replicateApiKey.value,
       openaiApiKey: openaiApiKey.value
@@ -74,6 +78,10 @@ export const useSettingsStore = defineStore('settings', () => {
 
   function setSkipSaveDialog(value) {
     skipSaveDialog.value = value
+  }
+
+  function setBetaAutoLayout(value) {
+    betaAutoLayout.value = value
   }
 
   function setAutoLayoutGroupContents(value) {
@@ -115,6 +123,7 @@ export const useSettingsStore = defineStore('settings', () => {
     // State
     showNodeHeaders,
     skipSaveDialog,
+    betaAutoLayout,
     autoLayoutGroupContents,
     replicateApiKey,
     openaiApiKey,
@@ -123,6 +132,7 @@ export const useSettingsStore = defineStore('settings', () => {
     toggleNodeHeaders,
     setNodeHeaders,
     setSkipSaveDialog,
+    setBetaAutoLayout,
     setAutoLayoutGroupContents,
     setReplicateApiKey,
     setOpenaiApiKey,

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -15,6 +15,7 @@
         ref="floatingMenu"
         :is-locked="isLocked"
         :is-nodes-menu-open="isNodesMenuOpen"
+        :show-auto-layout="settingsStore.betaAutoLayout"
         @toggle-nodes="toggleNodesMenu"
         @export="onExportClick"
         @import="handleImport"

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -21,6 +21,7 @@
         @open-batch="isBatchModalOpen = true"
         @lock-toggle="handleLockToggle"
         @fit-view="handleFitView"
+        @auto-layout="handleAutoLayout"
         @open-settings="isSettingsModalOpen = true"
       />
 
@@ -128,6 +129,7 @@ import { useCopyPaste } from '@/composables/useCopyPaste'
 import { useNodeCreation } from '@/composables/useNodeCreation'
 import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import { useGroupManagement } from '@/composables/useGroupManagement'
+import { useAutoLayout } from '@/composables/useAutoLayout'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useConnectionDrop } from '@/composables/useConnectionDrop'
@@ -152,7 +154,7 @@ const showIntro = ref(false)
 const showAlert = computed(() => !settingsStore.getReplicateApiKey())
 
 // VueFlow composable
-const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()
+const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, applyNodeChanges, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()
 
 // Use composables
 const { fileInput, handleExport, handleImport, onFileSelected, getDefaultFilename } = useFlowIO(flowStore, { addEdges })
@@ -217,6 +219,7 @@ const {
 } = useConnectionDrop(flowStore, createNodeAtPosition, screenToFlowCoordinate, { addEdges }, openNodesMenuAt, closeMenu)
 const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, { addEdges }, closeNodesMenu, menuOrigin)
 const { handleGroup } = useGroupManagement(flowStore, onNodeDragStop)
+const { handleAutoLayout, undoAutoLayout, canUndoLayout } = useAutoLayout(flowStore, { applyNodeChanges, fitView })
 
 // Register right-click handlers for context menus
 onPaneContextMenu(handlePaneContextMenu)
@@ -252,7 +255,7 @@ function onRenameConfirm(label) {
 }
 
 // Setup keyboard shortcuts
-useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, copiedNodes, flowStore })
+useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, canUndoLayout, copiedNodes, flowStore })
 
 // Register connection handler - use addEdges directly
 onConnect((params) => {


### PR DESCRIPTION
# What

The canvas can now tidy itself up. The feature ships as a **beta**: nothing changes for anyone until they turn it on in **Settings → Beta → Auto Layout**.

- Once enabled, an **Auto Layout** button appears in the left dock, next to Fit View. It rearranges every node by dependency: the nodes that start the flow go to the left, and each node lands to the right of whatever feeds it.
- Groups travel as blocks. A group is moved to wherever it belongs in the flow, carrying its content untouched — what is inside it is left exactly as its author arranged it, and the box keeps its size. A second setting, **Arrange the content of groups**, turns that on for whoever wants the inside tidied up and the box resized to fit; it is off by default.
- Comments stay where the user left them. They are notes, not part of the flow, so the layout does not drag them around; the only exception is a comment a group landed on top of, which is nudged aside.
- **Ctrl/Cmd+Z** undoes the arrangement and puts every node back exactly where it was. This is the only undoable action in the app, so the shortcut stays out of the way when there is no layout to revert.
- The button is disabled while the canvas is locked, the same as dragging.

# Why

Placing nodes by hand gets tedious as soon as a flow grows past a handful of them, and a canvas that has been edited for a while stops reading left to right. It is also a big, opinionated change to someone's canvas, which is why it sits behind a beta flag while the arrangement is tuned.

Most of what this needs was already in the repo. Columns come from the `levels` that `topologicalSort()` already returns: that layering puts a node right after its last dependency, which is exactly its column in a left to right arrangement. Sizes and the group rectangle come from `group-membership.js`. So the new `auto-layout.js` is pure logic with no new dependency — no dagre, no elkjs — and `useAutoLayout` is the thin part that writes it to the canvas and keeps the snapshot for the undo.

Groups are the reason the arrangement happens in two passes. Each group is collapsed into a single block, and when the setting asks for it the content is arranged first, because the resulting box is the slot the outer pass has to reserve — padding and minimum size included. With the setting off that slot is simply the size the group already had.

Two things needed care. Collapsing a group into a single block can turn an acyclic flow into a cyclic one — a node outside the group sitting between two of its children — and nothing in the app forbids a real cycle either. Left alone that would pile the whole canvas into one column, so a DFS drops the back edges before the columns are worked out, for the layout only: the flow keeps every connection.

The other one is group membership. A node whose center lands inside a group would be adopted by `syncGroupMembership()` on the next drag and would silently start travelling with that group. The layout keeps every box apart so this cannot happen, which is also why a group's block always reserves its full final size.

# Tests

e2e tests and local.

New spec `e2e/auto-layout.spec.js` with 11 tests covering the beta flag, ordering, groups with the content setting both off and on, the membership invariant, idempotence and the undo. The full suite was re-run: 75 passing, with only the 5 pre-existing `copy-paste` macOS failures left, identical to the baseline on `main`.

The arrangement was also fuzzed over 400 random graphs with groups and comments: no overlaps, no node left inside a group, no crash.

# How to test

- [ ] Open **Settings**: there is a new **Beta** section, unticked, and no Auto Layout button in the left dock.
- [ ] Tick **Auto Layout**: the button shows up in the dock, and an **Auto Layout** section appears in the settings.
- [ ] Drop a few nodes on the canvas in a deliberate mess, connect them into a chain, and click the button: the flow reads left to right, sources first.
- [ ] Connect two sources into the same node: both sources share a column and the node they feed sits to their right.
- [ ] Click the button a second time: nothing moves.
- [ ] Press **Ctrl/Cmd+Z**: every node goes back exactly where it was.
- [ ] Select two nodes, press `Ctrl/Cmd+G` to group them, connect a free node into one of the children, and run the layout: the group is pulled to where the flow puts it, at the same size, with its content exactly as it was.
- [ ] Tick **Arrange the content of groups** and run the layout again: now the nodes inside the group are rearranged too and the box is resized to fit them.
- [ ] Drag any node outside the group a few pixels and drop it: it does not become part of the group.
- [ ] Add a Comment somewhere far from the flow and run the layout: the comment does not move.
- [ ] Lock the canvas with the padlock: the Auto Layout button is disabled.
- [ ] Run the layout, save the flow to JSON and load it back: positions, group sizes and children survive the round trip.
- [ ] Reload the page: both settings are remembered.
