### PR TITLE
feat: add a node options side panel opened from the node toolbar

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -435,7 +435,8 @@ stops scaling past a handful of controls, so every model splits its `uiSchema` i
 `controls` for the toolbar and `advancedControls` for the panel. Both are the same
 descriptor shape and both write to `data.params`, so nothing about serialization or the
 API payload changes. The ⋮ button only appears when the current model declares advanced
-controls.
+controls. What is deliberately *not* there is anything that asks for more than one image:
+see [One image per generation](#one-image-per-generation).
 
 The panel reads its node through VueFlow's `findNode`, not through the store: `selected`
 is only kept up to date on VueFlow's own node objects, and the panel lives and dies by it.
@@ -694,7 +695,25 @@ const result = await replicateService.generateImage({
 Each model defines:
 - Accepted parameters
 - Default values
-- UI Schema for toolbar (dynamic controls)
+- UI Schema, split into `controls` for the node toolbar and `advancedControls` for the
+  node options side panel
+
+### One image per generation
+
+Several models can return a batch of images in a single prediction: `number_of_images` on
+the gpt-image models, `max_images` together with `sequential_image_generation` on
+seedream-4. **None of them is exposed in the UI, and `buildInput` always asks for exactly
+one image**, ignoring whatever a flow's `data.params` might carry.
+
+An Image Generator node renders a single output and reads `imageUrl`, the first entry of
+the response. Every extra image was billed and then dropped on the floor, which is a
+silent cost for something the user could not see. Fixing the value at 1 in `defaults`, and
+reading it from there rather than from `params`, is what keeps an imported JSON from
+re-enabling it behind the user's back.
+
+Should the canvas ever grow a node that can hold several images, the way back is to expose
+the parameter again and consume `imageUrls` / `allOutputs`, which the model configs already
+return from `parseResponse`.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,12 @@ flora/
 │   │   │   ├── FloatingMenu.vue      # Left sidebar menu with actions
 │   │   │   ├── NodesSidebar.vue      # Draggable nodes list
 │   │   │   ├── NodeContextMenu.vue   # Right-click menu on a node (batch marks)
+│   │   │   ├── NodeOptionsPanel.vue  # Side panel with the extra model options
 │   │   │   └── SettingsModal.vue     # Settings configuration modal
+│   │   ├── ui/
+│   │   │   ├── BaseModal.vue         # Centred modal dialog
+│   │   │   ├── BaseSidePanel.vue     # Panel docked to the right edge
+│   │   │   └── ModelControl.vue      # One uiSchema control, label over field
 │   │   ├── batch/
 │   │   │   └── BatchRunModal.vue     # Batch Run panel
 │   │   └── nodes/
@@ -45,6 +50,7 @@ flora/
 │   │   ├── useDragAndDrop.js         # Drag & drop logic
 │   │   ├── useGroupManagement.js     # Group/ungroup operations
 │   │   ├── useAutoLayout.js          # Arrange the canvas by dependency
+│   │   ├── useSidePanel.js           # Which side panel the canvas is showing
 │   │   └── useKeyboardShortcuts.js   # Global keyboard shortcuts
 │   ├── views/
 │   │   └── FlowCanvasView.vue        # Main app canvas (~177 lines)
@@ -117,6 +123,7 @@ User interacts with Canvas
 - `FloatingMenu.vue` - Left sidebar with action buttons
 - `NodesSidebar.vue` - Draggable nodes list
 - `SettingsModal.vue` - Settings configuration
+- `NodeOptionsPanel.vue` - Right side panel with the extra options of a node's model
 
 **Composables used:**
 ```javascript
@@ -134,6 +141,9 @@ const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, create
 const { handleGroup } = useGroupManagement(flowStore, onNodeDragStop)
 const { handleAutoLayout, undoAutoLayout, canUndoLayout } = useAutoLayout(flowStore, { applyNodeChanges, fitView })
 useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, canUndoLayout, copiedNodes, flowStore })
+
+// Side panels, opened from anywhere (a node toolbar, a menu, …)
+const { activePanel } = useSidePanel()
 ```
 
 **Features:**
@@ -145,6 +155,7 @@ useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, can
 - Copy/paste the selection, keeping its layout and input connections (Ctrl+C, Ctrl+V)
 - Group nodes (Ctrl+G)
 - Auto layout: arrange every node by dependency, undoable with Ctrl+Z (beta, off by default)
+- Node options side panel, opened from the ⋮ button in a node toolbar
 - Settings modal
 - Automatic group management
 
@@ -400,6 +411,36 @@ place; it is only nudged if a group happened to land on top of it. Comments insi
 group are arranged with the rest of its content. Since the repo has no history and a
 layout discards every manual placement, the composable keeps a one step snapshot that
 `Ctrl+Z` restores.
+
+**useSidePanel.js** - Which side panel the canvas is showing
+```javascript
+export const PANEL_TYPES = { NODE_OPTIONS: 'node-options' }
+
+export function useSidePanel() {
+  return { activePanel, isPanelOpen, openPanel, closePanel, closePanelOfType }
+}
+```
+The state lives at module level, not inside the function. What opens a panel is usually a
+button several components deep inside VueFlow, while the panel itself is rendered by
+`FlowCanvasView`; the same trick the workflow event bus uses to let a node talk to the
+canvas without prop drilling. One panel at a time: opening another replaces it.
+
+`BaseSidePanel.vue` is the shell, docked to the right edge over the full height. It is
+deliberately not a `BaseModal` variant, because it has no overlay: a panel that tracks the
+selection needs the canvas to stay interactive, or the user could never deselect while it
+is up. It sits at `z-index: 900`, below modals, so Settings still opens on top of it.
+
+`NodeOptionsPanel.vue` is the only content so far. A node toolbar is a single row and
+stops scaling past a handful of controls, so every model splits its `uiSchema` in two:
+`controls` for the toolbar and `advancedControls` for the panel. Both are the same
+descriptor shape and both write to `data.params`, so nothing about serialization or the
+API payload changes. The ⋮ button only appears when the current model declares advanced
+controls.
+
+The panel reads its node through VueFlow's `findNode`, not through the store: `selected`
+is only kept up to date on VueFlow's own node objects, and the panel lives and dies by it.
+A watch on the selection closes the panel when the node is deselected, replaced by another
+selection, or deleted.
 
 ### Complex Composables
 

--- a/docs/replicate-models-docs/image/gpt-image-1.md
+++ b/docs/replicate-models-docs/image/gpt-image-1.md
@@ -1,0 +1,110 @@
+## Basic model info
+
+Model name: openai/gpt-image-1
+Model description: A multimodal image generation model that creates high-quality images. You need to bring your own verified OpenAI key to use this model. Your OpenAI account will be charged for usage.
+
+
+## Model inputs
+
+- openai_api_key (required): Your OpenAI API key (string)
+- prompt (required): A text description of the desired image (string)
+- aspect_ratio (optional): The aspect ratio of the generated image (string)
+- input_fidelity (optional): Control how much effort the model will exert to match the style and features, especially facial features, of input images (string)
+- input_images (optional): A list of images to use as input for the generation (array)
+- number_of_images (optional): Number of images to generate (1-10) (integer)
+- quality (optional): The quality of the generated image (string)
+- background (optional): Set whether the background is transparent or opaque or choose automatically (string)
+- output_compression (optional): Compression level (0-100%) (integer)
+- output_format (optional): Output format (string)
+- moderation (optional): Content moderation level (string)
+- user_id (optional): An optional unique identifier representing your end-user. This helps OpenAI monitor and detect abuse. (string)
+
+
+## Model output schema
+
+{
+  "type": "array",
+  "items": {
+    "type": "string",
+    "format": "uri"
+  },
+  "title": "Output"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/1f7kjzpk7xrmc0cpfmmvysbdcc)
+
+#### Input
+
+```json
+{
+  "prompt": "Add the floral pattern to the vase",
+  "quality": "auto",
+  "background": "auto",
+  "moderation": "auto",
+  "aspect_ratio": "1:1",
+  "input_images": [
+    "https://replicate.delivery/pbxt/MusWuQJm1RJPu1Cj0ajRmoMnHyYNPk6ljT1QCU4DbHMsqDTF/53541851-62f3-44a7-b075-ef053ae2f324.jpg",
+    "https://replicate.delivery/pbxt/MusWuPkfcvyZQuuXeMIbQXEMe9K2G8rDCNraQffAt0OzMRaT/colored-flower-pattern-free-vector.jpg"
+  ],
+  "output_format": "webp",
+  "openai_api_key": "[REDACTED]",
+  "number_of_images": 1,
+  "output_compression": 90
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/hEcJpm50O9ouFVu506qf6wAjLKc4MH1oFeRZ4PORmTqVqVnUA/tmpfkxavg8q.png"
+]
+```
+
+
+## Model readme
+
+> GPT Image 1 is a new state-of-the-art image generation model. It is a natively multimodal language model that accepts both text and image inputs, and produces image outputs.
+> 
+> ## Capabilities
+> 
+> - Creates images across diverse styles
+> - Follows custom guidelines
+> - Leverages world knowledge
+> - Renders text accurately
+> 
+> ## Pricing
+> 
+> This is a bring-your-own-token model. You need to bring your own verified OpenAI key to use this model. Your OpenAI account will be charged for usage based on the following pricing.
+> 
+> See [OpenAI’s pricing](https://openai.com/api/pricing/) for details.
+> 
+> ## Safety Features
+> 
+> - Same safety guardrails as image generation in ChatGPT
+> - Safeguards against generating harmful images
+> - C2PA metadata included in generated images
+> - Moderation sensitivity control with the `moderation` parameter:
+>   - `auto` (default): standard filtering
+>   - `low`: less restrictive filtering
+> 
+> ## Data Usage
+> 
+> - By default, OpenAI does not train on customer API data
+> - All image inputs and outputs remain subject to API usage policies
+> 
+> # Verify Organization
+> 
+> If you see the error: "your organization must be verified to use the model" please go to [platform.openai.com/settings/organization/general](https://platform.openai.com/settings/organization/general) and click on `Verify Organization`. If you just verified, it can take up to 15 minutes for access to propagate.
+> 
+> # Billing
+> 
+> You pay OpenAI directly via your API key.
+

--- a/docs/replicate-models-docs/image/gpt-image-2.md
+++ b/docs/replicate-models-docs/image/gpt-image-2.md
@@ -1,0 +1,132 @@
+## Basic model info
+
+Model name: openai/gpt-image-2
+Model description: OpenAI's state-of-the-art image generation model. Create and edit images from text with strong instruction following, sharp text rendering, and detailed editing.
+
+
+## Model inputs
+
+- prompt (required): A text description of the desired image (string)
+- openai_api_key (optional): Your OpenAI API key (optional - uses proxy if not provided) (string)
+- aspect_ratio (optional): The size of the generated image. Use 'auto' to let the model pick. Sizes above 2560x1440 are experimental and may give more variable results. (string)
+- input_images (optional): A list of images to use as input for the generation (array)
+- number_of_images (optional): Number of images to generate (1-10) (integer)
+- quality (optional): The quality of the generated image (string)
+- background (optional): Set whether the background is transparent or opaque or choose automatically (string)
+- output_compression (optional): Compression level (0-100%) (integer)
+- output_format (optional): Output format (string)
+- moderation (optional): Content moderation level (string)
+- user_id (optional): An optional unique identifier representing your end-user. This helps OpenAI monitor and detect abuse. (string)
+
+
+## Model output schema
+
+{
+  "type": "array",
+  "items": {
+    "type": "string",
+    "format": "uri"
+  },
+  "title": "Output"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/drk132mwx5rmt0cxp878wad6gc)
+
+#### Input
+
+```json
+{
+  "prompt": "A photo of a computer screen displaying a Spotify playlist in golden hour evening in a living room with lots of green plants in the background. The playlist says GPT-image-2. caption is \"this new image model from OpenAI is dope.\" and the artists are Replicate. the songs are themes about open source AI and Machine learning. the account name is Replicate. use the logo for replicate as the profile picture and artist image.",
+  "quality": "auto",
+  "background": "auto",
+  "moderation": "auto",
+  "aspect_ratio": "3:2",
+  "input_images": [
+    "https://replicate.delivery/pbxt/Oy2U6Sw4k3ZYEZ5cXeuVJMq8k45GQ17J2iKvt1HcHVUtVj5O/download.jpg"
+  ],
+  "output_format": "webp",
+  "number_of_images": 1,
+  "output_compression": 90
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/AjohJsKVZ26WEZ4tkXI7fKIun2rUbTZxct9EfRKQAPcEWadWA/tmp5ydq16cm.webp"
+]
+```
+
+
+## Model readme
+
+> # GPT Image 2
+> 
+> GPT Image 2 is OpenAI's state-of-the-art image generation model. Create images from text or edit existing images with precise, instruction-following control.
+> 
+> ## What it does
+> 
+> GPT Image 2 handles two workflows: generating images from text descriptions, and editing existing images with specific instructions. It's designed to follow your directions closely while keeping the parts you want unchanged.
+> 
+> When you pass reference images, GPT Image 2 processes them at high fidelity automatically. There's no knob to adjust — the model always does its best to preserve the details of the input. Pass one image to edit it, or pass multiple images to combine styles, subjects, or references into a single output.
+> 
+> ## Key capabilities
+> 
+> **Photorealism and detail**: Natural-looking images with accurate lighting, believable materials, and rich textures. From honest, unposed photography to polished commercial visuals.
+> 
+> **Text rendering**: Dense text, small lettering, and complex layouts like infographics, UI mockups, and marketing materials.
+> 
+> **Precise editing**: Targeted changes without reinterpreting the entire image. The model preserves identity, composition, and lighting while you adjust specific elements.
+> 
+> **Style control**: Apply consistent visual styles across different subjects, or transfer the look of one image to another with minimal prompting.
+> 
+> **World knowledge**: Ask for a scene set in "Bethel, New York in August 1969" and the model understands you want Woodstock — it has reasoning built in.
+> 
+> ## Use cases
+> 
+> **Image generation**: Infographics, logos, UI mockups, photorealistic scenes, comic strips, marketing visuals. Works well for both creative exploration and production-ready outputs.
+> 
+> **Image editing**: Style transfer, virtual clothing try-ons, product mockups, text translation in images, lighting adjustments, object removal, scene compositing. Insert people into new scenes while preserving their likeness, or swap furniture in room photos without changing the camera angle.
+> 
+> **Character consistency**: Build multi-page illustrations where characters look the same across different scenes — useful for children's books, storyboards, and campaigns.
+> 
+> ## How to get good results
+> 
+> **Be specific**: Describe what you want clearly. Instead of "make it better," say "add soft coastal daylight" or "change the red hat to light blue velvet."
+> 
+> **Use photo language for realism**: Mention lens type, lighting quality, and framing when you want photorealistic results. "Shot with a 50mm lens, soft daylight, shallow depth of field" gets you closer to real photography than generic quality terms.
+> 
+> **Lock what shouldn't change**: When editing, explicitly state what must stay the same. "Change only the lighting, preserve the subject's face, pose, and clothing" prevents unwanted alterations.
+> 
+> **Put text in quotes**: For readable text in images, put the exact copy in "quotes" and describe the typography. "Bold sans-serif, centered, high contrast" helps ensure legibility.
+> 
+> **Iterate with small changes**: Start with a base image, then make one adjustment at a time rather than rewriting everything.
+> 
+> **Reference multiple images clearly**: When working with several input images, label them by number and describe how they relate. "Apply the style from image 1 to the subject in image 2."
+> 
+> ## Inputs
+> 
+> - `prompt`: What you want to generate or how to edit the input
+> - `input_images`: One or more reference images (for editing or composing)
+> - `aspect_ratio`: `1:1` (square), `3:2` (landscape), or `2:3` (portrait)
+> - `quality`: `low`, `medium`, `high`, or `auto` — lower quality is faster and cheaper
+> - `number_of_images`: Generate up to 10 images in a single call
+> - `output_format`: `webp` (default), `png`, or `jpeg`
+> - `background`: `auto` or `opaque`
+> - `moderation`: `auto` (default) or `low` for less strict content filtering
+> - `openai_api_key`: Optional — bring your own OpenAI API key to pay OpenAI directly
+> 
+> ## Notes
+> 
+> GPT Image 2 doesn't support transparent backgrounds. For transparent PNGs, use [openai/gpt-image-1.5](https://replicate.com/openai/gpt-image-1.5).
+> 
+> You can try this model on the Replicate Playground at [replicate.com/playground](https://replicate.com/playground).
+

--- a/docs/replicate-models-docs/image/lang-segment-anything.md
+++ b/docs/replicate-models-docs/image/lang-segment-anything.md
@@ -1,0 +1,53 @@
+## Basic model info
+
+Model name: tmappdev/lang-segment-anything
+Model description: Segment Anything with prompts
+
+
+## Model inputs
+
+- image (required): Path to the input image (string)
+- text_prompt (required): Text prompt for segmentation (string)
+
+
+## Model output schema
+
+{
+  "type": "string",
+  "title": "Output",
+  "format": "uri"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/a6qx184q6xrj20ckdqqvgy8cfw)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/M2tUXKe06UEAExSwWbcYvMOoGVXGtEbvsD52HaSgC3vulSfR/a2ed4.jpg",
+  "text_prompt": "text,watermark"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/yhqm/Q2pSoJaTgtbrE5kw9tKgC9SNEWAkFs5kS408pHxVjjYexm6JA/mask_output.png"
+```
+
+
+## Model readme
+
+> # Langsam
+> 
+> A [lang-segment-anything](https://github.com/luca-medeiros/lang-segment-anything) replicate app created by [@ashhadahsan](https://github.com/ashhadahsan).
+> 
+> Hit me up to get in touch.
+

--- a/docs/replicate-models-docs/image/seedream-4.md
+++ b/docs/replicate-models-docs/image/seedream-4.md
@@ -1,0 +1,131 @@
+## Basic model info
+
+Model name: bytedance/seedream-4
+Model description: Unified text-to-image generation and precise single-sentence editing at up to 4K resolution
+
+
+## Model inputs
+
+- prompt (required): Text prompt for image generation (string)
+- image_input (optional): Input image(s) for image-to-image generation. List of 1-10 images for single or multi-reference generation. (array)
+- size (optional): Image resolution: 1K (1024px), 2K (2048px), 4K (4096px), or 'custom' for specific dimensions. (string)
+- aspect_ratio (optional): Image aspect ratio. Only used when size is not 'custom'. Use 'match_input_image' to automatically match the input image's aspect ratio. (string)
+- width (optional): Custom image width (only used when size='custom'). Range: 1024-4096 pixels. (integer)
+- height (optional): Custom image height (only used when size='custom'). Range: 1024-4096 pixels. (integer)
+- sequential_image_generation (optional): Group image generation mode. 'disabled' generates a single image. 'auto' lets the model decide whether to generate multiple related images (e.g., story scenes, character variations). (string)
+- max_images (optional): Maximum number of images to generate when sequential_image_generation='auto'. Range: 1-15. Total images (input + generated) cannot exceed 15. (integer)
+- enhance_prompt (optional): Enable prompt enhancement for higher quality results, this will take longer to generate. (boolean)
+
+
+## Model output schema
+
+{
+  "type": "array",
+  "items": {
+    "type": "string",
+    "format": "uri"
+  },
+  "title": "Output"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/7g68gknx8drme0cs5s9bdyptjg)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "width": 2048,
+  "height": 2048,
+  "prompt": "a selection of photos of this woman looking at a store front and perusing a book shop that's called \"Seedream 4\", it sells books, a poster in the window says \"Seedream 4 now on Replicate\"",
+  "max_images": 4,
+  "image_input": [
+    "https://replicate.delivery/pbxt/NgNa2k87ua7v4G2Z51JpiWFcjXoTV1wPVQ86YjmLPfREnWfD/0_1.webp"
+  ],
+  "aspect_ratio": "4:3",
+  "sequential_image_generation": "auto"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/W4oDJ3dpV0phN1eLuLsHvZT1OjepgjA6hOqXg0nA0juhe4mqA/tmpe2n7sv24.jpg",
+  "https://replicate.delivery/xezq/D0RIbLaYuGaPGdCRO3Gssvs7iA02u7AK1QhfFbBXqzyQPupKA/tmpppiemf81.jpg",
+  "https://replicate.delivery/xezq/LGitpMjljpLdPNkctQwUZVRIoEJSB2zgJub8DLKFEFaoH3UF/tmp75bf8ax_.jpg"
+]
+```
+
+
+### Example (https://replicate.com/p/9ebj5m296nrme0cs6dhrr9zf9m)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "width": 2048,
+  "height": 2048,
+  "prompt": "a photo of a store front called \"Seedream 4\", it sells books, a poster in the window says \"Seedream 4 now on Replicate\"",
+  "max_images": 1,
+  "image_input": [],
+  "aspect_ratio": "4:3",
+  "sequential_image_generation": "disabled"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/fnJ14cVwXep4g0qfuyurzx9Dsk8eld3VDywecSJNNQg5kJeUF/tmp7cvbut6o.jpg"
+]
+```
+
+
+## Model readme
+
+> # Seedream 4.0
+> 
+> Seedream 4.0 is ByteDance’s next-generation image creation model that combines text-to-image generation and image editing into a single architecture. It offers fast, high-resolution image generation, rich prompt understanding, and support for multi-reference and batch workflows.
+> 
+> ## Key Features
+> 
+> - **Unified generation & editing**  
+>   Both text-to-image creation and image modifications (e.g. removing or replacing objects) are handled in one model—no need for separate tools.
+> 
+> - **High-resolution and fast inference**  
+>   Produces outputs up to 4K with significantly faster inference than prior versions.
+> 
+> - **Batch and multi-reference support**  
+>   Accepts multiple reference images and returns multiple outputs in one request.
+> 
+> - **Natural-language prompt editing**  
+>   Make precise edits using simple language, like “Remove the boy in this picture” or “Replace this dog with a Schnauzer.”
+> 
+> - **Versatile style transfer**  
+>   Apply diverse visual styles such as watercolor, cyberpunk, or architectural to inputs or prompts.
+> 
+> - **Knowledge-driven generation**  
+>   Capable of complex content like educational illustrations, charts, timelines, or annotated scenes, with strong reasoning and prompt-following abilities.
+> 
+> ## Use Cases
+> 
+> | Scenario                        | Example                                                                 |
+> |---------------------------------|-------------------------------------------------------------------------|
+> | Creative agencies / designers   | Generate batches of concept art or storyboards from multi-image inputs. |
+> | Illustration & education        | Produce accurate diagrams or timelines with labeled details.             |
+> | Visual editing & prototyping    | Modify photos or designs via text prompts for fast iteration.            |
+> 
+> ---
+> 
+> **Try the model yourself on the [Replicate Playground](https://replicate.com/google/nano-banana)** to explore its capabilities and see how it can enhance your creative workflow.
+

--- a/docs/replicate-models-docs/text/gemini-2.5-flash.md
+++ b/docs/replicate-models-docs/text/gemini-2.5-flash.md
@@ -1,0 +1,172 @@
+## Basic model info
+
+Model name: google/gemini-2.5-flash
+Model description: Google’s hybrid “thinking” AI model optimized for speed and cost-efficiency
+
+
+## Model inputs
+
+- prompt (required): The text prompt to send to the model (string)
+- images (optional): Input images to send with the prompt (max 10 images, each up to 7MB) (array)
+- videos (optional): Input videos to send with the prompt (max 10 videos, each up to 45 minutes) (array)
+- system_instruction (optional): System instruction to guide the model's behavior (string)
+- temperature (optional): Sampling temperature between 0 and 2 (number)
+- top_p (optional): Nucleus sampling parameter - the model considers the results of the tokens with top_p probability mass (number)
+- max_output_tokens (optional): Maximum number of tokens to generate (integer)
+- thinking_budget (optional): Thinking budget for reasoning (0 to disable thinking, higher values allow more reasoning) (integer)
+- dynamic_thinking (optional): Enable dynamic thinking - the model will adjust the thinking budget based on the complexity of the request (overrides thinking_budget parameter) (boolean)
+
+
+## Model output schema
+
+{
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "title": "Output",
+  "x-cog-array-type": "iterator",
+  "x-cog-array-display": "concatenate"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/75rmdjrcchrm80csnhdacrc7jr)
+
+#### Input
+
+```json
+{
+  "top_p": 0.95,
+  "prompt": "A recipe for flan",
+  "temperature": 1,
+  "dynamic_thinking": false,
+  "max_output_tokens": 65535
+}
+```
+
+#### Output
+
+```json
+[
+  "Flan is a classic, creamy, and wonderfully simple dessert with a rich caramel topping. This recipe focuses on a traditional Latin American style, which is often a bit denser and creamier than some other variations.\n\n**Classic Caramel Flan**\n\nThis",
+  " recipe makes one 8 or 9-inch round flan, serving 6-8 people.\n\n**Yields:** 1 flan (8-9 inches)\n**Prep time:** 20 minutes\n**Cook time:** ",
+  "50-70 minutes\n**Chill time:** At least 4 hours (preferably overnight)\n\n---\n\n**Ingredients:**\n\n**For the Caramel:**\n*   1 cup (200g) granulated sugar\n*   ",
+  "1/4 cup (60ml) water\n\n**For the Custard:**\n*   1 (14-ounce/397g) can sweetened condensed milk\n*   1 (12-ounce/35",
+  "4ml) can evaporated milk\n*   1 cup (240ml) whole milk (or half-and-half for extra richness)\n*   4 large eggs\n*   2 large egg yolks (for extra richness and",
+  " a smoother texture)\n*   2 teaspoons vanilla extract\n*   1/4 teaspoon salt\n\n---\n\n**Equipment:**\n*   8 or 9-inch round cake pan (or a 6-cup bundt pan,",
+  " or a loaf pan)\n*   Larger roasting pan (to create a water bath)\n*   Heavy-bottomed saucepan\n*   Whisk\n*   Fine-mesh sieve\n\n---\n\n**Instructions:**\n\n**1",
+  ". Preheat Oven & Prepare Water Bath:**\n    *   Preheat your oven to **350\u00b0F (175\u00b0C)**.\n    *   Place a large roasting pan on the middle rack of your oven. This is",
+  " where your flan pan will sit to bake in a water bath.\n\n**2. Make the Caramel:**\n    *   In a heavy-bottomed saucepan, combine the granulated sugar and water.\n    *   Cook over medium-high",
+  " heat, stirring until the sugar dissolves.\n    *   Once it starts to boil, **do not stir**. You can gently swirl the pan occasionally if needed to ensure even cooking.\n    *   Continue cooking until the sugar turns a deep amber or",
+  " light brown color. This usually takes about 5-8 minutes. Watch carefully, as it can burn quickly once it reaches the desired color.\n    *   Immediately and carefully pour the hot caramel into your 8 or 9-inch cake pan",
+  ".\n    *   Carefully tilt the pan to coat the bottom evenly with the caramel. Set aside to cool; the caramel will harden.\n\n**3. Prepare the Custard:**\n    *   In a large bowl, whisk together the",
+  " sweetened condensed milk, evaporated milk, whole milk (or half-and-half), eggs, egg yolks, vanilla extract, and salt until just combined.\n    *   **Important for Smoothness:** Strain the custard mixture through a fine",
+  "-mesh sieve into another bowl or a large measuring cup with a spout. This removes any bits of cooked egg or chalazae, ensuring a perfectly smooth flan. Discard any solids left in the sieve.\n\n**4. Assemble and Bake:**",
+  "\n    *   Carefully pour the strained custard mixture over the hardened caramel in the prepared cake pan.\n    *   Place the flan pan *inside* the larger roasting pan that's already in the oven.\n    *   ",
+  "Carefully pour hot tap water into the roasting pan until it comes about halfway up the sides of the flan pan. (Be careful not to splash water into the flan!)\n    *   Bake for 50-7",
+  "0 minutes, or until the edges are set but the center still jiggles slightly when gently shaken. A knife inserted near the edge should come out clean.\n    *   **Do not overbake**, or the flan can become rubber",
+  "y or develop cracks.\n\n**5. Cool and Chill:**\n    *   Carefully remove the flan pan from the water bath (leave the roasting pan in the oven if you want, or remove it as well).\n    ",
+  "*   Let the flan cool completely on a wire rack at room temperature.\n    *   Once cooled, cover the flan pan with plastic wrap and refrigerate for at least 4 hours, but preferably **overnight**. Ch",
+  "illing is crucial for the flan to set properly and for the caramel to liquify into a sauce.\n\n**6. Unmold and Serve:**\n    *   When ready to serve, run a thin knife around the outer edge of the fl",
+  "an to loosen it.\n    *   Place a large serving plate (with a slight rim to catch the caramel sauce) upside down over the flan pan.\n    *   Holding the plate and pan firmly together, quickly and confidently flip them over",
+  ".\n    *   Gently lift the flan pan. The flan should slide out, and the beautiful caramel sauce will cascade over it. If it doesn't release immediately, give the bottom of the pan a gentle tap.\n",
+  "    *   Serve chilled and enjoy!\n\n---\n\n**Tips for Success:**\n\n*   **Don't Stir the Caramel:** Once the sugar and water mixture boils, resist the urge to stir. Stirring can cause sugar crystals to form.",
+  " Swirl the pan instead.\n*   **Watch the Caramel Closely:** Caramel goes from perfect to burnt very quickly. Have your cake pan ready to pour it in immediately.\n*   **Water Bath is Key:** The water bath (",
+  "Bain-Marie) ensures even, gentle cooking, preventing the custard from curdling and keeping it wonderfully smooth and creamy.\n*   **Don't Overbake:** A slight jiggle in the center is good. Overbaking will result",
+  " in a tougher, less creamy flan.\n*   **Chill Thoroughly:** This is critical! A well-chilled flan has the best texture and allows the caramel to turn into a luscious sauce.\n*   **Strain the Cust",
+  "ard:** This step takes an extra minute but makes a huge difference in achieving that perfectly silky smooth texture.\n\nEnjoy your delicious homemade flan!"
+]
+```
+
+
+### Example (https://replicate.com/p/94p6hekpwnrme0ctc1kb2c6j18)
+
+#### Input
+
+```json
+{
+  "top_p": 0.95,
+  "images": [
+    "https://replicate.delivery/pbxt/O1TXLIqsDC7pdOzMl259hqrdwkDLjxrf8Fsg2ZwYVIIkoHkm/replicate-prediction-vygd5qqab1rmc0ctb9cbr14cxw.jpg"
+  ],
+  "prompt": "describe this image in detail",
+  "videos": [],
+  "temperature": 1,
+  "dynamic_thinking": false,
+  "max_output_tokens": 65535
+}
+```
+
+#### Output
+
+```json
+[
+  "This stunning image depicts a solitary samurai warrior in a moment of deep contemplation amidst a breathtaking autumn mountain landscape, rendered in a style reminiscent of classical painting with a touch of modern digital artistry.\n\nIn the foreground, slightly to the left of center",
+  ", a samurai is seated on a rugged, dark gray and brown rocky outcrop. He is in a contemplative or meditative posture, with his head bowed and gaze directed downwards. His hands are clasped or resting gently in his lap.\n\nThe",
+  " samurai's armor is remarkably ornate and colorful. He wears a regal purple kabuto (helmet) with golden, horn-like kuwagata crests on the front, adorned with intricate golden details. His face is obscured by a dark blue",
+  " or black mask (mempo), with subtle red accents around what appears to be the mouth or chin guard. The body armor consists of white or cream-colored sections with delicate, intricate purple patterns, possibly depicting floral motifs, clouds, or traditional",
+  " Japanese designs. These patterned sections are interspersed with solid purple plates, all appearing to be meticulously lacquered and held together with visible lacing. A katana, sheathed in a dark scabbard, rests at his left hip.\n\nDomin",
+  "ating the left and upper-middle sections of the image is a gnarled, ancient tree branch, its dark, textured bark contrasting with its vibrant foliage. The leaves are a magnificent tapestry of autumn colors: fiery reds, rich oranges, and",
+  " brilliant yellows, suggesting a maple or similar deciduous tree. The individual leaves are highly detailed, showing veins and variations in color, and are clustered densely on the branches, some smaller twigs extending with nascent buds or berries.\n\nThe background unfolds into a majestic",
+  " mountain range. Several layers of peaks fade into the distance, rendered with atmospheric perspective, appearing progressively lighter blue and hazier. The most prominent feature in the background is a towering, sharp, snow-capped mountain peak on the far right, its",
+  " pristine white snow standing out against the pale, almost white or light blue sky.\n\nThe overall color palette is a striking blend of vibrant autumn hues (reds, oranges, yellows) in the foliage, deep purples, whites, and dark",
+  " blues of the samurai's armor, and the cool blues, grays, and whites of the distant mountains and sky. The lighting is soft and diffused, creating a serene and introspective mood. The image evokes a sense of peace, resilience",
+  ", and the beauty of nature, with the samurai serving as a stoic, reflective presence within the grand landscape."
+]
+```
+
+
+### Example (https://replicate.com/p/8tkt960eahrme0ctc1kvw647g0)
+
+#### Input
+
+```json
+{
+  "top_p": 0.95,
+  "images": [],
+  "prompt": "describe this video",
+  "videos": [
+    "https://replicate.delivery/pbxt/O1TZsCqHFJPtCUxXmh6Qi4ptnGieu7UWpV5WKwlhYw9unnp6/replicate-prediction-fe1vrjn4pxrmc0ct9yprq3cf6w.mp4"
+  ],
+  "temperature": 1,
+  "dynamic_thinking": false,
+  "max_output_tokens": 65535
+}
+```
+
+#### Output
+
+```json
+[
+  "This video features a mesmerizing close-up of a soap bubble freezing in slow motion.\n\nInitially, a perfectly spherical, iridescent soap bubble floats centered in the frame, reflecting various rainbow colors \u2013 purples, blues, greens, and pinks \u2013 on its",
+  " surface. The background is dark and blurred, suggesting a cool or cold environment.\n\nAround the 0:02 mark, delicate, crystalline patterns begin to appear at the very bottom edge of the bubble. These patterns rapidly expand upwards and outwards across",
+  " the bubble's surface. They are intricate and resemble tiny snowflakes or fern fronds forming.\n\nAs the freezing progresses, the original shimmering iridescence of the bubble is gradually replaced by a frosty, opaque white texture. The ice crystals connect",
+  " and spread, creating a beautiful, detailed mosaic across the entire sphere.\n\nBy the end of the video, the bubble is completely frozen solid, transformed into a stunning, uniform white frosted orb, resembling a delicate miniature ice sculpture covered in intricate natural",
+  " patterns."
+]
+```
+
+
+## Model readme
+
+> # Gemini 2.5 Flash
+> 
+> Gemini 2.5 Flash is Google DeepMind’s cost-efficient, high-speed multimodal model designed for production workloads.  
+> It balances speed, reasoning, and controllable "thinking depth," making it ideal for developers who need performance at scale.
+> 
+> ---
+> 
+> ## Key Features
+> 
+> - **Multimodal Input**: Supports text, images, audio, and video as inputs.  
+> - **Long Context Handling**: Works with extremely long inputs (up to ~1 million tokens).  
+> - **Controllable Reasoning**: Developers can choose how much internal reasoning ("thinking") the model applies.  
+> - **Optimized for Speed & Cost**: Fast inference times with efficient compute usage.  
+> - **Flexible Output**: Generates text, captions, summaries, structured data, and more.
+

--- a/docs/replicate-models-docs/text/gpt-5.md
+++ b/docs/replicate-models-docs/text/gpt-5.md
@@ -1,0 +1,354 @@
+## Basic model info
+
+Model name: openai/gpt-5
+Model description: OpenAI's new model excelling at coding, writing, and reasoning.
+
+
+## Model inputs
+
+- prompt (optional): The prompt to send to the model. Do not use if using messages. (string)
+- system_prompt (optional): System prompt to set the assistant's behavior (string)
+- messages (optional): A JSON string representing a list of messages. For example: [{"role": "user", "content": "Hello, how are you?"}]. If provided, prompt and system_prompt are ignored. (array)
+- image_input (optional): List of images to send to the model (array)
+- reasoning_effort (optional): Constrains effort on reasoning for GPT-5 models. Currently supported values are minimal, low, medium, and high. The minimal value gets answers back faster without extensive reasoning first. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning). (string)
+- verbosity (optional): Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high. GPT-5 supports this parameter to help control whether answers are short and to the point or long and comprehensive. (string)
+- max_completion_tokens (optional): Maximum number of completion tokens to generate. For higher reasoning efforts you may need to increase your max_completion_tokens to avoid empty responses (where all the tokens are used on reasoning). (integer)
+
+
+## Model output schema
+
+{
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "title": "Output",
+  "x-cog-array-type": "iterator",
+  "x-cog-array-display": "concatenate"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/h9vsacmzg9rmc0crgr89xen3dm)
+
+#### Input
+
+```json
+{
+  "prompt": "Are you AGI?",
+  "image_input": [],
+  "reasoning_effort": "medium",
+  "max_completion_tokens": 4096
+}
+```
+
+#### Output
+
+```json
+[
+  "",
+  "Short",
+  " answer",
+  ":",
+  " No",
+  ".\n\n",
+  "I",
+  "\u2019m",
+  " a",
+  " large",
+  " language",
+  " model",
+  " (",
+  "Chat",
+  "GPT",
+  ")",
+  " \u2014",
+  " powerful",
+  " at",
+  " generating",
+  " and",
+  " reasoning",
+  " over",
+  " text",
+  " across",
+  " many",
+  " domains",
+  ",",
+  " but",
+  " not",
+  " an",
+  " autonomous",
+  " general",
+  " intelligence",
+  ".\n\n",
+  "Key",
+  " limits",
+  ":\n",
+  "-",
+  " No",
+  " consciousness",
+  ",",
+  " self",
+  "-awareness",
+  ",",
+  " or",
+  " feelings",
+  ".\n",
+  "-",
+  " No",
+  " self",
+  "-directed",
+  " goals",
+  " or",
+  " agency",
+  ";",
+  " I",
+  " act",
+  " only",
+  " on",
+  " user",
+  " prompts",
+  ".\n",
+  "-",
+  " No",
+  " persistent",
+  " memory",
+  " across",
+  " sessions",
+  ";",
+  " I",
+  " don",
+  "\u2019t",
+  " learn",
+  " on",
+  " my",
+  " own",
+  " after",
+  " training",
+  ".\n",
+  "-",
+  " Knowledge",
+  " is",
+  " static",
+  " up",
+  " to",
+  " October",
+  " ",
+  "202",
+  "4",
+  " and",
+  " can",
+  " be",
+  " incomplete",
+  " or",
+  " wrong",
+  ".\n",
+  "-",
+  " I",
+  " can",
+  "\u2019t",
+  " perceive",
+  " or",
+  " act",
+  " in",
+  " the",
+  " physical",
+  " world",
+  ".\n\n",
+  "If",
+  " you",
+  " tell",
+  " me",
+  " what",
+  " you",
+  "\u2019re",
+  " trying",
+  " to",
+  " do",
+  ",",
+  " I",
+  " can",
+  " say",
+  " whether",
+  " I",
+  "\u2019m",
+  " a",
+  " good",
+  " fit",
+  " and",
+  " help",
+  " accordingly",
+  ".",
+  "",
+  ""
+]
+```
+
+
+### Example (https://replicate.com/p/gcm040g0s5rm80crktgrjvz3b0)
+
+#### Input
+
+```json
+{
+  "prompt": "Are you AGI?",
+  "messages": [],
+  "verbosity": "medium",
+  "image_input": [],
+  "reasoning_effort": "minimal"
+}
+```
+
+#### Output
+
+```json
+[
+  "",
+  "No",
+  ".",
+  " I",
+  "\u2019m",
+  " a",
+  " narrow",
+  " AI",
+  " language",
+  " model",
+  ".",
+  " I",
+  " can",
+  " generate",
+  " and",
+  " reason",
+  " about",
+  " text",
+  " across",
+  " many",
+  " topics",
+  ",",
+  " but",
+  " I",
+  " don",
+  "\u2019t",
+  " have",
+  " general",
+  " human",
+  "-level",
+  " intelligence",
+  ",",
+  " self",
+  "-awareness",
+  ",",
+  " or",
+  " open",
+  "-ended",
+  " autonomy",
+  ".",
+  " My",
+  " abilities",
+  " are",
+  " bounded",
+  " by",
+  " my",
+  " training",
+  " data",
+  ",",
+  " design",
+  ",",
+  " and",
+  " the",
+  " information",
+  " you",
+  " provide",
+  " in",
+  " a",
+  " conversation",
+  "."
+]
+```
+
+
+## Model readme
+
+> GPT-5 is OpenAI's capable model to date, designed for advanced reasoning, code generation, instruction following, and tool use. This guide covers key features and how to get the most from the GPT-5 family.
+> 
+> **🧠 Model Variants**
+> 
+> gpt-5: Best for complex, multi-step tasks and rich world knowledge.
+> 
+> gpt-5-mini: Balanced speed and cost, ideal for chat and medium-difficulty reasoning.
+> 
+> gpt-5-nano: Lightweight, great for fast, simple tasks like classification.
+> 
+> **🔧 Key Features**
+> 
+> Reasoning Effort
+> Control how deeply the model thinks before responding.
+> 
+> minimal: Fastest; good for coding and clear instructions.
+> 
+> medium (default): Balanced.
+> 
+> high: Most thorough.
+> 
+> Prompt tip: For minimal, ask the model to "think step-by-step" to improve quality.
+> 
+> **Verbosity**
+> 
+> Control how much the model says.
+> 
+> low: Concise answers/code (e.g., SQL queries).
+> 
+> medium: Default.
+> 
+> high: Detailed explanations or refactoring.
+> 
+> **Custom Tools**
+> 
+> Define tools with freeform text input (code, SQL, etc.). Use grammars (CFGs) to constrain output to specific formats. Always validate inputs/outputs.
+> 
+> **Allowed Tools**
+> 
+> Control which tools the model can or must use via allowed_tools. Helps with safety, predictability, and caching.
+> 
+> **Preambles**
+> 
+> Ask the model to explain tool usage decisions before invoking them. Improves transparency and debugging.
+> 
+> **🔄 Migration Tips**
+> 
+> From older models: Use gpt-5 for o3 and gpt-4.1 tasks. Start with medium or minimal reasoning depending on complexity.
+> 
+> From Chat Completions: Switch to the Responses API to support reasoning carryover (CoT). This improves latency and cache hits.
+> 
+> **💻 Best Practices**
+> 
+> Coding
+> Define the model’s role clearly.
+> 
+> Require testing/validation for generated code.
+> 
+> Use examples for tool usage.
+> 
+> Guide formatting with Markdown standards.
+> 
+> **Frontend Development**
+> 
+> Supports Tailwind, shadcn/ui, Radix Themes, Lucide icons, Motion.
+> 
+> Use detailed prompts for better UI/UX, structure, and integration.
+> 
+> **Agentic Tasks**
+> 
+> Ask GPT-5 to break down tasks and persist until fully resolved.
+> 
+> Use preambles and TODO tools to improve planning and completeness.
+> 
+> **🧩 Reasoning Tokens**
+> 
+> GPT-5 retains and reuses reasoning across turns for improved performance. With ZDR or store=false, encrypted reasoning is supported for secure reuse.
+

--- a/docs/replicate-models-docs/video/p-video.md
+++ b/docs/replicate-models-docs/video/p-video.md
@@ -1,0 +1,204 @@
+## Basic model info
+
+Model name: prunaai/p-video
+Model description: Fast video generation with built-in draft mode for rapid creative iteration. Text-to-video, image-to-video, and audio-to-video in a single endpoint.
+
+
+## Model inputs
+
+- prompt (required): Text prompt for video generation. (string)
+- image (optional): Input image to generate video from (image-to-video). Supports jpg, jpeg, png, webp. (string)
+- last_frame_image (optional): Reference image for the last frame of the video. Supports jpg, jpeg, png, webp. (string)
+- audio (optional): Input audio to condition video generation. Supports flac, mp3, wav. (string)
+- duration (optional): Duration of the video in seconds (1-20). Ignored when audio is provided. (integer)
+- aspect_ratio (optional): Aspect ratio of the video. Ignored when an input image is provided. (string)
+- resolution (optional): Resolution of the video. (string)
+- fps (optional): Frames per second of the video. (integer)
+- draft (optional): Draft mode. Generates a lower-quality preview of the video. (boolean)
+- prompt_upsampling (optional): Use prompt upsampling to enhance the prompt. (boolean)
+- disable_safety_filter (optional): Disable safety filter for prompts (and input image). When disabled, prompts are not checked for unsafe content before generation. (boolean)
+- save_audio (optional): Save the video with audio. (boolean)
+- seed (optional): Random seed. Set for reproducible generation. (integer)
+- no_op (optional): Health check mode - returns status without inference. (boolean)
+
+
+## Model output schema
+
+{
+  "type": "string",
+  "title": "Output",
+  "format": "uri"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/mw0dgpeddxrmr0cwk7t9rzjtjm)
+
+#### Input
+
+```json
+{
+  "fps": 24,
+  "audio": "https://replicate.delivery/pbxt/Nw6ta10DEp6Q1RMCjtGBosVhDah8fN0JulfN95bBonZ1DiCx/replicate-prediction-gpnzzkjeghrme0ct2a59v9h038.wav",
+  "draft": false,
+  "image": "https://replicate.delivery/pbxt/Nw6tZuQCrJRv1wgMAkQaJhlNQJNLRX60UKJBrzCYW5RvmShk/replicate-prediction-vkwqkpxagnrm80ct2a4b0bye7g.webp",
+  "prompt": "A woman sings and strums her guitar",
+  "duration": 5,
+  "resolution": "720p",
+  "save_audio": true,
+  "aspect_ratio": "16:9",
+  "prompt_upsampling": true,
+  "disable_safety_filter": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/NYfH3gIkhnRgNybQFJJVLfiKk2USVQgl69J9s13Moev5FetYB/output.mp4"
+```
+
+
+### Example (https://replicate.com/p/m7b5n1sxndrmw0cwk7w8s9gz5m)
+
+#### Input
+
+```json
+{
+  "fps": 24,
+  "draft": false,
+  "image": "https://replicate.delivery/pbxt/OXkJpAQAIbwcBCpqV5USf14PGOhQpTzdTdtl2yhrrBqqde5E/replicate-prediction-px6n3hq8zhrmr0cw6jasjwafew.jpg",
+  "prompt": "the camera zooms in on to the man as he lifts both arms up in celebration",
+  "duration": 5,
+  "resolution": "720p",
+  "save_audio": true,
+  "aspect_ratio": "16:9",
+  "prompt_upsampling": true,
+  "disable_safety_filter": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/z2jCOh0Rbw4sHBlZZR5AZSonE6WbM3fbMFAkPMRVVf9bGfWsA/output.mp4"
+```
+
+
+### Example (https://replicate.com/p/6p0efnaywsrmt0cx056bk4wne8)
+
+#### Input
+
+```json
+{
+  "fps": 24,
+  "draft": false,
+  "image": "https://replicate.delivery/pbxt/OejQrIXERvqS9kpygH9PfQZDOIdzkD6GKytAXxedNSyyRtej/9.png",
+  "prompt": "The prune says \"And this, kids, is how you generate a video in less than 10 seconds\".",
+  "duration": 5,
+  "resolution": "720p",
+  "save_audio": true,
+  "aspect_ratio": "16:9",
+  "prompt_upsampling": false,
+  "disable_safety_filter": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/SMhKj9PDteyILCENXNH1dO1GDXuPGpkSeVpkmIaA3wISVGSWA/output.mp4"
+```
+
+
+### Example (https://replicate.com/p/jmc9cpgwxsrmw0cx1e6bew4fsc)
+
+#### Input
+
+```json
+{
+  "fps": 24,
+  "draft": false,
+  "image": "https://replicate.delivery/pbxt/OejQrIXERvqS9kpygH9PfQZDOIdzkD6GKytAXxedNSyyRtej/9.png",
+  "no_op": false,
+  "prompt": "The prune says \"And this, kids, is how you generate a video in less than 10 seconds\".",
+  "duration": 5,
+  "resolution": "720p",
+  "save_audio": true,
+  "aspect_ratio": "16:9",
+  "prompt_upsampling": false,
+  "disable_safety_filter": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/pyaeIfrebUZZpowThXDgjyaS98rlFKiuOtlbfpb3i4P7PBLZB/output.mp4"
+```
+
+
+## Model readme
+
+> # P-Video
+> 
+> P-Video is Pruna AI's video generation model built for speed and creative iteration. It generates a 5-second 720p video in about 10 seconds, and includes a draft mode that's 4× faster for quick previews before committing to a full render.
+> 
+> ## Features
+> 
+> - **All-in-one endpoint** — text-to-video, image-to-video, and audio-to-video
+> - **Draft mode** — 4× faster previews for rapid iteration
+> - **Built-in audio generation** — native dialogue and sound, plus custom audio import
+> - **Up to 1080p at 48 FPS**
+> - **Multi-aspect ratio support** — 16:9, 9:16, 4:3, 3:4, 3:2, 2:3, 1:1
+> - **Prompt upsampling** — automatic prompt enhancement with full user control
+> 
+> ## Pricing
+> 
+> |  | Draft OFF | Draft ON |
+> |---|---|---|
+> | **720p** | $0.02/sec | $0.005/sec |
+> | **1080p** | $0.04/sec | $0.01/sec |
+> 
+> ## Inputs
+> 
+> - **prompt** (required) — text description of the video you want to generate
+> - **image** — input image for image-to-video generation (jpg, jpeg, png, webp)
+> - **audio** — input audio to condition video generation (flac, mp3, wav)
+> - **duration** — video length in seconds, 1–10 (default: 5). Ignored when audio is provided
+> - **aspect_ratio** — 16:9, 9:16, 4:3, 3:4, 3:2, 2:3, or 1:1 (default: 16:9). Ignored when an input image is provided
+> - **resolution** — 720p or 1080p (default: 720p)
+> - **fps** — 24 or 48 frames per second (default: 24)
+> - **draft** — enable draft mode for faster, lower-quality previews (default: false)
+> - **prompt_upsampling** — enhance the prompt automatically (default: true)
+> - **seed** — set for reproducible generation
+> 
+> ## What it's good at
+> 
+> - **Talking avatars and lip sync** — strong input-image consistency with reliable lip synchronization and native dialogue generation
+> - **Close-up subjects** — particularly strong with foreground objects and close-up shots
+> - **Product animation** — turn static product images into animated videos
+> - **Social ads and short-form content** — fast iteration with multi-resolution output
+> - **Music videos** — combine your own audio with generated visuals
+> - **Animating low-resolution assets** — effective at bringing low-res images to life
+> 
+> ## Tips
+> 
+> - **Use draft mode for iteration.** Start with draft mode on to quickly explore different prompts and compositions, then switch it off for the final render.
+> - **Vertical formats may work better at 1080p and 48 FPS.**
+> - **Try different resolutions and FPS settings.** Output quality can vary depending on the combination of resolution, FPS, and input framing.
+> - **Light prompt refinement helps.** Like any generative model, a short experimentation phase with your prompts will get better results.
+> 
+> ## Limitations
+> 
+> - Not designed for extreme cinematic camera motion or complex multi-scene storytelling
+> - No native 4K output
+> - Sound effects (SFX) performance is limited — for premium voice realism or advanced sound design, dedicated audio providers can deliver higher fidelity, and their output can be used as audio input to P-Video
+> - Above two speakers, speaker separation can degrade
+> - Speaker attribution drift can occur (e.g., one voice delivering multiple lines)
+

--- a/e2e/generator-models.spec.js
+++ b/e2e/generator-models.spec.js
@@ -44,7 +44,8 @@ test.describe('Generator Model Selection', () => {
   })
 
   test('Image → ImageGenerator with Seedream-4', async ({ page }) => {
-    await mockSeedream4(page)
+    let received = null
+    await mockSeedream4(page, { assertRequest: (body) => { received = body.input } })
 
     await setupBlankCanvas(page)
     await addNodeFromSidebar(page, 'Image')
@@ -74,10 +75,15 @@ test.describe('Generator Model Selection', () => {
 
     await expect(imageGenNode.locator('.image-preview img')).toBeVisible({ timeout: 15000 })
     await expect(imageGenNode.locator('.image-preview img')).toHaveAttribute('src', FAKE_GENERATED_IMAGE)
+
+    // The node shows one image, so it must never pay for a batch
+    expect(received.max_images).toBe(1)
+    expect(received.sequential_image_generation).toBe('disabled')
   })
 
   test('Prompt → ImageGenerator with GPT Image 1', async ({ page }) => {
-    await mockGptImage1(page)
+    let received = null
+    await mockGptImage1(page, { assertRequest: (body) => { received = body.input } })
 
     await setupBlankCanvas(page)
     await addNodeFromSidebar(page, 'Prompt')
@@ -111,5 +117,33 @@ test.describe('Generator Model Selection', () => {
 
     await expect(imageGenNode.locator('.image-preview img')).toBeVisible({ timeout: 15000 })
     await expect(imageGenNode.locator('.image-preview img')).toHaveAttribute('src', FAKE_GENERATED_IMAGE)
+
+    // The node shows one image, so it must never pay for a batch
+    expect(received.number_of_images).toBe(1)
+  })
+
+  test('a saved flow cannot ask for more than one image', async ({ page }) => {
+    let received = null
+    await mockGptImage1(page, { assertRequest: (body) => { received = body.input } })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    const imageGenNode = page.locator('.vue-flow__node-image-generator')
+    await positionNodes(page, [{ type: 'image-generator', x: 300, y: 200 }])
+    await selectModel(page, imageGenNode, 'gpt-image-1')
+
+    // A JSON written before the option was pulled, or edited by hand
+    await page.evaluate(() => {
+      const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+      const node = pinia._s.get('flow').nodes.find(n => n.type === 'image-generator')
+      node.data.params = { ...node.data.params, number_of_images: 5 }
+    })
+
+    await imageGenNode.locator('textarea').fill('a golden sunset over the ocean')
+    await imageGenNode.getByRole('button', { name: 'Generate Image' }).click()
+
+    await expect(imageGenNode.locator('.image-preview img')).toBeVisible({ timeout: 15000 })
+    expect(received.number_of_images).toBe(1)
   })
 })

--- a/e2e/node-options-panel.spec.js
+++ b/e2e/node-options-panel.spec.js
@@ -1,0 +1,199 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+} from './helpers/canvas.js'
+
+const MORE_OPTIONS_BUTTON = 'button[title="More options"]'
+const PANEL = '.node-options-panel'
+
+/**
+ * Select a generator node so its toolbar shows up.
+ * Clicking the prompt textarea would not select it (it stops mousedown), so the
+ * click lands near the top of the node, on the preview area
+ */
+async function selectNode(page, nodeLocator) {
+  const box = await nodeLocator.boundingBox()
+  if (!box) throw new Error('selectNode: node has no bounding box')
+
+  await page.mouse.click(box.x + box.width / 2, box.y + 30)
+  await page.locator('#model-select').waitFor({ state: 'visible', timeout: 5000 })
+}
+
+/**
+ * Read a node from the Pinia store by type.
+ */
+async function readNode(page, type) {
+  return page.evaluate((nodeType) => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    const node = flowStore.nodes.find(n => n.type === nodeType)
+    if (!node) return null
+
+    return {
+      id: node.id,
+      model: node.data.model,
+      params: JSON.parse(JSON.stringify(node.data.params || {})),
+      position: { ...node.position },
+    }
+  }, type)
+}
+
+/**
+ * Drop a Video Generator on the canvas and open its options panel.
+ */
+async function openVideoPanel(page) {
+  await setupBlankCanvas(page)
+  await addNodeFromSidebar(page, 'Video Generator')
+
+  const videoNode = page.locator('.vue-flow__node-video-generator')
+  await positionNodes(page, [{ type: 'video-generator', x: 320, y: 260 }])
+
+  await selectNode(page, videoNode)
+  await page.locator(MORE_OPTIONS_BUTTON).click()
+  await expect(page.locator(PANEL)).toBeVisible()
+
+  return videoNode
+}
+
+test.describe('Node options panel', () => {
+  test('opens from the toolbar, docked to the right edge', async ({ page }) => {
+    await openVideoPanel(page)
+
+    const panel = page.locator('.flora-side-panel')
+    const box = await panel.boundingBox()
+    const viewport = page.viewportSize()
+
+    // Flush against the right edge and running the full height
+    expect(Math.round(box.x + box.width)).toBe(viewport.width)
+    expect(Math.round(box.height)).toBe(viewport.height)
+
+    // The model's secondary options are the ones on show
+    await expect(page.locator('#panel-control-draft')).toBeVisible()
+    await expect(page.locator('#panel-control-seed')).toBeVisible()
+    await expect(page.locator('#panel-control-prompt_upsampling')).toBeVisible()
+    await expect(page.locator('#panel-control-save_audio')).toBeVisible()
+  })
+
+  test('moves Draft out of the toolbar and into the panel', async ({ page }) => {
+    await openVideoPanel(page)
+
+    await expect(page.locator('#control-draft')).toHaveCount(0)
+    await expect(page.locator('#panel-control-draft')).toBeVisible()
+
+    // The primary controls stay where they were
+    await expect(page.locator('#control-duration')).toBeVisible()
+    await expect(page.locator('#control-fps')).toBeVisible()
+  })
+
+  test('closes with the close button', async ({ page }) => {
+    await openVideoPanel(page)
+
+    await page.locator('.side-panel-close').click()
+    await expect(page.locator(PANEL)).toBeHidden()
+
+    // Closing the panel does not deselect the node, so the toolbar stays
+    await expect(page.locator('#model-select')).toBeVisible()
+  })
+
+  test('closes when the node is deselected', async ({ page }) => {
+    await openVideoPanel(page)
+
+    // Empty canvas: away from the left dock and from the panel itself
+    await page.mouse.click(700, 620)
+    await expect(page.locator(PANEL)).toBeHidden()
+  })
+
+  test('closes when another node is selected', async ({ page }) => {
+    await openVideoPanel(page)
+
+    await addNodeFromSidebar(page, 'Prompt')
+    // Clear of the video node, of the panel on the right and of the left dock,
+    // any of which would swallow the click
+    await positionNodes(page, [{ type: 'prompt', x: 160, y: 600 }])
+
+    // The corner is padding: anywhere else on a Prompt node lands on the
+    // textarea or on the disabled send button, neither of which selects it
+    await page.locator('.vue-flow__node-prompt').click({ position: { x: 4, y: 4 } })
+
+    await expect(page.locator(PANEL)).toBeHidden()
+  })
+
+  test('closes when the node is deleted', async ({ page }) => {
+    await openVideoPanel(page)
+
+    await page.keyboard.press('Delete')
+
+    await expect(page.locator('.vue-flow__node-video-generator')).toHaveCount(0)
+    await expect(page.locator(PANEL)).toBeHidden()
+  })
+
+  test('writes the changed options into the node params', async ({ page }) => {
+    await openVideoPanel(page)
+
+    await page.locator('#panel-control-draft').check()
+    await page.locator('#panel-control-save_audio').uncheck()
+    await page.locator('#panel-control-seed').fill('1234')
+
+    const node = await readNode(page, 'video-generator')
+    expect(node.params.draft).toBe(true)
+    expect(node.params.save_audio).toBe(false)
+    // Numbers must not be stored as strings, or they reach the API as strings
+    expect(node.params.seed).toBe(1234)
+  })
+
+  test('leaves the canvas usable while it is open', async ({ page }) => {
+    const videoNode = await openVideoPanel(page)
+
+    const before = await readNode(page, 'video-generator')
+
+    const box = await videoNode.boundingBox()
+    await page.mouse.move(box.x + box.width / 2, box.y + 30)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width / 2 - 120, box.y + 90, { steps: 5 })
+    await page.mouse.up()
+    await page.waitForTimeout(200)
+
+    const after = await readNode(page, 'video-generator')
+    expect(after.position.x).not.toBe(before.position.x)
+
+    // Dragging keeps the node selected, so the panel is still up
+    await expect(page.locator(PANEL)).toBeVisible()
+  })
+
+  test('shows the options of a text model', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Text Generator')
+    await positionNodes(page, [{ type: 'text-generator', x: 320, y: 240 }])
+
+    const textNode = page.locator('.vue-flow__node-text-generator')
+    await selectNode(page, textNode)
+    await page.locator(MORE_OPTIONS_BUTTON).click()
+
+    await expect(page.locator(PANEL)).toBeVisible()
+    await expect(page.locator('#panel-control-system_prompt')).toBeVisible()
+
+    await page.locator('#panel-control-system_prompt').fill('Answer like a pirate')
+
+    const node = await readNode(page, 'text-generator')
+    expect(node.params.system_prompt).toBe('Answer like a pirate')
+  })
+
+  test('follows the model selected in the toolbar', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Text Generator')
+    await positionNodes(page, [{ type: 'text-generator', x: 320, y: 240 }])
+
+    const textNode = page.locator('.vue-flow__node-text-generator')
+    await selectNode(page, textNode)
+    await page.locator(MORE_OPTIONS_BUTTON).click()
+    await expect(page.locator('#panel-control-system_prompt')).toBeVisible()
+
+    // Gemini names the same idea differently, so the panel has to swap controls
+    await page.locator('#model-select').selectOption('gemini-2.5-flash')
+
+    await expect(page.locator('#panel-control-system_prompt')).toHaveCount(0)
+    await expect(page.locator('#panel-control-system_instruction')).toBeVisible()
+  })
+})

--- a/e2e/video-node.spec.js
+++ b/e2e/video-node.spec.js
@@ -132,10 +132,15 @@ test.describe('Video Generator Node', () => {
     await page.locator('#control-aspect_ratio').selectOption('9:16')
     await page.locator('#control-resolution').selectOption('1080p')
     await page.locator('#control-fps').selectOption('48')
-    await page.locator('#control-draft').check()
 
-    // Click away to dismiss the toolbar before using the node body
+    // Draft is a secondary option, so it lives in the side panel
+    await page.locator('button[title="More options"]').click()
+    await page.locator('#panel-control-draft').check()
+
+    // Click away to dismiss the toolbar before using the node body. It also
+    // deselects the node, which is what closes the panel
     await page.mouse.click(10, 10)
+    await expect(page.locator('.node-options-panel')).toBeHidden()
 
     await videoNode.locator('textarea').fill('a vertical clip of falling confetti')
     await videoNode.getByRole('button', { name: 'Generate Video' }).click()

--- a/src/components/canvas/NodeOptionsPanel.vue
+++ b/src/components/canvas/NodeOptionsPanel.vue
@@ -1,0 +1,117 @@
+<template>
+  <BaseSidePanel
+    :model-value="true"
+    :title="panelTitle"
+    :subtitle="modelLabel"
+    @close="closePanelOfType(PANEL_TYPES.NODE_OPTIONS)"
+  >
+    <div class="node-options-panel">
+      <div v-if="controls.length" class="node-options-list">
+        <ModelControl
+          v-for="control in controls"
+          :key="control.key"
+          :control="control"
+          :model-value="getParamValue(control.key)"
+          id-prefix="panel-control"
+          @change="onParamChange"
+        />
+      </div>
+
+      <p v-else class="node-options-empty">
+        This model has no extra options.
+      </p>
+    </div>
+  </BaseSidePanel>
+</template>
+
+<script setup>
+import { computed, watch } from 'vue'
+import { useVueFlow } from '@vue-flow/core'
+import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
+import BaseSidePanel from '@/components/ui/BaseSidePanel.vue'
+import ModelControl from '@/components/ui/ModelControl.vue'
+import replicateService from '@/services/replicate'
+
+/**
+ * Advanced model options for the node the panel was opened from.
+ *
+ * The toolbar above a node only fits a handful of controls, so every model
+ * declares the rest under `uiSchema.advancedControls` and they are rendered
+ * here. Values land in the same `data.params` the toolbar writes to.
+ */
+const props = defineProps({
+  nodeId: {
+    type: String,
+    required: true
+  }
+})
+
+const { findNode, updateNodeData, getSelectedNodes } = useVueFlow()
+const { closePanelOfType } = useSidePanel()
+
+/**
+ * Read through VueFlow rather than through the store: `selected` is only kept
+ * up to date on VueFlow's own node objects, and the panel lives and dies by it
+ */
+const targetNode = computed(() => findNode(props.nodeId))
+
+const currentModel = computed(() => targetNode.value?.data?.model || null)
+
+const uiSchema = computed(() => {
+  if (!currentModel.value) return null
+  return replicateService.getModelUiSchema(currentModel.value)
+})
+
+const controls = computed(() => uiSchema.value?.advancedControls || [])
+
+const modelLabel = computed(() => uiSchema.value?.label || currentModel.value || '')
+
+const panelTitle = computed(() => targetNode.value?.data?.label || 'Options')
+
+function getParamValue(key) {
+  return targetNode.value?.data?.params?.[key] ?? null
+}
+
+function onParamChange(key, value) {
+  const currentParams = targetNode.value?.data?.params || {}
+
+  updateNodeData(props.nodeId, {
+    params: {
+      ...currentParams,
+      [key]: value
+    }
+  })
+}
+
+/**
+ * The panel belongs to one node, so it goes away as soon as that node stops
+ * being the selected one. Covers deselecting, selecting a different node and
+ * deleting this one, which drops it out of the selection as well
+ */
+const isTargetSelected = computed(
+  () => getSelectedNodes.value.some(n => n.id === props.nodeId)
+)
+
+watch(isTargetSelected, (selected) => {
+  if (!selected) closePanelOfType(PANEL_TYPES.NODE_OPTIONS)
+})
+</script>
+
+<style scoped>
+.node-options-panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.node-options-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-4);
+}
+
+.node-options-empty {
+  margin: 0;
+  font-size: var(--flora-font-size-sm);
+  color: var(--flora-color-text-tertiary);
+}
+</style>

--- a/src/components/nodes/ImageGeneratorNode.vue
+++ b/src/components/nodes/ImageGeneratorNode.vue
@@ -76,6 +76,18 @@
           @change="onParamChange(control.key, $event.target.checked)"
         />
       </div>
+
+      <!-- The toolbar is one row and does not scale past a handful of
+           controls, so the rest of the model options live in a side panel -->
+      <button
+        v-if="advancedControls.length"
+        class="toolbar-more"
+        type="button"
+        title="More options"
+        @click="openPanel(PANEL_TYPES.NODE_OPTIONS, { nodeId: id })"
+      >
+        ⋮
+      </button>
     </div>
   </NodeToolbar>
 
@@ -187,6 +199,7 @@ import { PORT_TYPES } from '@/lib/node-shapes'
 import nodeRegistry from '@/lib/node-registry'
 import { convertImageUrlToBase64, isHttpUrl } from '@/lib/image-utils'
 import { useWorkflowEvents } from '@/composables/useWorkflowEvents'
+import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
 
 const props = defineProps({
   id: {
@@ -284,6 +297,11 @@ const uiSchema = computed(() => {
 
 // Controls to render
 const controls = computed(() => uiSchema.value?.controls || [])
+
+// Model options that go to the side panel instead of the toolbar
+const advancedControls = computed(() => uiSchema.value?.advancedControls || [])
+
+const { openPanel } = useSidePanel()
 
 // Get model label from uiSchema
 function getModelLabel(modelId) {
@@ -578,6 +596,31 @@ async function handleGenerate() {
   flex-direction: column;
   gap: var(--flora-space-1);
   min-width: 120px;
+}
+
+/* Pushed to the far right, and kept there even when the toolbar wraps */
+.toolbar-more {
+  margin-left: auto;
+  align-self: center;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--flora-radius-md);
+  cursor: pointer;
+  font-size: var(--flora-font-size-lg);
+  line-height: 1;
+  color: var(--flora-color-text-secondary);
+  transition: all var(--flora-transition-fast);
+  padding: 0;
+}
+
+.toolbar-more:hover {
+  background: var(--flora-color-bg-secondary);
+  color: var(--flora-color-text-primary);
 }
 
 /* Image Preview Modal */

--- a/src/components/nodes/TextGeneratorNode.vue
+++ b/src/components/nodes/TextGeneratorNode.vue
@@ -62,6 +62,18 @@
             @change="onParamChange(control.key, $event.target.checked)"
           />
         </div>
+
+        <!-- The toolbar is one row and does not scale past a handful of
+             controls, so the rest of the model options live in a side panel -->
+        <button
+          v-if="advancedControls.length"
+          class="toolbar-more"
+          type="button"
+          title="More options"
+          @click="openPanel(PANEL_TYPES.NODE_OPTIONS, { nodeId: id })"
+        >
+          ⋮
+        </button>
       </div>
     </NodeToolbar>
 
@@ -160,6 +172,7 @@ import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
 import nodeRegistry from '@/lib/node-registry'
 import { useWorkflowEvents } from '@/composables/useWorkflowEvents'
+import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
 
 const props = defineProps({
   id: { type: String, required: true },
@@ -193,6 +206,14 @@ const controls = computed(() => {
   const uiSchema = replicateService.getModelUiSchema(currentModel.value)
   return uiSchema ? uiSchema.controls : []
 })
+
+// Model options that go to the side panel instead of the toolbar
+const advancedControls = computed(() => {
+  const uiSchema = replicateService.getModelUiSchema(currentModel.value)
+  return uiSchema?.advancedControls || []
+})
+
+const { openPanel } = useSidePanel()
 
 // Get connected images from incoming edges (uses PORT_TYPE)
 const connectedImages = computed(() => {
@@ -343,6 +364,31 @@ async function handleGenerate() {
   flex-direction: column;
   gap: var(--flora-space-1);
   min-width: 120px;
+}
+
+/* Pushed to the far right, and kept there even when the toolbar wraps */
+.toolbar-more {
+  margin-left: auto;
+  align-self: center;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--flora-radius-md);
+  cursor: pointer;
+  font-size: var(--flora-font-size-lg);
+  line-height: 1;
+  color: var(--flora-color-text-secondary);
+  transition: all var(--flora-transition-fast);
+  padding: 0;
+}
+
+.toolbar-more:hover {
+  background: var(--flora-color-bg-secondary);
+  color: var(--flora-color-text-primary);
 }
 
 .text-generator-node-content {

--- a/src/components/nodes/VideoGeneratorNode.vue
+++ b/src/components/nodes/VideoGeneratorNode.vue
@@ -68,6 +68,18 @@
             @change="onParamChange(control.key, $event.target.checked)"
           />
         </div>
+
+        <!-- The toolbar is one row and does not scale past a handful of
+             controls, so the rest of the model options live in a side panel -->
+        <button
+          v-if="advancedControls.length"
+          class="toolbar-more"
+          type="button"
+          title="More options"
+          @click="openPanel(PANEL_TYPES.NODE_OPTIONS, { nodeId: id })"
+        >
+          ⋮
+        </button>
       </div>
     </NodeToolbar>
 
@@ -188,6 +200,7 @@ import { PORT_TYPES } from '@/lib/node-shapes'
 import nodeRegistry from '@/lib/node-registry'
 import { convertUrlToBase64, isHttpUrl } from '@/lib/image-utils'
 import { useWorkflowEvents } from '@/composables/useWorkflowEvents'
+import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
 
 const DEFAULT_MODEL = 'p-video'
 
@@ -302,6 +315,11 @@ const uiSchema = computed(() => {
 
 // Controls to render
 const controls = computed(() => uiSchema.value?.controls || [])
+
+// Model options that go to the side panel instead of the toolbar
+const advancedControls = computed(() => uiSchema.value?.advancedControls || [])
+
+const { openPanel } = useSidePanel()
 
 // Get model label from uiSchema
 function getModelLabel(modelId) {
@@ -601,6 +619,31 @@ async function handleGenerate() {
   flex-direction: column;
   gap: var(--flora-space-1);
   min-width: 120px;
+}
+
+/* Pushed to the far right, and kept there even when the toolbar wraps */
+.toolbar-more {
+  margin-left: auto;
+  align-self: center;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--flora-radius-md);
+  cursor: pointer;
+  font-size: var(--flora-font-size-lg);
+  line-height: 1;
+  color: var(--flora-color-text-secondary);
+  transition: all var(--flora-transition-fast);
+  padding: 0;
+}
+
+.toolbar-more:hover {
+  background: var(--flora-color-bg-secondary);
+  color: var(--flora-color-text-primary);
 }
 
 /* Video Preview Modal */

--- a/src/components/ui/BaseSidePanel.vue
+++ b/src/components/ui/BaseSidePanel.vue
@@ -1,0 +1,165 @@
+<template>
+  <Teleport to="body">
+    <Transition name="side-panel">
+      <aside
+        v-if="modelValue"
+        class="flora-side-panel"
+        :style="{ width: `${width}px` }"
+        role="complementary"
+      >
+        <!-- Header -->
+        <div class="flora-side-panel-header">
+          <slot name="header">
+            <div class="flora-side-panel-titles">
+              <h2 class="flora-side-panel-title">{{ title }}</h2>
+              <p v-if="subtitle" class="flora-side-panel-subtitle">{{ subtitle }}</p>
+            </div>
+          </slot>
+
+          <button
+            class="side-panel-close"
+            type="button"
+            aria-label="Close panel"
+            @click="close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <!-- Content -->
+        <div class="flora-side-panel-content">
+          <slot />
+        </div>
+      </aside>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+/**
+ * Panel docked to the right edge of the viewport.
+ *
+ * Deliberately not a BaseModal variant: there is no overlay, so the canvas
+ * stays interactive underneath. Panels that track a selection need that, or
+ * the user could never deselect while the panel is up.
+ */
+defineProps({
+  modelValue: {
+    type: Boolean,
+    required: true
+  },
+  title: {
+    type: String,
+    default: ''
+  },
+  subtitle: {
+    type: String,
+    default: ''
+  },
+  width: {
+    type: Number,
+    default: 360
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'close'])
+
+function close() {
+  emit('update:modelValue', false)
+  emit('close')
+}
+</script>
+
+<style scoped>
+.flora-side-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--flora-color-surface);
+  border-left: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+  box-shadow: var(--flora-shadow-xl);
+  /* Below BaseModal (1000): a modal opened on top of a panel must win */
+  z-index: 900;
+  max-width: 100vw;
+}
+
+.flora-side-panel-header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--flora-space-3);
+  padding: var(--flora-space-4) var(--flora-space-5);
+  border-bottom: var(--flora-border-width-thin) solid var(--flora-color-border-default);
+  flex-shrink: 0;
+}
+
+.flora-side-panel-titles {
+  flex: 1;
+  min-width: 0;
+}
+
+.flora-side-panel-title {
+  margin: 0;
+  font-size: var(--flora-font-size-lg);
+  font-weight: var(--flora-font-weight-semibold);
+  color: var(--flora-color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.flora-side-panel-subtitle {
+  margin: var(--flora-space-1) 0 0;
+  font-size: var(--flora-font-size-xs);
+  color: var(--flora-color-text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.side-panel-close {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--flora-radius-md);
+  cursor: pointer;
+  font-size: var(--flora-font-size-lg);
+  color: var(--flora-color-text-secondary);
+  transition: all var(--flora-transition-fast);
+  padding: 0;
+}
+
+.side-panel-close:hover {
+  background: var(--flora-color-bg-secondary);
+  color: var(--flora-color-text-primary);
+}
+
+.side-panel-close:active {
+  background: var(--flora-color-bg-tertiary);
+}
+
+.flora-side-panel-content {
+  padding: var(--flora-space-5);
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* Transitions */
+.side-panel-enter-active,
+.side-panel-leave-active {
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.side-panel-enter-from,
+.side-panel-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+}
+</style>

--- a/src/components/ui/ModelControl.vue
+++ b/src/components/ui/ModelControl.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="model-control">
+    <!-- Checkbox: it carries its own inline label, on the right of the box -->
+    <BaseCheckbox
+      v-if="control.type === 'checkbox'"
+      :id="controlId"
+      :model-value="!!value"
+      :label="control.label"
+      @change="emitValue($event.target.checked)"
+    />
+
+    <BaseLabel v-else :for="controlId">{{ control.label }}</BaseLabel>
+
+    <!-- Select -->
+    <BaseSelect
+      v-if="control.type === 'select'"
+      :id="controlId"
+      size="sm"
+      :model-value="value"
+      @change="emitValue(castSelect($event.target.value))"
+    >
+      <option
+        v-for="option in control.enum"
+        :key="option"
+        :value="option"
+      >
+        {{ option }}
+      </option>
+    </BaseSelect>
+
+    <!-- Multi-line text -->
+    <BaseTextarea
+      v-else-if="control.type === 'textarea'"
+      :id="controlId"
+      :model-value="value ?? ''"
+      :rows="control.rows || 4"
+      :placeholder="control.placeholder || ''"
+      @input="emitValue($event.target.value)"
+    />
+
+    <!-- Number -->
+    <BaseInput
+      v-else-if="control.type === 'number'"
+      :id="controlId"
+      type="number"
+      size="sm"
+      :model-value="value ?? ''"
+      :min="control.min"
+      :max="control.max"
+      :step="control.step"
+      :placeholder="control.placeholder || ''"
+      @input="emitValue(castNumber($event.target.value))"
+    />
+
+    <!-- Single-line text: the fallback for anything that is not a checkbox,
+         which was already rendered above with its own label -->
+    <BaseInput
+      v-else-if="control.type !== 'checkbox'"
+      :id="controlId"
+      type="text"
+      size="sm"
+      :model-value="value ?? ''"
+      :placeholder="control.placeholder || ''"
+      @input="emitValue($event.target.value)"
+    />
+
+    <p v-if="control.description" class="model-control-description">
+      {{ control.description }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import BaseLabel from '@/components/ui/BaseLabel.vue'
+import BaseSelect from '@/components/ui/BaseSelect.vue'
+import BaseInput from '@/components/ui/BaseInput.vue'
+import BaseTextarea from '@/components/ui/BaseTextarea.vue'
+import BaseCheckbox from '@/components/ui/BaseCheckbox.vue'
+
+/**
+ * Renders one uiSchema control descriptor, stacked label over field.
+ *
+ * The toolbars inside the generator nodes render the same descriptors inline;
+ * this component exists for the places that need a vertical layout and every
+ * control type in one go.
+ */
+const props = defineProps({
+  control: {
+    type: Object,
+    required: true
+  },
+  // Current param value. Null/undefined means "never set", so the control
+  // falls back to the default declared by the schema
+  modelValue: {
+    type: [String, Number, Boolean],
+    default: null
+  },
+  idPrefix: {
+    type: String,
+    default: 'control'
+  }
+})
+
+const emit = defineEmits(['change'])
+
+const controlId = computed(() => `${props.idPrefix}-${props.control.key}`)
+
+const value = computed(() => props.modelValue ?? props.control.default ?? null)
+
+function emitValue(next) {
+  emit('change', props.control.key, next)
+}
+
+/**
+ * Selects always hand back strings. Numeric enums (fps, for one) must stay
+ * numeric so the value survives serialization and reaches the API as a number
+ */
+function castSelect(raw) {
+  if (typeof props.control.default !== 'number') return raw
+
+  const parsed = Number(raw)
+  return Number.isNaN(parsed) ? raw : parsed
+}
+
+/**
+ * An empty field means "unset", not zero. A fractional step is what tells a
+ * float control (temperature) from an integer one (max tokens)
+ */
+function castNumber(raw) {
+  if (raw === '') return null
+
+  const step = props.control.step
+  const parsed = step && !Number.isInteger(step) ? parseFloat(raw) : parseInt(raw)
+  return Number.isNaN(parsed) ? null : parsed
+}
+</script>
+
+<style scoped>
+.model-control {
+  display: flex;
+  flex-direction: column;
+  gap: var(--flora-space-2);
+}
+
+.model-control-description {
+  margin: 0;
+  font-size: var(--flora-font-size-xs);
+  color: var(--flora-color-text-tertiary);
+  line-height: 1.4;
+}
+</style>

--- a/src/composables/useSidePanel.js
+++ b/src/composables/useSidePanel.js
@@ -1,0 +1,56 @@
+import { computed, ref } from 'vue'
+
+/**
+ * Side panel invocation, shared across the whole app.
+ *
+ * The state lives at module level on purpose: the panel is rendered by
+ * FlowCanvasView, but what opens it is a button inside a node, several
+ * components deep into VueFlow. Same trick the workflow event bus uses to let
+ * nodes talk to the canvas without prop drilling.
+ *
+ * Only one panel is open at a time; opening another one replaces it.
+ */
+
+/**
+ * Panels the canvas knows how to render. FlowCanvasView switches on these
+ */
+export const PANEL_TYPES = {
+  NODE_OPTIONS: 'node-options'
+}
+
+// { type: string, ...props } | null
+const activePanel = ref(null)
+
+export function useSidePanel() {
+  const isPanelOpen = computed(() => activePanel.value !== null)
+
+  /**
+   * @param {string} type - Panel to render, e.g. 'node-options'
+   * @param {Object} [props] - Payload the panel needs, e.g. { nodeId }
+   */
+  function openPanel(type, props = {}) {
+    activePanel.value = { type, ...props }
+  }
+
+  function closePanel() {
+    activePanel.value = null
+  }
+
+  /**
+   * Close only if the given panel type is the one on screen. Lets a panel shut
+   * itself down without stepping on whatever replaced it in the meantime
+   */
+  function closePanelOfType(type) {
+    if (activePanel.value?.type === type) {
+      activePanel.value = null
+    }
+  }
+
+  return {
+    activePanel,
+    isPanelOpen,
+    openPanel,
+    closePanel,
+    closePanelOfType
+  }
+}

--- a/src/services/models/gemini-2.5-flash.js
+++ b/src/services/models/gemini-2.5-flash.js
@@ -70,6 +70,21 @@ export const GEMINI_2_5_FLASH = {
         max: 24576,
         default: null
       }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'system_instruction',
+        label: 'System instruction',
+        type: 'textarea',
+        rows: 6,
+        default: '',
+        placeholder: 'Answer as a technical writer...',
+        description: 'Guides the behaviour of the model, on top of the prompt coming into the node'
+      }
     ]
   },
 

--- a/src/services/models/gemini-2.5-flash.js
+++ b/src/services/models/gemini-2.5-flash.js
@@ -47,28 +47,6 @@ export const GEMINI_2_5_FLASH = {
         max: 1,
         step: 0.05,
         default: 0.95
-      },
-      {
-        key: 'max_output_tokens',
-        label: 'Max Output Tokens',
-        type: 'number',
-        min: 1,
-        max: 65535,
-        default: 65535
-      },
-      {
-        key: 'dynamic_thinking',
-        label: 'Dynamic Thinking',
-        type: 'checkbox',
-        default: false
-      },
-      {
-        key: 'thinking_budget',
-        label: 'Thinking Budget',
-        type: 'number',
-        min: 0,
-        max: 24576,
-        default: null
       }
     ],
 
@@ -76,6 +54,31 @@ export const GEMINI_2_5_FLASH = {
      * Secondary options, rendered in the node options side panel
      */
     advancedControls: [
+      {
+        key: 'max_output_tokens',
+        label: 'Max output tokens',
+        type: 'number',
+        min: 1,
+        max: 65535,
+        default: 65535
+      },
+      {
+        key: 'dynamic_thinking',
+        label: 'Dynamic thinking',
+        type: 'checkbox',
+        default: false,
+        description: 'Let the model size its own reasoning budget, overriding the one below'
+      },
+      {
+        key: 'thinking_budget',
+        label: 'Thinking budget',
+        type: 'number',
+        min: 0,
+        max: 24576,
+        default: null,
+        placeholder: 'Model default',
+        description: 'Ignored while dynamic thinking is on. Set it to 0 to disable reasoning'
+      },
       {
         key: 'system_instruction',
         label: 'System instruction',

--- a/src/services/models/gpt-5.js
+++ b/src/services/models/gpt-5.js
@@ -40,14 +40,6 @@ export const GPT_5 = {
         type: 'select',
         enum: ['low', 'medium', 'high'],
         default: 'medium'
-      },
-      {
-        key: 'max_completion_tokens',
-        label: 'Max Tokens',
-        type: 'number',
-        min: 1,
-        max: 100000,
-        default: null
       }
     ],
 
@@ -55,6 +47,16 @@ export const GPT_5 = {
      * Secondary options, rendered in the node options side panel
      */
     advancedControls: [
+      {
+        key: 'max_completion_tokens',
+        label: 'Max tokens',
+        type: 'number',
+        min: 1,
+        max: 100000,
+        default: null,
+        placeholder: 'Model default',
+        description: 'A high reasoning effort may need a higher cap, or the answer comes back empty'
+      },
       {
         key: 'system_prompt',
         label: 'System prompt',

--- a/src/services/models/gpt-5.js
+++ b/src/services/models/gpt-5.js
@@ -49,6 +49,21 @@ export const GPT_5 = {
         max: 100000,
         default: null
       }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'system_prompt',
+        label: 'System prompt',
+        type: 'textarea',
+        rows: 6,
+        default: '',
+        placeholder: 'You are a helpful assistant...',
+        description: 'Sets how the assistant behaves, on top of the prompt coming into the node'
+      }
     ]
   },
 

--- a/src/services/models/gpt-image-1.js
+++ b/src/services/models/gpt-image-1.js
@@ -15,6 +15,10 @@ export const GPT_IMAGE_1 = {
 
   /**
    * Default parameters for the model
+   *
+   * `number_of_images` is fixed at 1 and is not exposed anywhere in the UI: an
+   * Image Generator node renders a single output, so any extra image would be
+   * billed and then dropped on the floor
    */
   defaults: {
     aspect_ratio: '1:1',
@@ -55,13 +59,6 @@ export const GPT_IMAGE_1 = {
         type: 'select',
         enum: ['low', 'high'],
         default: 'low'
-      },
-      {
-        key: 'background',
-        label: 'Background',
-        type: 'select',
-        enum: ['auto', 'transparent', 'opaque'],
-        default: 'auto'
       }
     ],
 
@@ -70,13 +67,12 @@ export const GPT_IMAGE_1 = {
      */
     advancedControls: [
       {
-        key: 'number_of_images',
-        label: 'Number of images',
-        type: 'number',
-        min: 1,
-        max: 10,
-        default: 1,
-        description: 'The node shows the first one; the rest come back in the same response'
+        key: 'background',
+        label: 'Background',
+        type: 'select',
+        enum: ['auto', 'transparent', 'opaque'],
+        default: 'auto',
+        description: 'A transparent background needs an output format that supports it'
       },
       {
         key: 'output_format',
@@ -153,7 +149,8 @@ export const GPT_IMAGE_1 = {
       openai_api_key: openaiApiKey,
       aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
       input_fidelity: params.input_fidelity || this.defaults.input_fidelity,
-      number_of_images: params.number_of_images || this.defaults.number_of_images,
+      // Always 1: the node has room for a single image, see `defaults`
+      number_of_images: this.defaults.number_of_images,
       quality: params.quality || this.defaults.quality,
       background: params.background || this.defaults.background,
       output_compression: params.output_compression || this.defaults.output_compression,
@@ -206,14 +203,6 @@ export const GPT_IMAGE_1 = {
       throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
     }
 
-    if (params.number_of_images !== undefined) {
-      const num = parseInt(params.number_of_images)
-      if (isNaN(num) || num < 1 || num > 10) {
-        throw new Error('number_of_images must be between 1 and 10')
-      }
-      validated.number_of_images = num
-    }
-
     if (params.output_compression !== undefined) {
       const comp = parseInt(params.output_compression)
       if (isNaN(comp) || comp < 0 || comp > 100) {
@@ -229,7 +218,7 @@ export const GPT_IMAGE_1 = {
       input_fidelity: params.input_fidelity,
       moderation: params.moderation,
       output_format: params.output_format,
-      number_of_images: validated.number_of_images,
+      // number_of_images is deliberately dropped: buildInput always sends 1
       output_compression: validated.output_compression,
       user_id: params.user_id
     }

--- a/src/services/models/gpt-image-1.js
+++ b/src/services/models/gpt-image-1.js
@@ -63,6 +63,53 @@ export const GPT_IMAGE_1 = {
         enum: ['auto', 'transparent', 'opaque'],
         default: 'auto'
       }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'number_of_images',
+        label: 'Number of images',
+        type: 'number',
+        min: 1,
+        max: 10,
+        default: 1,
+        description: 'The node shows the first one; the rest come back in the same response'
+      },
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['webp', 'png', 'jpeg'],
+        default: 'webp'
+      },
+      {
+        key: 'output_compression',
+        label: 'Output compression',
+        type: 'number',
+        min: 0,
+        max: 100,
+        default: 90,
+        description: 'Compression level as a percentage'
+      },
+      {
+        key: 'moderation',
+        label: 'Moderation',
+        type: 'select',
+        enum: ['auto', 'low'],
+        default: 'auto',
+        description: 'Content moderation level applied by OpenAI'
+      },
+      {
+        key: 'user_id',
+        label: 'User id',
+        type: 'text',
+        default: '',
+        placeholder: 'Optional',
+        description: 'Identifier for your end user, so OpenAI can trace abuse back to them'
+      }
     ]
   },
 

--- a/src/services/models/gpt-image-2.js
+++ b/src/services/models/gpt-image-2.js
@@ -15,6 +15,10 @@ export const GPT_IMAGE_2 = {
 
   /**
    * Default parameters for the model
+   *
+   * `number_of_images` is fixed at 1 and is not exposed anywhere in the UI: an
+   * Image Generator node renders a single output, so any extra image would be
+   * billed and then dropped on the floor
    */
   defaults: {
     aspect_ratio: '1:1',
@@ -49,13 +53,6 @@ export const GPT_IMAGE_2 = {
         default: 'auto'
       },
       {
-        key: 'background',
-        label: 'Background',
-        type: 'select',
-        enum: ['auto', 'transparent', 'opaque'],
-        default: 'auto'
-      },
-      {
         key: 'output_format',
         label: 'Output Format',
         type: 'select',
@@ -69,13 +66,12 @@ export const GPT_IMAGE_2 = {
      */
     advancedControls: [
       {
-        key: 'number_of_images',
-        label: 'Number of images',
-        type: 'number',
-        min: 1,
-        max: 10,
-        default: 1,
-        description: 'The node shows the first one; the rest come back in the same response'
+        key: 'background',
+        label: 'Background',
+        type: 'select',
+        enum: ['auto', 'transparent', 'opaque'],
+        default: 'auto',
+        description: 'A transparent background needs an output format that supports it'
       },
       {
         key: 'output_compression',
@@ -134,7 +130,8 @@ export const GPT_IMAGE_2 = {
     const input = {
       prompt: prompt.trim(),
       aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
-      number_of_images: params.number_of_images || this.defaults.number_of_images,
+      // Always 1: the node has room for a single image, see `defaults`
+      number_of_images: this.defaults.number_of_images,
       quality: params.quality || this.defaults.quality,
       background: params.background || this.defaults.background,
       output_compression: params.output_compression || this.defaults.output_compression,
@@ -192,14 +189,6 @@ export const GPT_IMAGE_2 = {
       throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
     }
 
-    if (params.number_of_images !== undefined) {
-      const num = parseInt(params.number_of_images)
-      if (isNaN(num) || num < 1 || num > 10) {
-        throw new Error('number_of_images must be between 1 and 10')
-      }
-      validated.number_of_images = num
-    }
-
     if (params.output_compression !== undefined) {
       const comp = parseInt(params.output_compression)
       if (isNaN(comp) || comp < 0 || comp > 100) {
@@ -214,7 +203,7 @@ export const GPT_IMAGE_2 = {
       background: params.background,
       moderation: params.moderation,
       output_format: params.output_format,
-      number_of_images: validated.number_of_images,
+      // number_of_images is deliberately dropped: buildInput always sends 1
       output_compression: validated.output_compression,
       user_id: params.user_id
     }

--- a/src/services/models/gpt-image-2.js
+++ b/src/services/models/gpt-image-2.js
@@ -62,6 +62,46 @@ export const GPT_IMAGE_2 = {
         enum: ['webp', 'png', 'jpeg'],
         default: 'webp'
       }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'number_of_images',
+        label: 'Number of images',
+        type: 'number',
+        min: 1,
+        max: 10,
+        default: 1,
+        description: 'The node shows the first one; the rest come back in the same response'
+      },
+      {
+        key: 'output_compression',
+        label: 'Output compression',
+        type: 'number',
+        min: 0,
+        max: 100,
+        default: 90,
+        description: 'Compression level as a percentage'
+      },
+      {
+        key: 'moderation',
+        label: 'Moderation',
+        type: 'select',
+        enum: ['auto', 'low'],
+        default: 'auto',
+        description: 'Content moderation level applied by OpenAI'
+      },
+      {
+        key: 'user_id',
+        label: 'User id',
+        type: 'text',
+        default: '',
+        placeholder: 'Optional',
+        description: 'Identifier for your end user, so OpenAI can trace abuse back to them'
+      }
     ]
   },
 

--- a/src/services/models/nano-banana-pro.js
+++ b/src/services/models/nano-banana-pro.js
@@ -47,6 +47,31 @@ export const NANO_BANANA_PRO = {
         enum: ['1K', '2K', '4K'],
         default: '2K'
       }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['png', 'jpg'],
+        default: 'png'
+      },
+      {
+        key: 'safety_filter_level',
+        label: 'Safety filter level',
+        type: 'select',
+        enum: [
+          'block_low_and_above',
+          'block_medium_and_above',
+          'block_only_high'
+        ],
+        default: 'block_only_high',
+        description: 'How strict the model is about blocking unsafe generations'
+      }
     ]
   },
 

--- a/src/services/models/p-video.js
+++ b/src/services/models/p-video.js
@@ -60,12 +60,41 @@ export const P_VIDEO = {
         type: 'select',
         enum: [24, 48],
         default: 24
-      },
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
       {
         key: 'draft',
-        label: 'Draft',
+        label: 'Draft mode',
         type: 'checkbox',
-        default: false
+        default: false,
+        description: 'Lower quality preview, around 4x faster and cheaper. Handy while iterating on a prompt'
+      },
+      {
+        key: 'prompt_upsampling',
+        label: 'Prompt upsampling',
+        type: 'checkbox',
+        default: true,
+        description: 'Let the model rewrite the prompt to enhance it'
+      },
+      {
+        key: 'save_audio',
+        label: 'Save audio',
+        type: 'checkbox',
+        default: true,
+        description: 'Keep the generated audio track in the video'
+      },
+      {
+        key: 'seed',
+        label: 'Seed',
+        type: 'number',
+        default: null,
+        placeholder: 'Random',
+        description: 'Fix it to reproduce the same generation twice'
       }
     ]
   },

--- a/src/services/models/seedream-4.js
+++ b/src/services/models/seedream-4.js
@@ -56,6 +56,47 @@ export const SEEDREAM_4 = {
         type: 'checkbox',
         default: true
       }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'width',
+        label: 'Custom width',
+        type: 'number',
+        min: 1024,
+        max: 4096,
+        default: 2048,
+        description: 'Only used when Size is set to custom'
+      },
+      {
+        key: 'height',
+        label: 'Custom height',
+        type: 'number',
+        min: 1024,
+        max: 4096,
+        default: 2048,
+        description: 'Only used when Size is set to custom'
+      },
+      {
+        key: 'sequential_image_generation',
+        label: 'Sequential generation',
+        type: 'select',
+        enum: ['disabled', 'auto'],
+        default: 'disabled',
+        description: 'With auto, the model decides whether to return a set of related images'
+      },
+      {
+        key: 'max_images',
+        label: 'Max images',
+        type: 'number',
+        min: 1,
+        max: 15,
+        default: 1,
+        description: 'Cap for sequential generation. Input plus generated images cannot exceed 15'
+      }
     ]
   },
 

--- a/src/services/models/seedream-4.js
+++ b/src/services/models/seedream-4.js
@@ -13,6 +13,10 @@ export const SEEDREAM_4 = {
 
   /**
    * Default parameters for the model
+   *
+   * `max_images` is fixed at 1 and `sequential_image_generation` at 'disabled',
+   * neither exposed in the UI: an Image Generator node renders a single output,
+   * so any extra image would be billed and then dropped on the floor
    */
   defaults: {
     size: '2K',
@@ -49,12 +53,6 @@ export const SEEDREAM_4 = {
           '3:2', '2:3', '21:9'
         ],
         default: 'match_input_image'
-      },
-      {
-        key: 'enhance_prompt',
-        label: 'Enhance Prompt',
-        type: 'checkbox',
-        default: true
       }
     ],
 
@@ -62,6 +60,13 @@ export const SEEDREAM_4 = {
      * Secondary options, rendered in the node options side panel
      */
     advancedControls: [
+      {
+        key: 'enhance_prompt',
+        label: 'Enhance prompt',
+        type: 'checkbox',
+        default: true,
+        description: 'Higher quality results, at the cost of a slower generation'
+      },
       {
         key: 'width',
         label: 'Custom width',
@@ -79,23 +84,6 @@ export const SEEDREAM_4 = {
         max: 4096,
         default: 2048,
         description: 'Only used when Size is set to custom'
-      },
-      {
-        key: 'sequential_image_generation',
-        label: 'Sequential generation',
-        type: 'select',
-        enum: ['disabled', 'auto'],
-        default: 'disabled',
-        description: 'With auto, the model decides whether to return a set of related images'
-      },
-      {
-        key: 'max_images',
-        label: 'Max images',
-        type: 'number',
-        min: 1,
-        max: 15,
-        default: 1,
-        description: 'Cap for sequential generation. Input plus generated images cannot exceed 15'
       }
     ]
   },
@@ -109,8 +97,7 @@ export const SEEDREAM_4 = {
       'match_input_image',
       '1:1', '4:3', '3:4', '16:9', '9:16',
       '3:2', '2:3', '21:9'
-    ],
-    sequential_image_generation: ['disabled', 'auto']
+    ]
   },
 
   /**
@@ -138,8 +125,9 @@ export const SEEDREAM_4 = {
       size: params.size || this.defaults.size,
       aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
       enhance_prompt: params.enhance_prompt !== undefined ? params.enhance_prompt : this.defaults.enhance_prompt,
-      max_images: params.max_images || this.defaults.max_images,
-      sequential_image_generation: params.sequential_image_generation || this.defaults.sequential_image_generation
+      // Always a single image, see `defaults`
+      max_images: this.defaults.max_images,
+      sequential_image_generation: this.defaults.sequential_image_generation
     }
 
     // Add width and height only if size is 'custom'
@@ -167,10 +155,6 @@ export const SEEDREAM_4 = {
       throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
     }
 
-    if (params.sequential_image_generation && !this.validValues.sequential_image_generation.includes(params.sequential_image_generation)) {
-      throw new Error(`Invalid sequential_image_generation. Must be one of: ${this.validValues.sequential_image_generation.join(', ')}`)
-    }
-
     if (params.width !== undefined) {
       const width = parseInt(params.width)
       if (isNaN(width) || width < 1024 || width > 4096) {
@@ -187,22 +171,14 @@ export const SEEDREAM_4 = {
       validated.height = height
     }
 
-    if (params.max_images !== undefined) {
-      const maxImages = parseInt(params.max_images)
-      if (isNaN(maxImages) || maxImages < 1 || maxImages > 15) {
-        throw new Error('max_images must be between 1 and 15')
-      }
-      validated.max_images = maxImages
-    }
-
     return {
       size: params.size,
       aspect_ratio: params.aspect_ratio,
       enhance_prompt: params.enhance_prompt,
       width: validated.width,
       height: validated.height,
-      max_images: validated.max_images,
-      sequential_image_generation: params.sequential_image_generation
+      // max_images and sequential_image_generation are deliberately dropped:
+      // buildInput always asks for a single image
     }
   },
 

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -79,6 +79,13 @@
       </VueFlow>
     </div>
 
+    <!-- Side panels, invoked from anywhere through useSidePanel -->
+    <NodeOptionsPanel
+      v-if="activePanel?.type === PANEL_TYPES.NODE_OPTIONS"
+      :key="activePanel.nodeId"
+      :node-id="activePanel.nodeId"
+    />
+
     <!-- Intro Modal -->
     <IntroModal v-model="showIntro" />
 
@@ -118,6 +125,7 @@ import FloatingMenu from '@/components/canvas/FloatingMenu.vue'
 import NodesSidebar from '@/components/canvas/NodesSidebar.vue'
 import NodeContextMenu from '@/components/canvas/NodeContextMenu.vue'
 import SettingsModal from '@/components/canvas/SettingsModal.vue'
+import NodeOptionsPanel from '@/components/canvas/NodeOptionsPanel.vue'
 import IntroModal from '@/components/canvas/IntroModal.vue'
 import AlertBanner from '@/components/canvas/AlertBanner.vue'
 import SaveDialog from '@/components/canvas/SaveDialog.vue'
@@ -134,9 +142,13 @@ import { useAutoLayout } from '@/composables/useAutoLayout'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useConnectionDrop } from '@/composables/useConnectionDrop'
+import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
 
 const flowStore = useFlowStore()
 const settingsStore = useSettingsStore()
+
+// Which side panel is on screen, if any. Nodes open theirs from their toolbar
+const { activePanel } = useSidePanel()
 
 const isNodesMenuOpen = ref(false)
 const mousePosition = ref({ x: 0, y: 0 })


### PR DESCRIPTION
# What

The bar that shows up when you click an Image, Text or Video Generator now ends in a **⋮** button. It opens a panel docked to the right edge of the screen, full height, with the options of the model that do not fit in the bar.

- The panel closes on its own when the node stops being selected — clicking somewhere else, picking another node or deleting it — and it also has a close button.
- The canvas stays usable while the panel is open: you can still drag nodes and pan around. That is on purpose, since deselecting is what closes it.
- Every model now shows the options it was already able to send but had nowhere to display: custom width and height on **seedream-4**, compression, format, moderation and user id on **gpt-image-1** and **gpt-image-2**, output format and safety level on **nano-banana-pro**, and the system prompt on **GPT-5** and **Gemini**.
- The bars keep only what is worth reaching for in one click. What moved down to the panel: **Draft** on p-video, next to prompt upsampling, save audio and the seed, which had no UI at all until now; max output tokens, dynamic thinking and thinking budget on Gemini; max tokens on GPT-5; enhance prompt on seedream-4; and background on both gpt-image models.
- **A generation is always one image now.** Several models can return a batch, but the node only ever shows the first one, so the rest were being billed and thrown away. The option is gone from the UI and the request always asks for one.
- The panel is a canvas surface, not something that belongs to the nodes, so the next thing that needs a side panel can just ask for one.

The official Replicate documentation of every registered model is committed too, under `docs/replicate-models-docs/`, split into `image/`, `text/` and `video/` folders that match the category each model declares.

# Why

The bar is a single row with a maximum width. It was already full, which is why a good number of model parameters were quietly unreachable: the code in `replicate.js` and in each model config knew how to send `seed`, `system_prompt`, `output_format` or `max_images`, but there was nowhere to type them. Anything new had to either push something else out or make the bar wrap into an unusable block.

So each model config splits its `uiSchema` in two: `controls` is what the bar shows, `advancedControls` is what the panel shows. Same descriptor shape, same `data.params` destination, so nothing changes about how a flow is saved or what reaches the API. A model that declares no advanced options simply gets no ⋮ button.

The multi-image parameters are the one thing that did not move but disappear. `parseResponse` returns every URL the model sent back, but the node reads `imageUrl`, the first one, and there is nowhere on the canvas to put the others. Asking for four images meant paying for four and seeing one. `buildInput` now reads those keys from `defaults` rather than from `params`, which is also what stops an older saved flow from re-enabling it silently.

The panel itself is deliberately not built inside the nodes. `useSidePanel` holds which panel is on screen, `BaseSidePanel` is the empty shell and `NodeOptionsPanel` is the only content so far, rendered by `FlowCanvasView` right next to the modals. What opens it is a button several components deep inside the canvas, so the state lives at module level — the same approach the workflow event bus already uses to let a node reach the canvas.

Two details took some care. `BaseSidePanel` has no dark overlay, unlike `BaseModal`: a panel that follows the selection needs the canvas to stay interactive, otherwise there would be no way to deselect and the panel could never close by itself. And the panel reads its node through VueFlow's own `findNode` rather than through the store, because `selected` is only kept up to date on VueFlow's node objects, and that flag is what the whole closing behaviour hangs on.

# Tests

e2e tests and local.

New spec `e2e/node-options-panel.spec.js` with 10 tests: opening from the toolbar, the geometry against the right edge, Draft having moved, the three ways the panel closes, values landing in `data.params` with the right type, the canvas still being draggable underneath, and the controls swapping when the model changes in the bar. The p-video toolbar spec was updated to tick Draft in the panel.

`e2e/generator-models.spec.js` now asserts the payload of seedream-4 and gpt-image-1 asks for a single image, plus a new test that a flow carrying `number_of_images: 5` still only gets one.

Full suite re-run: 86 passing, with only the 5 pre-existing `copy-paste` macOS failures left, identical to the baseline.

# How to test

- [ ] Drop a **Video Generator** and click it: the bar now ends in a **⋮** button.
- [ ] Click **⋮**: a panel opens against the right edge, full height, titled with the node name and the model.
- [ ] **Draft** is gone from the bar and is in the panel, along with prompt upsampling, save audio and seed.
- [ ] Change something in the panel, generate, and check the request carries it.
- [ ] On an **Image Generator** with GPT Image 1 or seedream-4, generate and check the request asks for a single image, with no way to change that anywhere in the UI.
- [ ] Check the thinned out bars: Gemini keeps only temperature and top P, GPT-5 only reasoning effort and verbosity, seedream-4 only size and aspect ratio, and the gpt-image models no longer show background. All of it is in the panel.
- [ ] Click the **✕**: the panel closes and the node stays selected, bar included.
- [ ] Open it again and click on empty canvas: the panel closes.
- [ ] Open it again and click a different node: the panel closes.
- [ ] Open it again and press **Delete**: the node and the panel both go.
- [ ] With the panel open, drag the node around: the canvas still responds and the panel stays.
- [ ] Do the same with an **Image Generator** and a **Text Generator**: each model shows its own options.
- [ ] On a Text Generator, switch model from GPT-5 to Gemini with the panel open: the system prompt control is replaced by the system instruction one.
- [ ] Fill in some advanced options, export the flow to JSON and load it back: the values survive the round trip.
- [ ] Open **Settings** while the panel is up: the modal opens on top of it.
