### PR TITLE
feat: add the FLUX.2, SeeDream 4.5/5-lite and Nano Banana 2 models

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -689,8 +689,25 @@ const result = await replicateService.generateImage({
 ```
 
 **Configured models:**
-- `nano-banana-pro` - Fast model
-- `seedream-4` - Advanced model with more options
+
+| Model | Category | Notes |
+|---|---|---|
+| `nano-banana-pro` | image | The default model |
+| `nano-banana-2` | image | Flash speed, optional web and image search grounding |
+| `seedream-4` | image | Custom dimensions through `size: 'custom'` |
+| `seedream-4.5` | image | Same, minus the 1K size |
+| `seedream-5-lite` | image | 2K/3K only, no custom dimensions |
+| `flux-2-flex` | image | Adds `steps` and `guidance` over the other two FLUX |
+| `flux-2-pro` | image | Up to 8 reference images |
+| `flux-2-max` | image | Highest fidelity of the FLUX family |
+| `gpt-image-1`, `gpt-image-2` | image | Need an OpenAI key for gpt-image-1 |
+| `lang-segment-anything` | image | Segmentation, no prompt-driven generation |
+| `gpt-5`, `gemini-2.5-flash` | text | |
+| `p-video` | video | |
+
+A model is picked up by the Image Generator's dropdown as soon as it is added to the
+`MODELS` registry with `category: 'image'` — the list comes from `listModels(category)`,
+so there is nothing to register on the component side.
 
 Each model defines:
 - Accepted parameters
@@ -698,12 +715,22 @@ Each model defines:
 - UI Schema, split into `controls` for the node toolbar and `advancedControls` for the
   node options side panel
 
+Two payload shapes coexist and are not interchangeable: the Google and ByteDance models
+take their reference images in `image_input`, while the FLUX and gpt-image ones take them
+in `input_images`. Each `buildInput` maps the node's images onto its own key.
+
+The FLUX models also swap parameters depending on the aspect ratio: `custom` sends `width`
+and `height` and omits `resolution`, anything else sends `resolution` and omits the
+dimensions. The panel shows all three at once because the model, not the UI, decides which
+ones matter.
+
 ### One image per generation
 
 Several models can return a batch of images in a single prediction: `number_of_images` on
 the gpt-image models, `max_images` together with `sequential_image_generation` on
-seedream-4. **None of them is exposed in the UI, and `buildInput` always asks for exactly
-one image**, ignoring whatever a flow's `data.params` might carry.
+seedream-4, seedream-4.5 and seedream-5-lite. **None of them is exposed in the UI, and
+`buildInput` always asks for exactly one image**, ignoring whatever a flow's `data.params`
+might carry.
 
 An Image Generator node renders a single output and reads `imageUrl`, the first entry of
 the response. Every extra image was billed and then dropped on the floor, which is a

--- a/docs/replicate-models-docs/image/flux-2-flex.md
+++ b/docs/replicate-models-docs/image/flux-2-flex.md
@@ -1,0 +1,230 @@
+## Basic model info
+
+Model name: black-forest-labs/flux-2-flex
+Model description: Max-quality image generation and editing with support for ten reference images
+
+
+## Model inputs
+
+- prompt (required): Text prompt for image generation (string)
+- input_images (optional): List of input images for image-to-image generation. Maximum 10 images. Must be jpeg, png, gif, or webp. (array)
+- aspect_ratio (optional): Aspect ratio for the generated image. Use 'match_input_image' to match the first input image's aspect ratio. (string)
+- resolution (optional): Resolution in megapixels. Up to 4 MP is possible, but 2 MP or below is recommended. The maximum image size is 2048x2048, which means that high-resolution images may not respect the resolution if aspect ratio is not 1:1.
+
+Resolution is not used when aspect_ratio is 'custom'. When aspect_ratio is 'match_input_image', use 'match_input_image' to match the input image's resolution (clamped to 0.5-4 MP). (string)
+- width (optional): Width of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16 (if it's not, it will be rounded to nearest multiple of 16). (integer)
+- height (optional): Height of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16 (if it's not, it will be rounded to nearest multiple of 16). (integer)
+- safety_tolerance (optional): Safety tolerance, 1 is most strict and 5 is most permissive (integer)
+- seed (optional): Random seed. Set for reproducible generation (integer)
+- prompt_upsampling (optional): Automatically modify the prompt for more creative generation (boolean)
+- steps (optional): Number of inference steps (integer)
+- guidance (optional): Guidance scale for generation. Controls how closely the output follows the prompt (number)
+- output_format (optional): Format of the output images. (string)
+- output_quality (optional): Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs (integer)
+
+
+## Model output schema
+
+{
+  "type": "string",
+  "title": "Output",
+  "format": "uri"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/bqxav211vnrm80ctqckad81qxg)
+
+#### Input
+
+```json
+{
+  "prompt": "Fluffy cotton candy sculpted into voluminous 3D letters spelling \"Flex\" in swirls of bubblegum pink, baby blue, and soft lavender, held on a wooden stick in front of a vintage pastel cotton candy cart with hand-painted signage reading \"Run FLUX.2 [flex] on Replicate!\" on a sunny carnival boardwalk. Shot on Kodak Portra 160 with a Mamiya RZ67, bright midday summer sunlight, the spun sugar texture catching light with wispy translucent edges and denser pillowy centers, visible sticky strands, a vintage pastel Ferris wheel and striped circus tents in the soft-focus background, weathered wooden boardwalk planks beneath.",
+  "resolution": "1 MP",
+  "aspect_ratio": "1:1",
+  "input_images": [],
+  "output_format": "webp",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/DxBvdhGcpX6FLxoUikZhQdbYs87OMEv83563fspgBuXS7a2KA/tmp249z689p.webp"
+```
+
+
+### Example (https://replicate.com/p/f6j5thqvjnrma0ctqe6bxbezs8)
+
+#### Input
+
+```json
+{
+  "prompt": "Photorealistic infographic showing the complete Berlin TV Tower (Fernsehturm) from ground base to antenna tip, full vertical view with entire structure visible including concrete shaft, metallic sphere, and antenna spire. Slight upward perspective angle looking up toward the iconic sphere, perfectly centered on clean white background. Left side labels with thin horizontal connector lines: the text '368m' in extra large bold dark grey numerals (#2D3748) positioned at exactly the antenna tip with 'TOTAL HEIGHT' in small caps below. The text '207m' in extra large bold with 'TELECAF\u00c9' in small caps below, with connector line touching the sphere precisely at the window level. Right side label with horizontal connector line touching the sphere's equator: the text '32m' in extra large bold dark grey numerals with 'SPHERE DIAMETER' in small caps below. Bottom section arranged in three balanced columns: Left - Large text '986' in extra bold dark grey with 'STEPS' in caps below. Center - 'BERLIN TV TOWER' in bold caps with 'FERNSEHTURM' in lighter weight below. Right - 'INAUGURATED' in bold caps with 'OCTOBER 3, 1969' below. At the very bottom center, below the columns, add small italicized text 'Run Flux.2 on Replicate' in medium grey (#A0AEC0). All typography in modern sans-serif font (such as Inter or Helvetica), color #2D3748 unless specified, clean minimal technical diagram style. Horizontal connector lines are thin, precise, and clearly visible, touching the tower structure at exact corresponding measurement points. Professional architectural elevation drawing aesthetic with dynamic low angle perspective creating sense of height and grandeur, poster-ready infographic design with perfect visual hierarchy.",
+  "resolution": "1 MP",
+  "aspect_ratio": "9:16",
+  "input_images": [],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/AoDktPZMjJrRGFTrjRXRAx6lmwzYB1qtDYQNeoe7JeI5fdzWB/tmpg3nd4scz.jpg"
+```
+
+
+### Example (https://replicate.com/p/hrv5h4jaf5rm80ctqeg9y1jkm8)
+
+#### Input
+
+```json
+{
+  "prompt": "The man is leaning against the wall reading a newspaper with the title \"FLUX.2\"\nThe woman is walking past him, carrying one of the tote bags with the text \"R8\" on it, wearing the black boots The focus is on their contrasting styles, her relaxed, creative vibe versus his formal look.",
+  "resolution": "1 MP",
+  "aspect_ratio": "1:1",
+  "input_images": [
+    "https://replicate.delivery/pbxt/O7lPaVJnrzTIXkrZAT0aVgatdR9vMab15CvzMMXZIS1JIPRY/jay-soundo.jpg",
+    "https://replicate.delivery/pbxt/O7lPbBWUQnWRAGjqJhdgH8us43PBhj0I6ibihABnKj9tNp9L/bags.jpg",
+    "https://replicate.delivery/pbxt/O7lPavCpg5ueAmZowUWShAeAZf6IJzitzWP0xCZP6X32phRk/woman-by-car.jpg",
+    "https://replicate.delivery/pbxt/O7lPbHGa4uKdbn8STRJjEMmCWehmsB1y07LFaVhS8uwnbWCr/shoes.jpg",
+    "https://replicate.delivery/pbxt/O7lPaxMstjGEZmDD6SsVEemF7mbelXC2in1jm7n6sNNlj2YJ/buildings.jpg"
+  ],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/wjZleLeN14mxYk6ge5Si8AN8hAP6ga7fmqeToxwm321gneNbF/tmphaic5du6.jpg"
+```
+
+
+### Example (https://replicate.com/p/hgavaafwb9rm80ctqen93x59jc)
+
+#### Input
+
+```json
+{
+  "prompt": "this exact image but the couple next to the fire replaced by the people in image 2 and 3",
+  "resolution": "1 MP",
+  "aspect_ratio": "3:4",
+  "input_images": [
+    "https://replicate.delivery/pbxt/O7lafo8rMDDriTkaHai6myxwfWKjgUaklcFJUNfqcJZYLaWb/campfire.jpg",
+    "https://replicate.delivery/pbxt/O7laerU6Uxxg9h8SZkLm42HpCRfQ6IrOLXmlJczakyg7XXe1/jay-soundo.jpg",
+    "https://replicate.delivery/pbxt/O7laevdOTIsAbw8gKb137e1CBQ7mkVGlCshNszadUiOwkQR1/woman-by-car.jpg"
+  ],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/qiGjhjKuiz53LVonkaT92odpyw5YMA5gVqOQ5wSr6u00fb2KA/tmpno431dzl.jpg"
+```
+
+
+### Example (https://replicate.com/p/tgpccs4gznrme0ctqgwtej2pxw)
+
+#### Input
+
+```json
+{
+  "prompt": "{\n  \"scene\": \"Professional studio product photography setup with polished concrete surface\",\n  \"subjects\": [\n    {\n      \"description\": \"Minimalist ceramic coffee mug with steam rising from hot coffee inside. The mug has white text: Run Flux.2 [flex] on Replicate\",\n      \"pose\": \"Stationary on surface\",\n      \"position\": \"Center foreground on polished concrete surface\",\n      \"color_palette\": [\"goo colored ceramic with red, yellow, orange, purple\"]\n    }\n  ],\n  \"style\": \"Ultra-realistic product photography with commercial quality\",\n  \"color_palette\": [\"red\", \"yellow\", \"orange\", \"purple\", \"concrete gray\", \"soft white highlights\"],\n  \"lighting\": \"Three-point softbox setup creating soft, diffused highlights with no harsh shadows\",\n  \"mood\": \"Clean, professional, minimalist\",\n  \"background\": \"Polished concrete surface with studio backdrop\",\n  \"composition\": \"rule of thirds\",\n  \"camera\": {\n    \"angle\": \"high angle\",\n    \"distance\": \"medium shot\",\n    \"focus\": \"Sharp focus on steam rising from coffee and mug details\",\n    \"lens-mm\": 85,\n    \"f-number\": \"f/5.6\",\n    \"ISO\": 200\n  }\n}",
+  "resolution": "1 MP",
+  "aspect_ratio": "1:1",
+  "input_images": [],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/KgizEOElkUbiBhPrccVD24W9MeXeWxkA59P7enuGq8kdh0ZrA/tmpmuva6rxw.jpg"
+```
+
+
+## Model readme
+
+> # Flux 2 Flex
+> 
+> Flux 2 Flex from Black Forest Labs gives you control over the quality-speed trade-off when generating images. Unlike typical text-to-image models that make these decisions for you, Flex lets you adjust how many steps to run and how strongly the model should follow your prompt.
+> 
+> This is the model to reach for when you're iterating on designs, creating typography-heavy work like infographics or UI mockups, or editing images with multiple reference photos.
+> 
+> ## What it's good at
+> 
+> Text rendering is where Flex really shines. The model can reliably generate clean typography, readable captions, and complex layouts—the kind of stuff that usually takes multiple attempts with other models. If you're making memes, posters, or product mockups with text, this is your model.
+> 
+> The multi-reference feature lets you blend up to ten images into a single output while keeping things coherent. Use this for style transfer, compositional guidance, or when you want to combine elements from different sources.
+> 
+> ## Practical tips
+> 
+> **Start simple with plain text prompts.** You don't need to overthink it:
+> 
+> ```
+> A neon-lit cyberpunk alley at night, rain-slick streets, reflective puddles
+> ```
+> 
+> **For more control, use a structured approach.** Describe what you want in clear sections:
+> 
+> ```
+> Scene: Modern coffee shop interior with large windows
+> Subjects: Barista preparing espresso, two customers chatting at a table
+> Lighting: Warm afternoon sunlight streaming through windows
+> Style: Photorealistic with shallow depth of field
+> Camera: Shot at eye level with 35mm lens
+> ```
+> 
+> **Negative prompts don't work here.** Instead of saying what you don't want, be specific about what you do want. Say "clean background" instead of "no clutter."
+> 
+> ## How the parameters work
+> 
+> **Guidance scale** controls how closely the model sticks to your prompt. Lower values (around 2-3) give the model more creative freedom. Higher values (4-5) make it follow your instructions more literally. Start around 3.5 and adjust based on what you're seeing.
+> 
+> **Number of steps** is your quality dial. Fewer steps (6-10) generate images quickly but with less detail—good for rapid prototyping. More steps (20-50) take longer but produce sharper results with better typography. For most work, 20 steps hits a good balance.
+> 
+> **Multi-reference images** let you upload up to ten reference photos (14 MB total). The model will extract style, composition, and other visual elements to inform the generation. This is useful for maintaining consistent characters across outputs or matching a specific aesthetic.
+> 
+> ## Image editing
+> 
+> Flex handles editing at resolutions up to 4 megapixels. Upload a base image and describe what you want to change or add. The model will make modifications while keeping the rest of the image coherent.
+> 
+> For style transfer or compositional changes, provide reference images alongside your edit instructions. The model uses these to understand the direction you're going.
+> 
+> ## What to expect
+> 
+> Output resolution is 1024 × 1024 pixels in PNG format. The model accepts PNG or JPEG inputs for reference images and editing tasks.
+> 
+> Generation time varies based on your step count—expect 10-30 seconds for typical runs. Higher resolutions and more steps will take longer.
+> 
+> This model is built for production workflows where you need reliable typography and the flexibility to fine-tune quality versus speed. If you're making quick sketches or need the absolute highest fidelity, check out the other models in the [Flux family](https://replicate.com/collections/flux).
+> 
+> ## Try it yourself
+> 
+> You can experiment with Flux 2 Flex on the Replicate Playground at [replicate.com/playground](https://replicate.com/playground).
+

--- a/docs/replicate-models-docs/image/flux-2-max.md
+++ b/docs/replicate-models-docs/image/flux-2-max.md
@@ -1,0 +1,125 @@
+## Basic model info
+
+Model name: black-forest-labs/flux-2-max
+Model description: The highest fidelity image model from Black Forest Labs
+
+
+## Model inputs
+
+- prompt (required): Text prompt for image generation (string)
+- input_images (optional): List of input images for image-to-image generation. Maximum 8 images. Must be jpeg, png, gif, or webp. (array)
+- aspect_ratio (optional): Aspect ratio for the generated image. Use 'match_input_image' to match the first input image's aspect ratio. (string)
+- resolution (optional): Resolution in megapixels. Up to 4 MP is possible, but 2 MP or below is recommended. The maximum image size is 2048x2048, which means that high-resolution images may not respect the resolution if aspect ratio is not 1:1.
+
+Resolution is not used when aspect_ratio is 'custom'. When aspect_ratio is 'match_input_image', use 'match_input_image' to match the input image's resolution (clamped to 0.5-4 MP). (string)
+- width (optional): Width of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16 (if it's not, it will be rounded to nearest multiple of 16). (integer)
+- height (optional): Height of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16 (if it's not, it will be rounded to nearest multiple of 16). (integer)
+- safety_tolerance (optional): Safety tolerance, 1 is most strict and 5 is most permissive (integer)
+- seed (optional): Random seed. Set for reproducible generation (integer)
+- output_format (optional): Format of the output images. (string)
+- output_quality (optional): Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs (integer)
+
+
+## Model output schema
+
+{
+  "type": "string",
+  "title": "Output",
+  "format": "uri"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/xs953f0q8nrmc0cv4yxtzptxwr)
+
+#### Input
+
+```json
+{
+  "prompt": "A photorealistic wide shot of a large minimalist digital billboard standing in the middle of a forest filled with purple and lavender-hued trees. Soft violet foliage surrounds the scene, creating a surreal yet elegant atmosphere. The billboard has a sleek metal frame with subtle overhead lights, blending advanced technology with dreamlike nature. On the screen, a dark glass display shows a clean, futuristic UI with gentle lavender and magenta accents. The billboard is transparent, showing the trees behind it. Centered text reads: \u201cFLUX.2 [max]\u201d in a modern sans-serif font, calm, confident, and precise. Soft daylight with a purple color cast, cinematic composition, ultra-high resolution, premium AI launch aesthetic, minimalism, tranquil mood.",
+  "resolution": "1 MP",
+  "aspect_ratio": "1:1",
+  "input_images": [],
+  "output_format": "webp",
+  "output_quality": 80,
+  "safety_tolerance": 2
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/ao8amjkARBLSJBU1ke494CLvIOKReDfmiACAcuJyPtCkNlnrA/tmp67_fq1dd.webp"
+```
+
+
+## Model readme
+
+> # FLUX.2 [max]
+> 
+> **FLUX.2 [max]** is the new top-tier image model from **Black Forest Labs**, pushing image quality, prompt understanding, and editing consistency to the highest level yet.
+> 
+> With **FLUX.2 [pro]**, we introduced a high-quality, production-grade model designed to scale to the highest volumes. **FLUX.2 [max]** now puts the cherry on top 🍒 — improving upon FLUX.2 [pro] across *all* dimensions.
+> 
+> It is easier and more intuitive to prompt, delivers superior prompt adherence, and enables even more consistent editing of **characters, objects, styles, and backgrounds**.
+> 
+> If you’re looking to give your professional content the final polish before publishing — at a competitive price — **FLUX.2 [max]** is the definitive choice.
+> 
+> ---
+> 
+> ## For which use cases can I use FLUX.2 [max]?
+> 
+> Use **FLUX.2 [max]** for the following and more:
+> 
+> - Use FLUX.2 [max] in scenarios where FLUX.2 [pro] lacks consistency. It delivers a higher hit/miss ratio for very complex edits involving multiple references, while offering superior prompt adherence for image generation.
+> - Create top-quality product imagery from **0 to 1**, reducing time-to-online from days to minutes.
+> - Transform low-quality product photos into high-quality shots ready for publishing — straight from your phone to your product website.
+> - Generate cinematic, motion-picture-quality **key frames** for animation while preserving characters *and* emotions, saving thousands of dollars in pre-visualization.
+> - Create systematic color variations of products, precisely controlled by **hex color codes** in your prompt.
+> - Generate new **3D views** of a scene from a single image or a small set of references, enabling virtual tours of real or imagined environments.
+> - Produce images grounded in **real-time information** — visualize trending products, current events, or the latest styles without manually sourcing references.
+> 
+> ---
+> 
+> ## Where should I use FLUX.2 [max] vs FLUX.2 [pro] vs FLUX.2 [flex]?
+> 
+> |  | **FLUX.2 [max]** | **FLUX.2 [pro]** | **FLUX.2 [flex]** |
+> | --- | --- | --- | --- |
+> | **General Description** | **Maximum performance.** Highest editing consistency across tasks, vast world knowledge, strongest prompt following, and faithful representation of styles. | **Top performance at an affordable price.** A production-grade image generation and editing model. | **Specialized models** optimized for typography and preserving small details. |
+> | **Product Marketing** | Highest-quality product shots ready for top-tier online marketplaces. | Create scalable ad creatives for social campaigns. | Finalize content with text overlays while preserving fine details. |
+> | **Movie Making** | Cinematic-quality content with accurate emotions and styles, ideal for high-end pre-visualization. | Rapid ideation and static movie banner generation. | Best for text-heavy assets like intros, credits, and advertising materials. |
+> | **Creative Design Platforms (Multi-tier Subscriptions)** | Premium model for highest subscription tiers. | Backbone model for pro subscriptions handling scaled traffic. | Text-placement and overlay specialist, available across tiers with higher quotas at the top tier. |
+> | **Food Imagery** | Final polish for real food images or upsampled outputs, ready for advertising. | Generate multiple upsampled variations from casual food photos, making dishes look more appealing. | Rapid daily text edits for deals and localized advertising content. |
+> 
+> ---
+> 
+> ## Why it matters
+> 
+> - **Highest precision image editing**  
+>   FLUX.2 [max] delivers the most consistent image editing in the FLUX.2 lineup to date. It preserves colors, lighting, faces, text, and objects with exceptional fidelity, making it the default choice for high-quality use cases such as **product marketing, e-commerce, product variations, interior design, 3D reconstruction, food imagery, and video production**.
+> 
+> - **A model that truly understands your intent**  
+>   Best-in-class prompt following for both short and long prompts. FLUX.2 [max] understands instructions more accurately than any previous FLUX model.
+> 
+> - **Multi-reference editing with state-of-the-art character consistency**  
+>   Maintain identities, products, and styles across large batches:
+>   - Up to **8 reference images** via API  
+>   - Up to **10 reference images** in the Playground  
+>   Create dozens of ad variants using the same face, consistent product mockups across environments, or dynamic fashion editorials with unwavering identity fidelity.
+> 
+> - **Our most creative model yet**  
+>   Generate multiple images from the same prompt where no two results look alike — while still respecting the prompt. Ideal for ideation, exploration, and creative discovery.
+> 
+> - **Maximum quality at FLUX speed**  
+>   Despite major gains in image quality, editing precision, and prompt adherence, FLUX.2 [max] generates content nearly as fast as FLUX.2 [pro], making it up to **3× faster** than competing models of similar quality.
+> 
+> ---
+> 
+> **FLUX.2 [max]**  
+> *Maximum performance. Maximum consistency. Maximum creative control.*
+

--- a/docs/replicate-models-docs/image/flux-2-pro.md
+++ b/docs/replicate-models-docs/image/flux-2-pro.md
@@ -1,0 +1,269 @@
+## Basic model info
+
+Model name: black-forest-labs/flux-2-pro
+Model description: High-quality image generation and editing with support for eight reference images
+
+
+## Model inputs
+
+- prompt (required): Text prompt for image generation (string)
+- input_images (optional): List of input images for image-to-image generation. Maximum 8 images. Must be jpeg, png, gif, or webp. (array)
+- aspect_ratio (optional): Aspect ratio for the generated image. Use 'match_input_image' to match the first input image's aspect ratio. (string)
+- resolution (optional): Resolution in megapixels. Up to 4 MP is possible, but 2 MP or below is recommended. The maximum image size is 2048x2048, which means that high-resolution images may not respect the resolution if aspect ratio is not 1:1.
+
+Resolution is not used when aspect_ratio is 'custom'. When aspect_ratio is 'match_input_image', use 'match_input_image' to match the input image's resolution (clamped to 0.5-4 MP). (string)
+- width (optional): Width of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16 (if it's not, it will be rounded to nearest multiple of 16). (integer)
+- height (optional): Height of the generated image. Only used when aspect_ratio=custom. Must be a multiple of 16 (if it's not, it will be rounded to nearest multiple of 16). (integer)
+- safety_tolerance (optional): Safety tolerance, 1 is most strict and 5 is most permissive (integer)
+- seed (optional): Random seed. Set for reproducible generation (integer)
+- output_format (optional): Format of the output images. (string)
+- output_quality (optional): Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs (integer)
+
+
+## Model output schema
+
+{
+  "type": "string",
+  "title": "Output",
+  "format": "uri"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/rwn48vjygdrma0ctqcgbrd06t4)
+
+#### Input
+
+```json
+{
+  "prompt": "Glossy candy-colored 3D letters in hot pink, electric orange, and lime green on a sun-drenched poolside patio with bold terrazzo tiles and vintage lounge chairs in turquoise and yellow. Shot on Kodachrome film with a Hasselblad 500C, warm golden afternoon sunlight, dramatic lens flare, punchy oversaturated colors with that distinctive 70s yellow-orange cast, shallow depth of field with the text sharp in the foreground, tropical palms and a sparkling aquamarine pool behind that spells out \"Run FLUX.2 [pro] on Replicate!\"",
+  "resolution": "1 MP",
+  "aspect_ratio": "1:1",
+  "input_images": [],
+  "output_format": "webp",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/EXuyWm6qQuK9J19lUCtc9sbO4k2RyHwoOP6GoYMCpeyM4a2KA/tmpzd16m4x2.webp"
+```
+
+
+### Example (https://replicate.com/p/4xa7gdmjj5rmc0ctqdksd7z4q4)
+
+#### Input
+
+```json
+{
+  "prompt": "The person from image 1 is petting the cat from image 2, the bird from image 3 is next to them",
+  "resolution": "1 MP",
+  "aspect_ratio": "match_input_image",
+  "input_images": [
+    "https://replicate.delivery/pbxt/O7kSsp5sasepfpL7XJm6lcALZEaFLxHYN6UrQONik4Z19QIM/woman-by-car.webp",
+    "https://replicate.delivery/pbxt/O7kSt7OV4b92EmiTyXsqN51O3aPTEyWTQfMha9kHNFaL4ylt/cat-at-window.webp",
+    "https://replicate.delivery/pbxt/O7kSscCDcTZNDbkIdDzXMIpw5rAufD3dpcXBBUGRBbc5ZnTo/bird.webp"
+  ],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/rK8Zcn68IPIEMtGHj4fe6YZfWwcxz45zfb4DGvKDtLyhmbzWB/tmpec2opkym.jpg"
+```
+
+
+### Example (https://replicate.com/p/errce0p8ssrma0ctqdv9efe794)
+
+#### Input
+
+```json
+{
+  "prompt": "change the car to blue",
+  "resolution": "1 MP",
+  "aspect_ratio": "match_input_image",
+  "input_images": [
+    "https://replicate.delivery/pbxt/O7kie6B4lIVLUi3ikTBWZCviUUzNeIVv2HLduINkdxlnNkPZ/woman-by-car.jpg"
+  ],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/qwxw1mHmUGarO93xDG2NwAjeg8u9hNePulz8InznPGZ8I3sVA/tmpso5ny8db.jpg"
+```
+
+
+### Example (https://replicate.com/p/pjh9wf0he1rma0ctqe6a1tgywm)
+
+#### Input
+
+```json
+{
+  "prompt": "Photorealistic infographic showing the complete Berlin TV Tower (Fernsehturm) from ground base to antenna tip, full vertical view with entire structure visible including concrete shaft, metallic sphere, and antenna spire. Slight upward perspective angle looking up toward the iconic sphere, perfectly centered on clean white background. Left side labels with thin horizontal connector lines: the text '368m' in extra large bold dark grey numerals (#2D3748) positioned at exactly the antenna tip with 'TOTAL HEIGHT' in small caps below. The text '207m' in extra large bold with 'TELECAF\u00c9' in small caps below, with connector line touching the sphere precisely at the window level. Right side label with horizontal connector line touching the sphere's equator: the text '32m' in extra large bold dark grey numerals with 'SPHERE DIAMETER' in small caps below. Bottom section arranged in three balanced columns: Left - Large text '986' in extra bold dark grey with 'STEPS' in caps below. Center - 'BERLIN TV TOWER' in bold caps with 'FERNSEHTURM' in lighter weight below. Right - 'INAUGURATED' in bold caps with 'OCTOBER 3, 1969' below. At the very bottom center, below the columns, add small italicized text 'Run Flux.2 on Replicate' in medium grey (#A0AEC0). All typography in modern sans-serif font (such as Inter or Helvetica), color #2D3748 unless specified, clean minimal technical diagram style. Horizontal connector lines are thin, precise, and clearly visible, touching the tower structure at exact corresponding measurement points. Professional architectural elevation drawing aesthetic with dynamic low angle perspective creating sense of height and grandeur, poster-ready infographic design with perfect visual hierarchy.",
+  "resolution": "1 MP",
+  "aspect_ratio": "9:16",
+  "input_images": [],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/xGyq3mJeG0wlfUSw1LMSG94xfUGkwyYBLOlWpeHU8Qnw6dzWB/tmpy_bgo81_.jpg"
+```
+
+
+### Example (https://replicate.com/p/hrf30ppv3nrm80ctqgxbsr7tvw)
+
+#### Input
+
+```json
+{
+  "prompt": "{\n  \"scene\": \"Professional studio product photography setup with polished concrete surface\",\n  \"subjects\": [\n    {\n      \"description\": \"Minimalist ceramic coffee mug with steam rising from hot coffee inside. The mug has white text: Run Flux.2 [pro] on Replicate\",\n      \"pose\": \"Stationary on surface\",\n      \"position\": \"Center foreground on polished concrete surface\",\n      \"color_palette\": [\"goo colored ceramic with red, yellow, orange, purple\"]\n    }\n  ],\n  \"style\": \"Ultra-realistic product photography with commercial quality\",\n  \"color_palette\": [\"red\", \"yellow\", \"orange\", \"purple\", \"concrete gray\", \"soft white highlights\"],\n  \"lighting\": \"Three-point softbox setup creating soft, diffused highlights with no harsh shadows\",\n  \"mood\": \"Clean, professional, minimalist\",\n  \"background\": \"Polished concrete surface with studio backdrop\",\n  \"composition\": \"rule of thirds\",\n  \"camera\": {\n    \"angle\": \"high angle\",\n    \"distance\": \"medium shot\",\n    \"focus\": \"Sharp focus on steam rising from coffee and mug details\",\n    \"lens-mm\": 85,\n    \"f-number\": \"f/5.6\",\n    \"ISO\": 200\n  }\n}",
+  "resolution": "1 MP",
+  "aspect_ratio": "1:1",
+  "input_images": [],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/A19fBcdcemvzL0qWisFe43KV3KBz2HV7n6fOLo6YGSEDHpzWB/tmpq3mpq5_m.jpg"
+```
+
+
+### Example (https://replicate.com/p/y27283sg6srma0ctqh0tjtrzdw)
+
+#### Input
+
+```json
+{
+  "prompt": "this exact image but the couple next to the fire is replaced by the people in image 2 and 3",
+  "resolution": "1 MP",
+  "aspect_ratio": "3:4",
+  "input_images": [
+    "https://replicate.delivery/pbxt/O7o67ArxiVtSQL9PlXRUt6WkFyudWGi4ig7Ez6u9vRNTW6XH/campfire.jpg",
+    "https://replicate.delivery/pbxt/O7nxUlRnxGieBbqXqeFkTddC3xVJpvLPajC3Hlbczk3FW1sI/jay-soundo.jpg",
+    "https://replicate.delivery/pbxt/O7nxUrruI8z37aQjPd0tniQAdkp86jNKlmr7NMpU4oa5hHXc/woman-by-car.jpg"
+  ],
+  "output_format": "jpg",
+  "output_quality": 80,
+  "safety_tolerance": 2,
+  "prompt_upsampling": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/FUAAfqs53GVWT6l0aTgC9eeCYk1HK3kq9la7B5DN9u7kw0ZrA/tmpzpavqdgi.jpg"
+```
+
+
+## Model readme
+
+> # Flux 2 Pro
+> 
+> Flux 2 Pro is an image generation and editing model by Black Forest Labs. It creates high-quality images from text prompts and can edit existing images using natural language instructions. The model handles complex text rendering, photorealistic details, and maintains consistent characters or styles across multiple reference images.
+> 
+> ## What it does
+> 
+> Generate images from text descriptions, edit existing images, or combine multiple reference images to create something new. The model understands detailed instructions and can work with up to eight reference images at once on the API.
+> 
+> Some things it's particularly good at:
+> 
+> **Text rendering** - The model can write legible text in images, including complex typography, infographics, and user interface mockups. This works reliably in production, not just for simple cases.
+> 
+> **Photorealism** - Sharp textures, natural lighting, and realistic details make this useful for product photography, architectural visualization, and scenes that need to look like real photographs.
+> 
+> **Character consistency** - Use multiple reference images to maintain the same character, product, or style across different generations. This helps when you need a consistent look across a series of images.
+> 
+> **Structured prompting** - You can use JSON to precisely control scene composition, including camera angles, lighting, color palettes, and the positioning of subjects.
+> 
+> ## How to use it
+> 
+> ### Basic text-to-image
+> 
+> Write a clear description of what you want. The model works best when you organize your prompt by importance: subject first, then action, style, and context.
+> 
+> For example: "A sleek silver sports car racing along a coastal highway at sunset, high-dynamic-range, hyper-realistic"
+> 
+> The more specific you are, the more predictable the output.
+> 
+> ### Editing images
+> 
+> Upload an image and describe what to change using natural language. You can reference specific parts of the image or point to other reference images by their index number.
+> 
+> For example: "Replace the background with the beach in image 3" or "Make the woman in the blue dress wear a red jacket"
+> 
+> ### JSON prompting
+> 
+> For precise control, you can structure your prompt as JSON with fields like scene, subjects, style, lighting, camera, and color_palette. Each field accepts plain English descriptions.
+> 
+> The camera field lets you specify angle, distance, focal length, aperture, and ISO. The color_palette field accepts hex codes or color names to control the overall look.
+> 
+> ### Using reference images
+> 
+> You can upload multiple reference images to guide the generation. The model will use these to understand style, composition, or specific elements you want to include. The total input size is limited to 9 megapixels on the API.
+> 
+> ## Things to know
+> 
+> **No negative prompts** - The model doesn't understand negative prompts like "no text" or "no extra fingers." If you try using them, it might actually add what you're trying to avoid. Instead, describe what you want to see. Write "Clean background with natural hands at rest out of frame" instead of "no cluttered background, no extra fingers."
+> 
+> **Color control** - You can use hex codes in your prompts to match exact colors. This is useful for brand work or when you need specific color accuracy.
+> 
+> **Resolution** - The model can edit images at resolutions up to 4 megapixels while keeping detail and coherence.
+> 
+> **Multi-reference editing** - When working with multiple reference images, you can point to specific images by their index number to tell the model which elements to use from where.
+> 
+> ## About the model
+> 
+> Flux 2 Pro uses a latent flow matching architecture that combines the Mistral-3 24 billion parameter vision-language model with a rectified flow transformer. The vision-language model brings real-world knowledge and context, while the transformer handles spatial relationships, materials, and composition. The model was trained from scratch with a new latent space optimized for both image quality and efficient learning.
+> 
+> Black Forest Labs built Flux 2 Pro as part of their open core approach - releasing both open-weight models for research and community use, alongside production-ready endpoints for teams that need reliability and scale.
+> 
+> ## Tips for better results
+> 
+> Use clear, specific language. The more detail you give, the more control you have over the output.
+> 
+> Describe what you want rather than what you don't want. Positive descriptions work much better than trying to exclude things.
+> 
+> Try hex codes when you need exact colors.
+> 
+> Experiment with multiple reference images to blend styles or maintain consistency across generations.
+> 
+> Keep your prompts concise but descriptive. You don't need to write paragraphs - just include the important details organized by priority.
+> 
+> ---
+> 
+> You can try Flux 2 Pro on the Replicate playground at replicate.com/playground
+

--- a/docs/replicate-models-docs/image/nano-banana-2.md
+++ b/docs/replicate-models-docs/image/nano-banana-2.md
@@ -1,0 +1,297 @@
+## Basic model info
+
+Model name: google/nano-banana-2
+Model description: Google's fast image generation model with conversational editing, multi-image fusion, and character consistency
+
+
+## Model inputs
+
+- prompt (required): A text description of the image you want to generate (string)
+- image_input (optional): Input images to transform or use as reference (supports up to 14 images) (array)
+- aspect_ratio (optional): Aspect ratio of the generated image (string)
+- resolution (optional): Resolution of the generated image. Higher resolutions take longer to generate. (string)
+- google_search (optional): Use Google Web Search grounding to generate images based on real-time information (e.g. weather, sports scores, recent events). (boolean)
+- image_search (optional): Use Google Image Search grounding to find web images as visual context for generation. When enabled, web search is also used automatically. (boolean)
+- output_format (optional): Format of the output image (string)
+
+
+## Model output schema
+
+{
+  "type": "string",
+  "title": "Output",
+  "format": "uri"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/pazq5tpd7xrmr0cwkbb8ek35pr)
+
+#### Input
+
+```json
+{
+  "prompt": "Create a picture of a nano banana 2 dish in a fancy restaurant with a Replicate theme",
+  "image_input": [],
+  "aspect_ratio": "match_input_image",
+  "output_format": "jpg"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/PNicQdZsGyLWNpXvNX4pqiaaotTP5j23J9cSyTuReLpLVxFLA/tmpx6zdponu.jpeg"
+```
+
+
+### Example (https://replicate.com/p/bca2qphr91rmw0cwkbb9ped188)
+
+#### Input
+
+```json
+{
+  "prompt": "a golden retriever puppy playing in autumn leaves, warm sunlight"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/0plMmeVefCSxxJV8MvxSWcIpzg08BRJX6pA9vKRJO02zTFXsA/tmp5hj7uutl.jpeg"
+```
+
+
+### Example (https://replicate.com/p/5cjmq0082hrmt0cwkbq8djs220)
+
+#### Input
+
+```json
+{
+  "prompt": "Anime character design, full color, concept sketch against white. Just the characters, no other sketches or words. A young adult man and woman on their phones, sitting cross legged, back to back. Pick interesting fashion choices, hair style and unusual footwear.",
+  "image_input": [],
+  "aspect_ratio": "1:1",
+  "output_format": "jpg"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/TZKrfYQ0XjUTKC5yAB1xV2HIQC1NIDYx4OXs1aGvCD1HhxFLA/tmp54fifmcm.jpeg"
+```
+
+
+### Example (https://replicate.com/p/gd6jm64pc1rmw0cwkbtrame0tm)
+
+#### Input
+
+```json
+{
+  "prompt": "A photorealistic close-up portrait of an elderly Japanese ceramicist with deep wrinkles and a warm smile, carefully inspecting a freshly glazed tea bowl in his rustic sun-drenched workshop. Soft golden hour light streams through a window, highlighting the texture of the clay. Shot with an 85mm portrait lens, shallow depth of field with creamy bokeh.",
+  "aspect_ratio": "3:4"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/IigIzxqBovIzM5GIkBm6Ef3LVeuT0djhy464hZdQHF8AKjLWA/tmpaiuubx6q.jpeg"
+```
+
+
+### Example (https://replicate.com/p/xycfvywebhrmw0cwkbvbz4sa6m)
+
+#### Input
+
+```json
+{
+  "prompt": "A kawaii-style sticker of a happy red panda wearing a tiny bamboo hat, munching on a green bamboo leaf. Bold clean outlines, simple cel-shading, vibrant color palette. White background.",
+  "aspect_ratio": "1:1"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/qnWLBLoTfV0vNSYB127ZEm6JMoOFNvdrWBZd4r4zTh4dlxFLA/tmp2oqfsqal.jpeg"
+```
+
+
+### Example (https://replicate.com/p/f6q14t3pasrmw0cwkbvr5ygnz0)
+
+#### Input
+
+```json
+{
+  "prompt": "A scientifically accurate cross-section infographic of the human eye, with clean labels pointing to the cornea, iris, pupil, lens, retina, and optic nerve. Modern flat design style with a dark navy background and bright accent colors. Title reads 'ANATOMY OF THE HUMAN EYE' in a clean sans-serif font at the top.",
+  "aspect_ratio": "16:9"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/6mD39k2BFyIAFlO3WJqx8hIZ2Yp4e2ALoM1qJeQz0A64LjLWA/tmppsnii9dg.jpeg"
+```
+
+
+### Example (https://replicate.com/p/5epfabq5zhrmw0cwkbvvbe7fr4)
+
+#### Input
+
+```json
+{
+  "prompt": "A cinematic wide shot of a lone astronaut standing on the surface of Mars, looking up at Earth visible in the dusty orange sky. Dramatic rim lighting from the setting sun creates a silhouette. Sci-fi atmosphere, photorealistic. Anamorphic lens flare.",
+  "aspect_ratio": "16:9"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/a6ZAPpRP0jKNCxBigH8HosbwZf2FtsnpPX5715yCjoiKmxFLA/tmpvkyyuodm.jpeg"
+```
+
+
+### Example (https://replicate.com/p/8pn0xwawd9rmt0cwkbw8wdhpz0)
+
+#### Input
+
+```json
+{
+  "prompt": "A watercolor painting of a Venetian canal at dawn. Gondolas are moored along weathered stone walls. Soft pastel reflections shimmer on the water. Loose, expressive brushstrokes with visible paper texture. Warm golden and cool blue tones.",
+  "aspect_ratio": "3:2"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/dYKsIq3ekWXwE6UweedeDWSAaAJNr1CWk2vbYwS7hXjXzMuYB/tmp3t1o4coa.jpeg"
+```
+
+
+### Example (https://replicate.com/p/bx55z76pc9rmt0cwkbwbv8601r)
+
+#### Input
+
+```json
+{
+  "prompt": "A modern minimalist logo for a sustainable coffee brand called 'EVERGREEN ROASTERS'. The logo features a stylized coffee leaf integrated with a coffee bean. Clean geometric lines, forest green and cream color scheme. White background.",
+  "aspect_ratio": "1:1"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/NKeJ1uwvfwsCFkb58grsKRBVExxF5acafVeoIUlIeKnJqZcxC/tmpmwiwv6gk.jpeg"
+```
+
+
+### Example (https://replicate.com/p/sty1jqtjc5rmt0cwkbwvm4hmtm)
+
+#### Input
+
+```json
+{
+  "prompt": "Transform this photograph into a Studio Ghibli anime style illustration. Keep the same composition but render everything with soft cel-shading, warm colors, and the dreamy atmosphere of a Miyazaki film.",
+  "image_input": [
+    "https://replicate.delivery/xezq/Res3dPZneqnk9E9z0qrPtIQchh0cc36J385ISGlJd3eeQLuYB/tmpcc4o9c5a.jpeg"
+  ],
+  "aspect_ratio": "match_input_image"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/Rh8hOr979h45BZnyYAMb12xy5Ef2ZIEPheIEwja3aOl4NjLWA/tmpnc9vxl6b.jpeg"
+```
+
+
+### Example (https://replicate.com/p/z92xaxpyhsrmw0cwkbwrm6jq8w)
+
+#### Input
+
+```json
+{
+  "prompt": "A 3-panel comic strip in a clean, modern cartoon style. Panel 1: A programmer stares at their screen with a confused expression, coffee cup in hand. Panel 2: The programmer's eyes widen as they spot the bug. Panel 3: The programmer celebrates with arms raised, confetti falls, and the screen shows a green checkmark. Caption at the bottom reads 'THE DEBUGGING EXPERIENCE'.",
+  "aspect_ratio": "16:9"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/YRmQpEdlIs6ULZPLTEiYh2Nd153SCW1IlssGry5FeWeZOjLWA/tmp_9laf92c.jpeg"
+```
+
+
+### Example (https://replicate.com/p/61egkqv1v9rmt0cwkbxbzw766w)
+
+#### Input
+
+```json
+{
+  "prompt": "An isometric 3D miniature diorama of a cozy Japanese ramen shop at night. Warm light spills from the entrance. Tiny detailed figures sit at the counter. Steam rises from bowls of ramen. Rain puddles reflect neon signs on the street. Tilt-shift photography effect.",
+  "aspect_ratio": "1:1"
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/aW4vaIf7HUzcXqnlgGeyic1l1eH0zUrRxNGtwcdDYOfu7MuYB/tmp7ag51byn.jpeg"
+```
+
+
+## Model readme
+
+> Nano Banana 2 is Google's latest image generation model, built on Gemini 3.1 Flash Image. It's the high-efficiency counterpart to [Nano Banana Pro](https://replicate.com/google/nano-banana-pro) — optimized for speed and high-volume use cases while still producing high-fidelity images.
+> 
+> Google [announced Nano Banana 2](https://blog.google/innovation-and-ai/technology/developers-tools/build-with-nano-banana-2/) on February 26, 2026, describing it as their "best image generation and editing model" — combining Pro-level visual quality with Flash-level speed and pricing.
+> 
+> ## What it can do
+> 
+> **Generate images from text.** Describe what you want and the model creates it — photorealistic scenes, illustrations, product mockups, whatever you need.
+> 
+> ![A cozy café interior at golden hour](https://replicate.delivery/xezq/Res3dPZneqnk9E9z0qrPtIQchh0cc36J385ISGlJd3eeQLuYB/tmpcc4o9c5a.jpeg)
+> 
+> **Render text accurately.** One of the standout improvements over previous Flash image models — text in images is crisp and readable, with support for multiple languages.
+> 
+> 
+> **Edit existing images.** Pass in one or more images along with a text prompt to transform them — change backgrounds, swap colors, adjust styles, or combine multiple images into one scene.
+> 
+> **Use up to 14 reference images.** Feed in multiple images for style transfer, image combination, or complex editing tasks that draw on several visual references at once.
+> 
+> ## Key improvements over the original Nano Banana
+> 
+> - Higher fidelity output with richer textures and sharper details
+> - Much better text rendering and multilingual support
+> - Stronger instruction following for complex prompts
+> - New aspect ratios: 1:4, 4:1, 1:8, and 8:1 (in addition to the standard set)
+> - Multiple output resolutions: 512px, 1K, 2K, and 4K
+> 
+> ## Aspect ratios
+> 
+> Supports `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, and `21:9`. Set `match_input_image` to automatically match the aspect ratio of your input image.
+> 
+> ## Output format
+> 
+> Choose between `jpg` (default) and `png`.
+> 
+> ## Links
+> 
+> - [Google's announcement blog post](https://blog.google/innovation-and-ai/technology/developers-tools/build-with-nano-banana-2/)
+> - [Gemini 3.1 Flash Image API docs](https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-image-preview)
+> - [Image generation guide](https://ai.google.dev/gemini-api/docs/image-generation)
+> 
+> You can try Nano Banana 2 on the [Replicate playground](https://replicate.com/playground).
+

--- a/docs/replicate-models-docs/image/seedream-4.5.md
+++ b/docs/replicate-models-docs/image/seedream-4.5.md
@@ -1,0 +1,157 @@
+## Basic model info
+
+Model name: bytedance/seedream-4.5
+Model description: Seedream 4.5: Upgraded Bytedance image model with stronger spatial understanding and world knowledge
+
+
+## Model inputs
+
+- prompt (required): Text prompt for image generation. Maximum 4000 characters. BytePlus recommends keeping prompts under 600 English words for best results. (string)
+- image_input (optional): Input image(s) for image-to-image generation. List of 1-14 images for single or multi-reference generation. (array)
+- size (optional): Image resolution: 2K (2048px), 4K (4096px), or 'custom' for specific dimensions. Note: 1K resolution is not supported in Seedream 4.5. (string)
+- aspect_ratio (optional): Image aspect ratio. Only used when size is not 'custom'. Use 'match_input_image' to automatically match the input image's aspect ratio. (string)
+- width (optional): Custom image width (only used when size='custom'). Range: 1024-4096 pixels. (integer)
+- height (optional): Custom image height (only used when size='custom'). Range: 1024-4096 pixels. (integer)
+- sequential_image_generation (optional): Group image generation mode. 'disabled' generates a single image. 'auto' lets the model decide whether to generate multiple related images (e.g., story scenes, character variations). (string)
+- max_images (optional): Maximum number of images to generate when sequential_image_generation='auto'. Range: 1-15. Total images (input + generated) cannot exceed 15. (integer)
+- disable_safety_checker (optional): Disable the safety checker for generated images. When enabled, input moderation is relaxed to only block illegal content (CSAM). Use responsibly. (boolean)
+
+
+## Model output schema
+
+{
+  "type": "array",
+  "items": {
+    "type": "string",
+    "format": "uri"
+  },
+  "title": "Output"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/9vw2ze1x09rme0ctwjdvgfa1c8)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "prompt": "an abstract modern art painting of glass fruit, the glass shines with an iridescent flare, the fruit is transparent",
+  "max_images": 1,
+  "image_input": [],
+  "aspect_ratio": "match_input_image",
+  "sequential_image_generation": "disabled"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/DRFeuDyXJUxzJCjEfvCAUHFg1CrysxvzWwu5y4Xbl7VfVf9WB/tmphy771eq9.jpg"
+]
+```
+
+
+### Example (https://replicate.com/p/v5h0j0cwhsrma0ctwjhvzdp4s4)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "prompt": "new york",
+  "max_images": 1,
+  "image_input": [
+    "https://replicate.delivery/pbxt/OAaYu3nOgLO4ukhJDZEDCXJhgxb34siLv1LMnWhS2yodrAYI/preview-7.webp"
+  ],
+  "aspect_ratio": "match_input_image",
+  "sequential_image_generation": "disabled"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/v6u1m55gG1LfYaUnAZZUNyLxY797ttIOV7cvxI7amffcmf9WB/tmptbtp7ee8.jpg"
+]
+```
+
+
+### Example (https://replicate.com/p/gajz93f8gdrmc0ctx9kt03372r)
+
+#### Input
+
+```json
+{
+  "size": "4K",
+  "width": 2048,
+  "height": 2048,
+  "prompt": "A warm, nostalgic film-style interior of a cozy caf\u00e9, shot on 35mm-inspired digital photography with soft afternoon sunlight filtering through the front windows. Wooden shelves display neatly arranged ceramics, pastries, and coffee beans. Hand-painted signage on the main interior window reads \u2018Seedream 4.5\u2019 in clean, classic lettering, similar to boutique branding. A vintage bicycle with a wicker basket is visible outside the entrance, casting soft shadows on the floor. Rich textures, natural light, warm tones, subtle grain, and calm neighborhood-caf\u00e9 ambiance.",
+  "max_images": 1,
+  "image_input": [],
+  "aspect_ratio": "16:9",
+  "sequential_image_generation": "disabled"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/lSRiDsXJnC5HD9gOSrb2HTgAYRMRSmyd0UcbvzMhVSEp29bF/tmpq47k3q7q.jpg"
+]
+```
+
+
+## Model readme
+
+> Seedream 4.5 is a next-generation visual generation model designed for high-quality, consistent, and production-ready outputs. It delivers cinematic aesthetics, strong spatial reasoning, and precise instruction following, making it suitable for both creative and professional workflows.
+> 
+> Features:
+> 
+> ⭐ Superior Aesthetics
+> 
+> Produces cinematic, film-like visuals
+> Refined lighting, shading, and rendering for polished results
+> 
+> 🔁 Higher Consistency
+> 
+> Maintains stable subjects across multiple images
+> 
+> Preserves clear details and coherent scenes
+> 
+> 🧠 Smarter Instruction Following
+> 
+> Accurately interprets complex or layered prompts
+> 
+> Supports precise visual control and interactive editing
+> 
+> 📐 Stronger Spatial Understanding
+> 
+> Realistic proportions, layout, and object placement
+> 
+> Generates believable, structured environments
+> 
+> 🌍 Richer World Knowledge
+> 
+> Creates knowledge-grounded visuals
+> 
+> Supports accurate scientific, technical, and real-world reasoning
+> 
+> 🏭 Industry-Ready Applications
+> 
+> Optimized for professional workflows across:
+> E-commerce,
+> Film & advertising,
+> Gaming & virtual worlds,
+> Education & training,
+> Interior & architectural design
+

--- a/docs/replicate-models-docs/image/seedream-5-lite.md
+++ b/docs/replicate-models-docs/image/seedream-5-lite.md
@@ -1,0 +1,246 @@
+## Basic model info
+
+Model name: bytedance/seedream-5-lite
+Model description: Seedream 5.0 lite: image generation with built-in reasoning, example-based editing, and deep domain knowledge
+
+
+## Model inputs
+
+- prompt (required): Text prompt for image generation. Maximum 4000 characters. BytePlus recommends keeping prompts under 600 English words for best results. (string)
+- image_input (optional): Input image(s) for image-to-image generation. List of 1-14 images for single or multi-reference generation. (array)
+- size (optional): Image resolution: 2K (2048px) or 3K (3072px). (string)
+- aspect_ratio (optional): Image aspect ratio. Use 'match_input_image' to automatically match the input image's aspect ratio. (string)
+- sequential_image_generation (optional): Group image generation mode. 'disabled' generates a single image. 'auto' lets the model decide whether to generate multiple related images (e.g., story scenes, character variations). (string)
+- max_images (optional): Maximum number of images to generate when sequential_image_generation='auto'. Range: 1-15. Total images (input + generated) cannot exceed 15. (integer)
+- output_format (optional): Output image format. (string)
+- return_byteplus_urls (optional): Return raw BytePlus-hosted image URLs instead of downloading the images. These URLs are recognized as trusted inputs by Seedance 2.0, bypassing face detection moderation when passed as reference images. URLs expire after 24 hours. (boolean)
+
+
+## Model output schema
+
+{
+  "type": "array",
+  "items": {
+    "type": "string",
+    "format": "uri"
+  },
+  "title": "Output"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/644agnmbgdrmt0cwhwnsz3fe4w)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "prompt": "A Renaissance-style oil painting of a modern-day farmer's market. A woman in a hoodie and jeans examines heirloom tomatoes under a striped canvas awning, lit like a Vermeer interior. Behind her, a man with a beard sells artisanal sourdough loaves arranged in a pyramid. A golden retriever sits patiently beside a stroller. Bunches of sunflowers, purple lavender, and fresh herbs in mason jars line the tables. String lights crisscross overhead. A busker plays acoustic guitar in the background. Children chase soap bubbles. The scene has the warm, golden light of a Dutch Golden Age painting but every detail is unmistakably contemporary.",
+  "aspect_ratio": "16:9"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/eG2pfAezTFZtzow6LeIxb6wiyJYlcsNW6Y092mDvLFjrfWWxC/tmpud9jmfu_.png"
+]
+```
+
+
+### Example (https://replicate.com/p/h5gb22d3hsrmy0cwhwp8hd7pxc)
+
+#### Input
+
+```json
+{
+  "size": "3K",
+  "prompt": "A detailed cross-section diagram of a coral reef ecosystem, scientific illustration style. Below: volcanic basalt foundation. Middle: calcium carbonate reef structure with visible fossil layers. Upper reef: a thriving ecosystem with labeled species \u2014 staghorn coral, brain coral, clownfish in an anemone, a moray eel in a crevice, parrotfish grazing, sea turtle swimming above. Above the waterline: a small tropical island with palm trees. Depth markers on the left edge in meters. Precise linework with watercolor fills. Labels in elegant serif type. Published in Nature magazine style.",
+  "aspect_ratio": "16:9"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/wUZPIpHJ3MIXGhIeWqlmCTrDalOf67gbAnndKlehPJtCylVsA/tmpzh3ov7wk.png"
+]
+```
+
+
+### Example (https://replicate.com/p/fqwbwgp8k9rmw0cwhwp9n2pf38)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "prompt": "A large-format typographic poster for a fictional jazz festival. At the top in bold condensed sans-serif: \"BLUE NOTE SESSIONS\" in deep navy. Below in elegant script: \"Summer 2026 \u2014 Central Park, New York.\" The poster lists four performers: \"Miles Ahead Quintet / Saturday 8PM\" \"Sarah Chen Trio / Saturday 10PM\" \"The Monk Revival / Sunday 7PM\" \"Coltrane Legacy Orchestra / Sunday 9PM\". A stylized golden saxophone silhouette runs vertically along the right edge. Background is a gradient from midnight blue to warm amber. At the bottom in small caps: \"Tickets at bluenote.nyc \u2014 All ages welcome.\"",
+  "aspect_ratio": "2:3"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/YrcPJs8bekVhOafodLLfSHIQFqCWIV6fuzreu2tFRqfMRusiF/tmpnxzxgtdu.png"
+]
+```
+
+
+### Example (https://replicate.com/p/hmjg29v36nrmw0cwhwnvgzresm)
+
+#### Input
+
+```json
+{
+  "size": "3K",
+  "prompt": "A 2x3 comic strip panel layout in a bold, dynamic superhero style with thick black outlines and vibrant colors. Panel 1: A masked hero in a red and gold suit stands on a rooftop at night, cape billowing, city skyline behind her. Speech bubble: \"The signal...\". Panel 2: Close-up of her eyes narrowing with determination, reflections of fire in her visor. Panel 3: She leaps off the building, dynamic diagonal composition with speed lines. Sound effect text: \"WHOOOOSH\". Panel 4: She lands in a crater on a street, one fist down, cracks radiating outward. Panel 5: She looks up at a towering robot with glowing red eyes. Speech bubble: \"You picked the wrong city.\" Panel 6: Wide shot of her charging at the robot, energy crackling from her fists. Bold title at top: \"CRIMSON VANGUARD\" issue #1.",
+  "aspect_ratio": "2:3"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/lJnomOULuzJgBNDtrNd8Ivmrl4HfNB6pANsTzZOfNntG4yKWA/tmprodz3p3y.png"
+]
+```
+
+
+### Example (https://replicate.com/p/rn3r1mrvmhrmt0cwhwsb8fjgp8)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "prompt": "A woman standing in a Tokyo alleyway at dusk, neon signs reflecting off wet pavement. Shot on expired Kodak Portra 800, pushed two stops. The tungsten light from a ramen shop spills warm orange across her face while the neon casts cool cyan highlights on her hair. Visible grain, halation around the light sources, slightly lifted blacks. She's mid-step, caught between two worlds of color.",
+  "aspect_ratio": "2:3"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/gLPicWRN4L4FORGw0oo2NnOUG4fizBjcsM5bxt02vNgRfyKWA/tmpd2i2i3b0.png"
+]
+```
+
+
+### Example (https://replicate.com/p/csr99hh919rmw0cwhwsr58c4e4)
+
+#### Input
+
+```json
+{
+  "size": "2K",
+  "prompt": "A striking fashion editorial photograph of a model wearing an elaborate haute couture gown made entirely of living flowers \u2014 white peonies, pale pink roses, and trailing jasmine. She stands in a misty English garden at dawn. The dress cascades to the ground and merges with the garden floor. Dewdrops on every petal catch the first light. Her hair is pulled back severely, face serene, skin porcelain. A single monarch butterfly rests on her shoulder. The background is a soft impressionist blur of green hedgerows and pale sky. Shot on Phase One IQ4 150MP, every stamen and pistil razor sharp.",
+  "aspect_ratio": "2:3"
+}
+```
+
+#### Output
+
+```json
+[
+  "https://replicate.delivery/xezq/jgk6z2NaG3oELlJTG2ZifjbadsXTmHAPqSKjmhpQefWCfLrYB/tmpqviali82.png"
+]
+```
+
+
+## Model readme
+
+> # Seedream 5.0 lite
+> 
+> Seedream 5.0 lite is ByteDance's latest image generation model. It goes beyond standard text-to-image by adding multi-step reasoning, example-based editing, and deep domain knowledge to the generation process.
+> 
+> ## What's new in 5.0
+> 
+> ### Example-based editing
+> Instead of describing a complex edit in words, show the model what you want. Give it a before/after pair, then a new image — the model figures out what changed and applies the same transformation. This works for material swaps, style transfers, scene changes, and more.
+> 
+> ### Logical reasoning
+> Seedream 5.0 reasons through spatial relationships, physics, and processes. Ask it to put objects on a seesaw with correct weight distribution, draw a clock with hands in the right positions, or illustrate a metamorphosis across life stages — it gets the details right.
+> 
+> ### Deep domain knowledge
+> The model understands professional conventions across architecture, science, health, and design. Feed it a floor plan sketch and get a photorealistic interior rendering. Ask for a scientific cross-section diagram and get labeled, accurate illustrations.
+> 
+> ## Features
+> 
+> - **Text-to-image**: Generate images from text prompts with strong aesthetic quality
+> - **Image-to-image**: Edit existing images using natural language instructions
+> - **Multi-image blending**: Combine up to 14 reference images with text to create new compositions
+> - **Sequential batch generation**: Generate sets of related images (storyboards, brand identity packages, character sheets) in one request
+> - **Text rendering**: Accurate typography with support for multiple languages — wrap text in double quotes for best results
+> - **Output format**: PNG or JPEG output
+> 
+> ## Resolutions
+> 
+> - **2K**: Up to 2048px base dimension
+> - **3K**: Up to 3072px base dimension
+> 
+> Supported aspect ratios: 1:1, 4:3, 3:4, 16:9, 9:16, 3:2, 2:3, 21:9
+> 
+> ## Prompting tips
+> 
+> 1. **Use natural language, not keyword lists.** "A girl in a lavish dress walking under a parasol along a tree-lined path, in the style of a Monet oil painting" works better than "girl, umbrella, tree-lined street, oil painting texture."
+> 2. **Use double quotes for text rendering.** If you want specific text in your image, wrap it in double quotation marks.
+> 3. **Be specific about what to keep.** When editing, tell the model what shouldn't change: "Replace the hat with a crown, keeping the pose and expression unchanged."
+> 4. **For example-based editing, show don't tell.** When the transformation is hard to describe in words, provide a before/after example pair as input images.
+> 5. **Specify your use case.** Telling the model "Design a logo for a gaming company" gives better results than just describing the visual elements.
+> 
+> ## API quickstart
+> 
+> ```python
+> import replicate
+> 
+> output = replicate.run(
+>     "bytedance/seedream-5",
+>     input={
+>         "prompt": "A color film-inspired portrait with shallow depth of field, fine grain suggesting high ISO film stock, candid documentary style",
+>         "size": "2K",
+>         "aspect_ratio": "3:2",
+>     }
+> )
+> 
+> print(output)
+> ```
+> 
+> ### With image input
+> 
+> ```python
+> output = replicate.run(
+>     "bytedance/seedream-5",
+>     input={
+>         "prompt": "Transform the color grading to match a Wong Kar-wai film — saturated teal shadows, warm amber highlights, soft diffusion",
+>         "image_input": ["https://example.com/portrait.jpg"],
+>         "size": "2K",
+>     }
+> )
+> ```
+> 
+> ### Batch generation
+> 
+> ```python
+> output = replicate.run(
+>     "bytedance/seedream-5",
+>     input={
+>         "prompt": "A series of 4 coherent illustrations of a courtyard across the four seasons",
+>         "sequential_image_generation": "auto",
+>         "max_images": 4,
+>     }
+> )
+> ```
+

--- a/e2e/mocks/api.js
+++ b/e2e/mocks/api.js
@@ -131,6 +131,101 @@ export async function mockGptImage1(page, { response = FAKE_GENERATED_IMAGE, ass
 }
 
 /**
+ * Mock the Nano Banana 2 image generation endpoint.
+ * The real model returns a single URI, so `output` is a plain string here.
+ */
+export async function mockNanoBanana2(page, { response = FAKE_GENERATED_IMAGE, assertRequest } = {}) {
+  await page.route('**/v1/models/google/nano-banana-2/predictions', async (route) => {
+    const body = JSON.parse(route.request().postData())
+
+    if (assertRequest) {
+      assertRequest(body)
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'img-pred-' + Date.now(),
+        status: 'succeeded',
+        output: response,
+      }),
+    })
+  })
+}
+
+/**
+ * Mock the Seedream-4.5 image generation endpoint.
+ */
+export async function mockSeedream45(page, { response = FAKE_GENERATED_IMAGE, assertRequest } = {}) {
+  await page.route('**/v1/models/bytedance/seedream-4.5/predictions', async (route) => {
+    const body = JSON.parse(route.request().postData())
+
+    if (assertRequest) {
+      assertRequest(body)
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'img-pred-' + Date.now(),
+        status: 'succeeded',
+        output: [response],
+      }),
+    })
+  })
+}
+
+/**
+ * Mock the Seedream-5 Lite image generation endpoint.
+ */
+export async function mockSeedream5Lite(page, { response = FAKE_GENERATED_IMAGE, assertRequest } = {}) {
+  await page.route('**/v1/models/bytedance/seedream-5-lite/predictions', async (route) => {
+    const body = JSON.parse(route.request().postData())
+
+    if (assertRequest) {
+      assertRequest(body)
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'img-pred-' + Date.now(),
+        status: 'succeeded',
+        output: [response],
+      }),
+    })
+  })
+}
+
+/**
+ * Mock any of the three FLUX.2 image generation endpoints.
+ * They share a payload shape, so the variant is just part of the path.
+ * @param {'flex'|'pro'|'max'} variant
+ */
+export async function mockFlux2(page, variant, { response = FAKE_GENERATED_IMAGE, assertRequest } = {}) {
+  await page.route(`**/v1/models/black-forest-labs/flux-2-${variant}/predictions`, async (route) => {
+    const body = JSON.parse(route.request().postData())
+
+    if (assertRequest) {
+      assertRequest(body)
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'img-pred-' + Date.now(),
+        status: 'succeeded',
+        output: response,
+      }),
+    })
+  })
+}
+
+/**
  * Mock the P-Video video generation endpoint.
  * The real model returns a single URI, so `output` is a plain string here.
  */

--- a/e2e/new-image-models.spec.js
+++ b/e2e/new-image-models.spec.js
@@ -1,0 +1,246 @@
+import { test, expect } from '@playwright/test'
+import {
+  FAKE_GENERATED_IMAGE,
+  mockNanoBanana2,
+  mockSeedream45,
+  mockSeedream5Lite,
+  mockFlux2,
+} from './mocks/api.js'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+  selectModel,
+} from './helpers/canvas.js'
+
+const MORE_OPTIONS_BUTTON = 'button[title="More options"]'
+const PANEL = '.node-options-panel'
+
+/**
+ * What each new model puts in the node toolbar and what it moves to the side
+ * panel. The toolbar is one row, so only the two options worth a single click
+ * live there
+ */
+const MODELS = [
+  {
+    id: 'nano-banana-2',
+    toolbar: ['aspect_ratio', 'resolution'],
+    panel: ['output_format', 'google_search', 'image_search'],
+  },
+  {
+    id: 'seedream-4.5',
+    toolbar: ['size', 'aspect_ratio'],
+    panel: ['width', 'height', 'disable_safety_checker'],
+  },
+  {
+    id: 'seedream-5-lite',
+    toolbar: ['aspect_ratio', 'size'],
+    panel: ['output_format', 'return_byteplus_urls'],
+  },
+  {
+    id: 'flux-2-flex',
+    toolbar: ['aspect_ratio', 'resolution'],
+    panel: ['steps', 'guidance', 'prompt_upsampling', 'output_format', 'seed'],
+  },
+  {
+    id: 'flux-2-pro',
+    toolbar: ['aspect_ratio', 'resolution'],
+    panel: ['width', 'height', 'output_format', 'safety_tolerance', 'seed'],
+  },
+  {
+    id: 'flux-2-max',
+    toolbar: ['aspect_ratio', 'resolution'],
+    panel: ['width', 'height', 'output_format', 'safety_tolerance', 'seed'],
+  },
+]
+
+/**
+ * Drop an Image Generator on the canvas and switch it to `modelId`.
+ */
+async function setupGenerator(page, modelId) {
+  await setupBlankCanvas(page)
+  await addNodeFromSidebar(page, 'Image Generator')
+
+  const node = page.locator('.vue-flow__node-image-generator')
+  await positionNodes(page, [{ type: 'image-generator', x: 320, y: 220 }])
+  await selectModel(page, node, modelId)
+
+  return node
+}
+
+/**
+ * Select the node again so its toolbar shows, then open the options panel.
+ */
+async function openPanel(page, nodeLocator) {
+  const box = await nodeLocator.boundingBox()
+  await page.mouse.click(box.x + box.width / 2, box.y + 30)
+  await page.locator('#model-select').waitFor({ state: 'visible', timeout: 5000 })
+
+  await page.locator(MORE_OPTIONS_BUTTON).click()
+  await expect(page.locator(PANEL)).toBeVisible()
+}
+
+/**
+ * Type a prompt and generate, waiting for the image to land in the node.
+ */
+async function generate(page, nodeLocator, prompt = 'a lighthouse in a storm') {
+  await nodeLocator.locator('textarea').fill(prompt)
+  await nodeLocator.getByRole('button', { name: 'Generate Image' }).click()
+
+  await expect(nodeLocator.locator('.image-preview img')).toBeVisible({ timeout: 15000 })
+  await expect(nodeLocator.locator('.image-preview img')).toHaveAttribute('src', FAKE_GENERATED_IMAGE)
+}
+
+test.describe('New image models', () => {
+  test('every new model is offered by the Image Generator', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    const node = page.locator('.vue-flow__node-image-generator')
+    await positionNodes(page, [{ type: 'image-generator', x: 320, y: 220 }])
+
+    const box = await node.boundingBox()
+    await page.mouse.click(box.x + box.width / 2, box.y + 30)
+
+    const modelSelect = page.locator('#model-select')
+    await modelSelect.waitFor({ state: 'visible', timeout: 5000 })
+
+    const values = await modelSelect.locator('option').evaluateAll(
+      options => options.map(o => o.value)
+    )
+
+    for (const model of MODELS) {
+      expect(values).toContain(model.id)
+    }
+  })
+
+  for (const model of MODELS) {
+    test(`${model.id} splits its options between toolbar and panel`, async ({ page }) => {
+      const node = await setupGenerator(page, model.id)
+      await openPanel(page, node)
+
+      for (const key of model.toolbar) {
+        await expect(page.locator(`#control-${key}`)).toBeVisible()
+      }
+
+      for (const key of model.panel) {
+        await expect(page.locator(`#panel-control-${key}`)).toBeVisible()
+        // A key never shows up in both places at once
+        await expect(page.locator(`#control-${key}`)).toHaveCount(0)
+      }
+    })
+  }
+
+  test('Nano Banana 2 sends its toolbar and panel options', async ({ page }) => {
+    let received = null
+    await mockNanoBanana2(page, { assertRequest: (body) => { received = body.input } })
+
+    const node = await setupGenerator(page, 'nano-banana-2')
+    await openPanel(page, node)
+
+    await page.locator('#panel-control-google_search').check()
+    await page.locator('#panel-control-output_format').selectOption('png')
+
+    // Clicking away dismisses the toolbar and closes the panel with it
+    await page.mouse.click(10, 10)
+    await expect(page.locator(PANEL)).toBeHidden()
+
+    await generate(page, node)
+
+    expect(received.aspect_ratio).toBe('match_input_image')
+    expect(received.resolution).toBe('2K')
+    expect(received.output_format).toBe('png')
+    expect(received.google_search).toBe(true)
+    expect(received.image_search).toBe(false)
+  })
+
+  test('Seedream-4.5 asks for a single image', async ({ page }) => {
+    let received = null
+    await mockSeedream45(page, { assertRequest: (body) => { received = body.input } })
+
+    const node = await setupGenerator(page, 'seedream-4.5')
+    await generate(page, node)
+
+    expect(received.size).toBe('2K')
+    // The node shows one image, so it must never pay for a batch
+    expect(received.max_images).toBe(1)
+    expect(received.sequential_image_generation).toBe('disabled')
+    expect(received.disable_safety_checker).toBe(false)
+  })
+
+  test('Seedream-5 Lite asks for a single image', async ({ page }) => {
+    let received = null
+    await mockSeedream5Lite(page, { assertRequest: (body) => { received = body.input } })
+
+    const node = await setupGenerator(page, 'seedream-5-lite')
+    await generate(page, node)
+
+    expect(received.size).toBe('2K')
+    expect(received.output_format).toBe('png')
+    expect(received.max_images).toBe(1)
+    expect(received.sequential_image_generation).toBe('disabled')
+  })
+
+  test('FLUX.2 Flex sends steps, guidance and a numeric seed', async ({ page }) => {
+    let received = null
+    await mockFlux2(page, 'flex', { assertRequest: (body) => { received = body.input } })
+
+    const node = await setupGenerator(page, 'flux-2-flex')
+    await openPanel(page, node)
+
+    await page.locator('#panel-control-steps').fill('30')
+    await page.locator('#panel-control-guidance').fill('4.5')
+    await page.locator('#panel-control-seed').fill('4242')
+    await page.locator('#panel-control-seed').blur()
+
+    await page.mouse.click(10, 10)
+    await expect(page.locator(PANEL)).toBeHidden()
+
+    await generate(page, node)
+
+    expect(received.steps).toBe(30)
+    expect(received.guidance).toBe(4.5)
+    expect(received.seed).toBe(4242)
+    expect(received.resolution).toBe('1 MP')
+    expect(received.output_quality).toBe(80)
+  })
+
+  test('FLUX.2 Pro swaps resolution for width and height on a custom ratio', async ({ page }) => {
+    let received = null
+    await mockFlux2(page, 'pro', { assertRequest: (body) => { received = body.input } })
+
+    const node = await setupGenerator(page, 'flux-2-pro')
+    await openPanel(page, node)
+
+    // Dimensions are only read when the ratio is free-form
+    await page.locator('#control-aspect_ratio').selectOption('custom')
+    await page.locator('#panel-control-width').fill('1500')
+    await page.locator('#panel-control-height').fill('1000')
+    await page.locator('#panel-control-height').blur()
+
+    await page.mouse.click(10, 10)
+    await expect(page.locator(PANEL)).toBeHidden()
+
+    await generate(page, node)
+
+    expect(received.aspect_ratio).toBe('custom')
+    expect(received.resolution).toBeUndefined()
+    // Rounded to the multiple of 16 the model works in
+    expect(received.width).toBe(1504)
+    expect(received.height).toBe(1008)
+  })
+
+  test('FLUX.2 Max sends its defaults untouched', async ({ page }) => {
+    let received = null
+    await mockFlux2(page, 'max', { assertRequest: (body) => { received = body.input } })
+
+    const node = await setupGenerator(page, 'flux-2-max')
+    await generate(page, node)
+
+    expect(received.aspect_ratio).toBe('1:1')
+    expect(received.resolution).toBe('1 MP')
+    expect(received.output_format).toBe('webp')
+    expect(received.safety_tolerance).toBe(2)
+    expect(received.input_images).toEqual([])
+  })
+})

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -80,6 +80,64 @@ Fast and efficient image generation model.
 
 **Input Images:** Supports up to 14 input images
 
+#### nano-banana-2 (Google)
+
+Gemini 3.1 Flash Image: Pro-level quality at Flash speed, with web grounding.
+
+**Parameters:**
+- `aspect_ratio`: "match_input_image", "1:1", "16:9", … up to "8:1" (default: "match_input_image")
+- `resolution`: "1K", "2K", "4K" (default: "2K")
+- `output_format`: "jpg", "png" (default: "jpg")
+- `google_search`: boolean (default: false) - Ground the image on real-time web results
+- `image_search`: boolean (default: false) - Use web images as visual context
+
+**Input Images:** Supports up to 14 input images
+
+#### seedream-4.5 (ByteDance)
+
+Upgraded SeeDream with stronger spatial understanding. Note that 1K is not a
+valid size here, unlike SeeDream-4.
+
+**Parameters:**
+- `size`: "2K", "4K", "custom" (default: "2K")
+- `aspect_ratio`: "match_input_image", "1:1", "16:9", … (default: "match_input_image")
+- `width` / `height`: 1024-4096, only read when `size` is "custom"
+- `disable_safety_checker`: boolean (default: false)
+
+**Input Images:** Supports up to 14 input images
+
+#### seedream-5-lite (ByteDance)
+
+SeeDream 5.0 lite: built-in reasoning and example-based editing.
+
+**Parameters:**
+- `aspect_ratio`: "match_input_image", "1:1", "16:9", … (default: "match_input_image")
+- `size`: "2K", "3K" (default: "2K")
+- `output_format`: "png", "jpeg" (default: "png")
+- `return_byteplus_urls`: boolean (default: false) - URLs that expire in 24 hours
+
+**Input Images:** Supports up to 14 input images
+
+#### flux-2-flex, flux-2-pro, flux-2-max (Black Forest Labs)
+
+The FLUX.2 family. They share a payload; Flex adds the quality-versus-speed
+dials, Max is the highest fidelity of the three.
+
+**Parameters:**
+- `aspect_ratio`: "match_input_image", "1:1", … , "custom" (default: "1:1")
+- `resolution`: "match_input_image", "0.5 MP", "1 MP", "2 MP", "4 MP" (default: "1 MP")
+- `width` / `height`: 256-2048, rounded to a multiple of 16, only read when
+  `aspect_ratio` is "custom". They replace `resolution`, which is not sent then
+- `output_format`: "webp", "jpg", "png" (default: "webp")
+- `output_quality`: 0-100 (default: 80), ignored for png
+- `safety_tolerance`: 1-5 (default: 2), 1 being the strictest
+- `seed`: integer (optional)
+- Flex only — `steps`: 1-50 (default: 20), `guidance`: 1-10 (default: 3.5),
+  `prompt_upsampling`: boolean (default: false)
+
+**Input Images:** Flex takes up to 10, Pro and Max up to 8. The payload key is
+`input_images`, not `image_input`
+
 ### Text Generation Models
 
 #### GPT-5 (OpenAI)

--- a/src/services/models/flux-2-flex.js
+++ b/src/services/models/flux-2-flex.js
@@ -1,0 +1,317 @@
+/**
+ * Black Forest Labs FLUX.2 Flex Model Configuration
+ * Model: black-forest-labs/flux-2-flex
+ */
+
+export const FLUX_2_FLEX = {
+  id: 'flux-2-flex',
+  name: 'FLUX.2 Flex',
+  owner: 'black-forest-labs',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/black-forest-labs/flux-2-flex/predictions',
+
+  /**
+   * Default parameters for the model
+   */
+  defaults: {
+    aspect_ratio: '1:1',
+    resolution: '1 MP',
+    width: 1024,
+    height: 1024,
+    steps: 20,
+    guidance: 3.5,
+    prompt_upsampling: false,
+    safety_tolerance: 2,
+    output_format: 'webp',
+    output_quality: 80
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'flux-2-flex',
+    label: 'FLUX.2 Flex',
+    controls: [
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: [
+          'match_input_image',
+          '1:1', '3:4', '4:3', '2:3', '3:2',
+          '4:5', '5:4', '9:16', '16:9', '9:21', '21:9',
+          'custom'
+        ],
+        default: '1:1'
+      },
+      {
+        key: 'resolution',
+        label: 'Resolution',
+        type: 'select',
+        enum: ['match_input_image', '0.5 MP', '1 MP', '2 MP', '4 MP'],
+        default: '1 MP'
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'steps',
+        label: 'Steps',
+        type: 'number',
+        min: 1,
+        max: 50,
+        default: 20,
+        description: 'The quality dial. Few steps generate fast, many sharpen the detail'
+      },
+      {
+        key: 'guidance',
+        label: 'Guidance',
+        type: 'number',
+        min: 1,
+        max: 10,
+        step: 0.1,
+        default: 3.5,
+        description: 'How literally the model follows the prompt. Low values leave it more freedom'
+      },
+      {
+        key: 'prompt_upsampling',
+        label: 'Prompt upsampling',
+        type: 'checkbox',
+        default: false,
+        description: 'Let the model rewrite the prompt for a more creative generation'
+      },
+      {
+        key: 'width',
+        label: 'Custom width',
+        type: 'number',
+        min: 256,
+        max: 2048,
+        step: 16,
+        default: 1024,
+        description: 'Only used when Aspect Ratio is set to custom. Rounded to a multiple of 16'
+      },
+      {
+        key: 'height',
+        label: 'Custom height',
+        type: 'number',
+        min: 256,
+        max: 2048,
+        step: 16,
+        default: 1024,
+        description: 'Only used when Aspect Ratio is set to custom. Rounded to a multiple of 16'
+      },
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['webp', 'jpg', 'png'],
+        default: 'webp'
+      },
+      {
+        key: 'output_quality',
+        label: 'Output quality',
+        type: 'number',
+        min: 0,
+        max: 100,
+        default: 80,
+        description: 'Ignored for png outputs'
+      },
+      {
+        key: 'safety_tolerance',
+        label: 'Safety tolerance',
+        type: 'number',
+        min: 1,
+        max: 5,
+        default: 2,
+        description: '1 is the strictest, 5 the most permissive'
+      },
+      {
+        key: 'seed',
+        label: 'Seed',
+        type: 'number',
+        default: null,
+        placeholder: 'Random',
+        description: 'Fix it to reproduce the same generation twice'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    aspect_ratio: [
+      'match_input_image',
+      '1:1', '3:4', '4:3', '2:3', '3:2',
+      '4:5', '5:4', '9:16', '16:9', '9:21', '21:9',
+      'custom'
+    ],
+    resolution: ['match_input_image', '0.5 MP', '1 MP', '2 MP', '4 MP'],
+    output_format: ['webp', 'jpg', 'png']
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {Array<string>} [options.imageInput] - Input images (up to 10)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    if (imageInput.length > 10) {
+      throw new Error('Maximum 10 input images are supported')
+    }
+
+    const input = {
+      prompt: prompt.trim(),
+      input_images: imageInput,
+      aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
+      steps: params.steps ?? this.defaults.steps,
+      guidance: params.guidance ?? this.defaults.guidance,
+      prompt_upsampling: params.prompt_upsampling !== undefined
+        ? params.prompt_upsampling
+        : this.defaults.prompt_upsampling,
+      safety_tolerance: params.safety_tolerance ?? this.defaults.safety_tolerance,
+      output_format: params.output_format || this.defaults.output_format,
+      output_quality: params.output_quality ?? this.defaults.output_quality
+    }
+
+    // Width and height replace the resolution when the ratio is free-form
+    if (input.aspect_ratio === 'custom') {
+      input.width = params.width || this.defaults.width
+      input.height = params.height || this.defaults.height
+    } else {
+      input.resolution = params.resolution || this.defaults.resolution
+    }
+
+    // Optional seed for reproducible generations
+    if (params.seed !== undefined && params.seed !== null && params.seed !== '') {
+      input.seed = parseInt(params.seed)
+    }
+
+    return input
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    const validated = {}
+
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.resolution && !this.validValues.resolution.includes(params.resolution)) {
+      throw new Error(`Invalid resolution. Must be one of: ${this.validValues.resolution.join(', ')}`)
+    }
+
+    if (params.output_format && !this.validValues.output_format.includes(params.output_format)) {
+      throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
+    }
+
+    if (params.steps !== undefined && params.steps !== null) {
+      const steps = parseInt(params.steps)
+      if (isNaN(steps) || steps < 1 || steps > 50) {
+        throw new Error('steps must be between 1 and 50')
+      }
+      validated.steps = steps
+    }
+
+    if (params.guidance !== undefined && params.guidance !== null) {
+      const guidance = parseFloat(params.guidance)
+      if (isNaN(guidance) || guidance < 1 || guidance > 10) {
+        throw new Error('guidance must be between 1 and 10')
+      }
+      validated.guidance = guidance
+    }
+
+    if (params.safety_tolerance !== undefined && params.safety_tolerance !== null) {
+      const tolerance = parseInt(params.safety_tolerance)
+      if (isNaN(tolerance) || tolerance < 1 || tolerance > 5) {
+        throw new Error('safety_tolerance must be between 1 and 5')
+      }
+      validated.safety_tolerance = tolerance
+    }
+
+    if (params.output_quality !== undefined && params.output_quality !== null) {
+      const quality = parseInt(params.output_quality)
+      if (isNaN(quality) || quality < 0 || quality > 100) {
+        throw new Error('output_quality must be between 0 and 100')
+      }
+      validated.output_quality = quality
+    }
+
+    // The model rounds the dimensions to a multiple of 16 anyway, so it is done
+    // here to keep what the panel shows and what the API gets in sync
+    if (params.width !== undefined && params.width !== null) {
+      const width = parseInt(params.width)
+      if (isNaN(width) || width < 256 || width > 2048) {
+        throw new Error('Width must be between 256 and 2048 pixels')
+      }
+      validated.width = Math.round(width / 16) * 16
+    }
+
+    if (params.height !== undefined && params.height !== null) {
+      const height = parseInt(params.height)
+      if (isNaN(height) || height < 256 || height > 2048) {
+        throw new Error('Height must be between 256 and 2048 pixels')
+      }
+      validated.height = Math.round(height / 16) * 16
+    }
+
+    return {
+      aspect_ratio: params.aspect_ratio,
+      resolution: params.resolution,
+      width: validated.width,
+      height: validated.height,
+      steps: validated.steps,
+      guidance: validated.guidance,
+      prompt_upsampling: params.prompt_upsampling,
+      safety_tolerance: validated.safety_tolerance,
+      output_format: params.output_format,
+      output_quality: validated.output_quality,
+      seed: params.seed
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The model returns a single URI, but tolerate an array response
+    const imageUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      imageUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default FLUX_2_FLEX

--- a/src/services/models/flux-2-max.js
+++ b/src/services/models/flux-2-max.js
@@ -1,0 +1,264 @@
+/**
+ * Black Forest Labs FLUX.2 Max Model Configuration
+ * Model: black-forest-labs/flux-2-max
+ */
+
+export const FLUX_2_MAX = {
+  id: 'flux-2-max',
+  name: 'FLUX.2 Max',
+  owner: 'black-forest-labs',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/black-forest-labs/flux-2-max/predictions',
+
+  /**
+   * Default parameters for the model
+   */
+  defaults: {
+    aspect_ratio: '1:1',
+    resolution: '1 MP',
+    width: 1024,
+    height: 1024,
+    safety_tolerance: 2,
+    output_format: 'webp',
+    output_quality: 80
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'flux-2-max',
+    label: 'FLUX.2 Max',
+    controls: [
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: [
+          'match_input_image',
+          '1:1', '3:4', '4:3', '2:3', '3:2',
+          '4:5', '5:4', '9:16', '16:9', '9:21', '21:9',
+          'custom'
+        ],
+        default: '1:1'
+      },
+      {
+        key: 'resolution',
+        label: 'Resolution',
+        type: 'select',
+        enum: ['match_input_image', '0.5 MP', '1 MP', '2 MP', '4 MP'],
+        default: '1 MP'
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'width',
+        label: 'Custom width',
+        type: 'number',
+        min: 256,
+        max: 2048,
+        step: 16,
+        default: 1024,
+        description: 'Only used when Aspect Ratio is set to custom. Rounded to a multiple of 16'
+      },
+      {
+        key: 'height',
+        label: 'Custom height',
+        type: 'number',
+        min: 256,
+        max: 2048,
+        step: 16,
+        default: 1024,
+        description: 'Only used when Aspect Ratio is set to custom. Rounded to a multiple of 16'
+      },
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['webp', 'jpg', 'png'],
+        default: 'webp'
+      },
+      {
+        key: 'output_quality',
+        label: 'Output quality',
+        type: 'number',
+        min: 0,
+        max: 100,
+        default: 80,
+        description: 'Ignored for png outputs'
+      },
+      {
+        key: 'safety_tolerance',
+        label: 'Safety tolerance',
+        type: 'number',
+        min: 1,
+        max: 5,
+        default: 2,
+        description: '1 is the strictest, 5 the most permissive'
+      },
+      {
+        key: 'seed',
+        label: 'Seed',
+        type: 'number',
+        default: null,
+        placeholder: 'Random',
+        description: 'Fix it to reproduce the same generation twice'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    aspect_ratio: [
+      'match_input_image',
+      '1:1', '3:4', '4:3', '2:3', '3:2',
+      '4:5', '5:4', '9:16', '16:9', '9:21', '21:9',
+      'custom'
+    ],
+    resolution: ['match_input_image', '0.5 MP', '1 MP', '2 MP', '4 MP'],
+    output_format: ['webp', 'jpg', 'png']
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {Array<string>} [options.imageInput] - Input images (up to 8)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    if (imageInput.length > 8) {
+      throw new Error('Maximum 8 input images are supported')
+    }
+
+    const input = {
+      prompt: prompt.trim(),
+      input_images: imageInput,
+      aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
+      safety_tolerance: params.safety_tolerance ?? this.defaults.safety_tolerance,
+      output_format: params.output_format || this.defaults.output_format,
+      output_quality: params.output_quality ?? this.defaults.output_quality
+    }
+
+    // Width and height replace the resolution when the ratio is free-form
+    if (input.aspect_ratio === 'custom') {
+      input.width = params.width || this.defaults.width
+      input.height = params.height || this.defaults.height
+    } else {
+      input.resolution = params.resolution || this.defaults.resolution
+    }
+
+    // Optional seed for reproducible generations
+    if (params.seed !== undefined && params.seed !== null && params.seed !== '') {
+      input.seed = parseInt(params.seed)
+    }
+
+    return input
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    const validated = {}
+
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.resolution && !this.validValues.resolution.includes(params.resolution)) {
+      throw new Error(`Invalid resolution. Must be one of: ${this.validValues.resolution.join(', ')}`)
+    }
+
+    if (params.output_format && !this.validValues.output_format.includes(params.output_format)) {
+      throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
+    }
+
+    if (params.safety_tolerance !== undefined && params.safety_tolerance !== null) {
+      const tolerance = parseInt(params.safety_tolerance)
+      if (isNaN(tolerance) || tolerance < 1 || tolerance > 5) {
+        throw new Error('safety_tolerance must be between 1 and 5')
+      }
+      validated.safety_tolerance = tolerance
+    }
+
+    if (params.output_quality !== undefined && params.output_quality !== null) {
+      const quality = parseInt(params.output_quality)
+      if (isNaN(quality) || quality < 0 || quality > 100) {
+        throw new Error('output_quality must be between 0 and 100')
+      }
+      validated.output_quality = quality
+    }
+
+    // The model rounds the dimensions to a multiple of 16 anyway, so it is done
+    // here to keep what the panel shows and what the API gets in sync
+    if (params.width !== undefined && params.width !== null) {
+      const width = parseInt(params.width)
+      if (isNaN(width) || width < 256 || width > 2048) {
+        throw new Error('Width must be between 256 and 2048 pixels')
+      }
+      validated.width = Math.round(width / 16) * 16
+    }
+
+    if (params.height !== undefined && params.height !== null) {
+      const height = parseInt(params.height)
+      if (isNaN(height) || height < 256 || height > 2048) {
+        throw new Error('Height must be between 256 and 2048 pixels')
+      }
+      validated.height = Math.round(height / 16) * 16
+    }
+
+    return {
+      aspect_ratio: params.aspect_ratio,
+      resolution: params.resolution,
+      width: validated.width,
+      height: validated.height,
+      safety_tolerance: validated.safety_tolerance,
+      output_format: params.output_format,
+      output_quality: validated.output_quality,
+      seed: params.seed
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The model returns a single URI, but tolerate an array response
+    const imageUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      imageUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default FLUX_2_MAX

--- a/src/services/models/flux-2-pro.js
+++ b/src/services/models/flux-2-pro.js
@@ -1,0 +1,264 @@
+/**
+ * Black Forest Labs FLUX.2 Pro Model Configuration
+ * Model: black-forest-labs/flux-2-pro
+ */
+
+export const FLUX_2_PRO = {
+  id: 'flux-2-pro',
+  name: 'FLUX.2 Pro',
+  owner: 'black-forest-labs',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/black-forest-labs/flux-2-pro/predictions',
+
+  /**
+   * Default parameters for the model
+   */
+  defaults: {
+    aspect_ratio: '1:1',
+    resolution: '1 MP',
+    width: 1024,
+    height: 1024,
+    safety_tolerance: 2,
+    output_format: 'webp',
+    output_quality: 80
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'flux-2-pro',
+    label: 'FLUX.2 Pro',
+    controls: [
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: [
+          'match_input_image',
+          '1:1', '3:4', '4:3', '2:3', '3:2',
+          '4:5', '5:4', '9:16', '16:9', '9:21', '21:9',
+          'custom'
+        ],
+        default: '1:1'
+      },
+      {
+        key: 'resolution',
+        label: 'Resolution',
+        type: 'select',
+        enum: ['match_input_image', '0.5 MP', '1 MP', '2 MP', '4 MP'],
+        default: '1 MP'
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'width',
+        label: 'Custom width',
+        type: 'number',
+        min: 256,
+        max: 2048,
+        step: 16,
+        default: 1024,
+        description: 'Only used when Aspect Ratio is set to custom. Rounded to a multiple of 16'
+      },
+      {
+        key: 'height',
+        label: 'Custom height',
+        type: 'number',
+        min: 256,
+        max: 2048,
+        step: 16,
+        default: 1024,
+        description: 'Only used when Aspect Ratio is set to custom. Rounded to a multiple of 16'
+      },
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['webp', 'jpg', 'png'],
+        default: 'webp'
+      },
+      {
+        key: 'output_quality',
+        label: 'Output quality',
+        type: 'number',
+        min: 0,
+        max: 100,
+        default: 80,
+        description: 'Ignored for png outputs'
+      },
+      {
+        key: 'safety_tolerance',
+        label: 'Safety tolerance',
+        type: 'number',
+        min: 1,
+        max: 5,
+        default: 2,
+        description: '1 is the strictest, 5 the most permissive'
+      },
+      {
+        key: 'seed',
+        label: 'Seed',
+        type: 'number',
+        default: null,
+        placeholder: 'Random',
+        description: 'Fix it to reproduce the same generation twice'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    aspect_ratio: [
+      'match_input_image',
+      '1:1', '3:4', '4:3', '2:3', '3:2',
+      '4:5', '5:4', '9:16', '16:9', '9:21', '21:9',
+      'custom'
+    ],
+    resolution: ['match_input_image', '0.5 MP', '1 MP', '2 MP', '4 MP'],
+    output_format: ['webp', 'jpg', 'png']
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {Array<string>} [options.imageInput] - Input images (up to 8)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    if (imageInput.length > 8) {
+      throw new Error('Maximum 8 input images are supported')
+    }
+
+    const input = {
+      prompt: prompt.trim(),
+      input_images: imageInput,
+      aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
+      safety_tolerance: params.safety_tolerance ?? this.defaults.safety_tolerance,
+      output_format: params.output_format || this.defaults.output_format,
+      output_quality: params.output_quality ?? this.defaults.output_quality
+    }
+
+    // Width and height replace the resolution when the ratio is free-form
+    if (input.aspect_ratio === 'custom') {
+      input.width = params.width || this.defaults.width
+      input.height = params.height || this.defaults.height
+    } else {
+      input.resolution = params.resolution || this.defaults.resolution
+    }
+
+    // Optional seed for reproducible generations
+    if (params.seed !== undefined && params.seed !== null && params.seed !== '') {
+      input.seed = parseInt(params.seed)
+    }
+
+    return input
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    const validated = {}
+
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.resolution && !this.validValues.resolution.includes(params.resolution)) {
+      throw new Error(`Invalid resolution. Must be one of: ${this.validValues.resolution.join(', ')}`)
+    }
+
+    if (params.output_format && !this.validValues.output_format.includes(params.output_format)) {
+      throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
+    }
+
+    if (params.safety_tolerance !== undefined && params.safety_tolerance !== null) {
+      const tolerance = parseInt(params.safety_tolerance)
+      if (isNaN(tolerance) || tolerance < 1 || tolerance > 5) {
+        throw new Error('safety_tolerance must be between 1 and 5')
+      }
+      validated.safety_tolerance = tolerance
+    }
+
+    if (params.output_quality !== undefined && params.output_quality !== null) {
+      const quality = parseInt(params.output_quality)
+      if (isNaN(quality) || quality < 0 || quality > 100) {
+        throw new Error('output_quality must be between 0 and 100')
+      }
+      validated.output_quality = quality
+    }
+
+    // The model rounds the dimensions to a multiple of 16 anyway, so it is done
+    // here to keep what the panel shows and what the API gets in sync
+    if (params.width !== undefined && params.width !== null) {
+      const width = parseInt(params.width)
+      if (isNaN(width) || width < 256 || width > 2048) {
+        throw new Error('Width must be between 256 and 2048 pixels')
+      }
+      validated.width = Math.round(width / 16) * 16
+    }
+
+    if (params.height !== undefined && params.height !== null) {
+      const height = parseInt(params.height)
+      if (isNaN(height) || height < 256 || height > 2048) {
+        throw new Error('Height must be between 256 and 2048 pixels')
+      }
+      validated.height = Math.round(height / 16) * 16
+    }
+
+    return {
+      aspect_ratio: params.aspect_ratio,
+      resolution: params.resolution,
+      width: validated.width,
+      height: validated.height,
+      safety_tolerance: validated.safety_tolerance,
+      output_format: params.output_format,
+      output_quality: validated.output_quality,
+      seed: params.seed
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The model returns a single URI, but tolerate an array response
+    const imageUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      imageUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default FLUX_2_PRO

--- a/src/services/models/nano-banana-2.js
+++ b/src/services/models/nano-banana-2.js
@@ -1,0 +1,181 @@
+/**
+ * Google Nano Banana 2 Model Configuration
+ * Model: google/nano-banana-2
+ */
+
+export const NANO_BANANA_2 = {
+  id: 'nano-banana-2',
+  name: 'Nano Banana 2',
+  owner: 'google',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/google/nano-banana-2/predictions',
+
+  /**
+   * Default parameters for the model
+   */
+  defaults: {
+    aspect_ratio: 'match_input_image',
+    resolution: '2K',
+    output_format: 'jpg',
+    google_search: false,
+    image_search: false
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'nano-banana-2',
+    label: 'Nano Banana 2',
+    controls: [
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: [
+          'match_input_image',
+          '1:1', '2:3', '3:2', '3:4', '4:3',
+          '4:5', '5:4', '9:16', '16:9', '21:9',
+          '1:4', '4:1', '1:8', '8:1'
+        ],
+        default: 'match_input_image'
+      },
+      {
+        key: 'resolution',
+        label: 'Resolution',
+        type: 'select',
+        enum: ['1K', '2K', '4K'],
+        default: '2K'
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['jpg', 'png'],
+        default: 'jpg'
+      },
+      {
+        key: 'google_search',
+        label: 'Google Search grounding',
+        type: 'checkbox',
+        default: false,
+        description: 'Ground the image on real-time web results, such as weather or recent events'
+      },
+      {
+        key: 'image_search',
+        label: 'Image Search grounding',
+        type: 'checkbox',
+        default: false,
+        description: 'Pull web images in as visual context. It turns on web search too'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    aspect_ratio: [
+      'match_input_image',
+      '1:1', '2:3', '3:2', '3:4', '4:3',
+      '4:5', '5:4', '9:16', '16:9', '21:9',
+      '1:4', '4:1', '1:8', '8:1'
+    ],
+    resolution: ['1K', '2K', '4K'],
+    output_format: ['jpg', 'png']
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {Array<string>} [options.imageInput] - Input images (up to 14)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    if (imageInput.length > 14) {
+      throw new Error('Maximum 14 input images are supported')
+    }
+
+    return {
+      prompt: prompt.trim(),
+      image_input: imageInput,
+      aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
+      resolution: params.resolution || this.defaults.resolution,
+      output_format: params.output_format || this.defaults.output_format,
+      google_search: params.google_search !== undefined
+        ? params.google_search
+        : this.defaults.google_search,
+      image_search: params.image_search !== undefined
+        ? params.image_search
+        : this.defaults.image_search
+    }
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.resolution && !this.validValues.resolution.includes(params.resolution)) {
+      throw new Error(`Invalid resolution. Must be one of: ${this.validValues.resolution.join(', ')}`)
+    }
+
+    if (params.output_format && !this.validValues.output_format.includes(params.output_format)) {
+      throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
+    }
+
+    return {
+      aspect_ratio: params.aspect_ratio,
+      resolution: params.resolution,
+      output_format: params.output_format,
+      google_search: params.google_search,
+      image_search: params.image_search
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The model returns a single URI, but tolerate an array response
+    const imageUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      imageUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default NANO_BANANA_2

--- a/src/services/models/seedream-4.5.js
+++ b/src/services/models/seedream-4.5.js
@@ -1,0 +1,212 @@
+/**
+ * ByteDance SeeDream-4.5 Model Configuration
+ * Model: bytedance/seedream-4.5
+ */
+
+export const SEEDREAM_4_5 = {
+  id: 'seedream-4.5',
+  name: 'SeeDream-4.5',
+  owner: 'bytedance',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/bytedance/seedream-4.5/predictions',
+
+  /**
+   * Default parameters for the model
+   *
+   * `max_images` is fixed at 1 and `sequential_image_generation` at 'disabled',
+   * neither exposed in the UI: an Image Generator node renders a single output,
+   * so any extra image would be billed and then dropped on the floor
+   */
+  defaults: {
+    size: '2K',
+    aspect_ratio: 'match_input_image',
+    width: 2048,
+    height: 2048,
+    disable_safety_checker: false,
+    max_images: 1,
+    sequential_image_generation: 'disabled'
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'seedream-4.5',
+    label: 'SeeDream-4.5',
+    controls: [
+      {
+        key: 'size',
+        label: 'Size',
+        type: 'select',
+        // 1K is not supported by this version, unlike SeeDream-4
+        enum: ['2K', '4K', 'custom'],
+        default: '2K'
+      },
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: [
+          'match_input_image',
+          '1:1', '4:3', '3:4', '16:9', '9:16',
+          '3:2', '2:3', '21:9'
+        ],
+        default: 'match_input_image'
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'width',
+        label: 'Custom width',
+        type: 'number',
+        min: 1024,
+        max: 4096,
+        default: 2048,
+        description: 'Only used when Size is set to custom'
+      },
+      {
+        key: 'height',
+        label: 'Custom height',
+        type: 'number',
+        min: 1024,
+        max: 4096,
+        default: 2048,
+        description: 'Only used when Size is set to custom'
+      },
+      {
+        key: 'disable_safety_checker',
+        label: 'Disable safety checker',
+        type: 'checkbox',
+        default: false,
+        description: 'Relaxes moderation down to illegal content only. Use responsibly'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    size: ['2K', '4K', 'custom'],
+    aspect_ratio: [
+      'match_input_image',
+      '1:1', '4:3', '3:4', '16:9', '9:16',
+      '3:2', '2:3', '21:9'
+    ]
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {Array<string>} [options.imageInput] - Input images (up to 14)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    if (imageInput.length > 14) {
+      throw new Error('Maximum 14 input images are supported')
+    }
+
+    const input = {
+      prompt: prompt.trim(),
+      image_input: imageInput,
+      size: params.size || this.defaults.size,
+      aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
+      disable_safety_checker: params.disable_safety_checker !== undefined
+        ? params.disable_safety_checker
+        : this.defaults.disable_safety_checker,
+      // Always a single image, see `defaults`
+      max_images: this.defaults.max_images,
+      sequential_image_generation: this.defaults.sequential_image_generation
+    }
+
+    // Add width and height only if size is 'custom'
+    if (input.size === 'custom') {
+      input.width = params.width || this.defaults.width
+      input.height = params.height || this.defaults.height
+    }
+
+    return input
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    const validated = {}
+
+    if (params.size && !this.validValues.size.includes(params.size)) {
+      throw new Error(`Invalid size. Must be one of: ${this.validValues.size.join(', ')}`)
+    }
+
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.width !== undefined) {
+      const width = parseInt(params.width)
+      if (isNaN(width) || width < 1024 || width > 4096) {
+        throw new Error('Width must be between 1024 and 4096 pixels')
+      }
+      validated.width = width
+    }
+
+    if (params.height !== undefined) {
+      const height = parseInt(params.height)
+      if (isNaN(height) || height < 1024 || height > 4096) {
+        throw new Error('Height must be between 1024 and 4096 pixels')
+      }
+      validated.height = height
+    }
+
+    return {
+      size: params.size,
+      aspect_ratio: params.aspect_ratio,
+      width: validated.width,
+      height: validated.height,
+      disable_safety_checker: params.disable_safety_checker
+      // max_images and sequential_image_generation are deliberately dropped:
+      // buildInput always asks for a single image
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The output is an array of URLs, but tolerate a single string
+    const imageUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      imageUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default SEEDREAM_4_5

--- a/src/services/models/seedream-5-lite.js
+++ b/src/services/models/seedream-5-lite.js
@@ -1,0 +1,178 @@
+/**
+ * ByteDance SeeDream-5 Lite Model Configuration
+ * Model: bytedance/seedream-5-lite
+ */
+
+export const SEEDREAM_5_LITE = {
+  id: 'seedream-5-lite',
+  name: 'SeeDream-5 Lite',
+  owner: 'bytedance',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/bytedance/seedream-5-lite/predictions',
+
+  /**
+   * Default parameters for the model
+   *
+   * `max_images` is fixed at 1 and `sequential_image_generation` at 'disabled',
+   * neither exposed in the UI: an Image Generator node renders a single output,
+   * so any extra image would be billed and then dropped on the floor
+   */
+  defaults: {
+    aspect_ratio: 'match_input_image',
+    size: '2K',
+    output_format: 'png',
+    return_byteplus_urls: false,
+    max_images: 1,
+    sequential_image_generation: 'disabled'
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'seedream-5-lite',
+    label: 'SeeDream-5 Lite',
+    controls: [
+      {
+        key: 'aspect_ratio',
+        label: 'Aspect Ratio',
+        type: 'select',
+        enum: [
+          'match_input_image',
+          '1:1', '4:3', '3:4', '16:9', '9:16',
+          '3:2', '2:3', '21:9'
+        ],
+        default: 'match_input_image'
+      },
+      {
+        key: 'size',
+        label: 'Size',
+        type: 'select',
+        enum: ['2K', '3K'],
+        default: '2K'
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['png', 'jpeg'],
+        default: 'png'
+      },
+      {
+        key: 'return_byteplus_urls',
+        label: 'Return BytePlus URLs',
+        type: 'checkbox',
+        default: false,
+        description: 'Skips the download and hands back BytePlus URLs that expire in 24 hours'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    size: ['2K', '3K'],
+    aspect_ratio: [
+      'match_input_image',
+      '1:1', '4:3', '3:4', '16:9', '9:16',
+      '3:2', '2:3', '21:9'
+    ],
+    output_format: ['png', 'jpeg']
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {string} options.prompt - Text description
+   * @param {Array<string>} [options.imageInput] - Input images (up to 14)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { prompt, imageInput = [], params = {} } = options
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error('Prompt is required and must be a non-empty string')
+    }
+
+    if (imageInput.length > 14) {
+      throw new Error('Maximum 14 input images are supported')
+    }
+
+    return {
+      prompt: prompt.trim(),
+      image_input: imageInput,
+      size: params.size || this.defaults.size,
+      aspect_ratio: params.aspect_ratio || this.defaults.aspect_ratio,
+      output_format: params.output_format || this.defaults.output_format,
+      return_byteplus_urls: params.return_byteplus_urls !== undefined
+        ? params.return_byteplus_urls
+        : this.defaults.return_byteplus_urls,
+      // Always a single image, see `defaults`
+      max_images: this.defaults.max_images,
+      sequential_image_generation: this.defaults.sequential_image_generation
+    }
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    if (params.size && !this.validValues.size.includes(params.size)) {
+      throw new Error(`Invalid size. Must be one of: ${this.validValues.size.join(', ')}`)
+    }
+
+    if (params.aspect_ratio && !this.validValues.aspect_ratio.includes(params.aspect_ratio)) {
+      throw new Error(`Invalid aspect_ratio. Must be one of: ${this.validValues.aspect_ratio.join(', ')}`)
+    }
+
+    if (params.output_format && !this.validValues.output_format.includes(params.output_format)) {
+      throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
+    }
+
+    return {
+      size: params.size,
+      aspect_ratio: params.aspect_ratio,
+      output_format: params.output_format,
+      return_byteplus_urls: params.return_byteplus_urls
+      // max_images and sequential_image_generation are deliberately dropped:
+      // buildInput always asks for a single image
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The output is an array of URLs, but tolerate a single string
+    const imageUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      imageUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default SEEDREAM_5_LITE

--- a/src/services/replicate.js
+++ b/src/services/replicate.js
@@ -4,7 +4,13 @@
  */
 
 import NANO_BANANA_PRO from './models/nano-banana-pro'
+import NANO_BANANA_2 from './models/nano-banana-2'
 import SEEDREAM_4 from './models/seedream-4'
+import SEEDREAM_4_5 from './models/seedream-4.5'
+import SEEDREAM_5_LITE from './models/seedream-5-lite'
+import FLUX_2_FLEX from './models/flux-2-flex'
+import FLUX_2_PRO from './models/flux-2-pro'
+import FLUX_2_MAX from './models/flux-2-max'
 import LANG_SEGMENT_ANYTHING from './models/lang-segment-anything'
 import GPT_IMAGE_1 from './models/gpt-image-1'
 import GPT_IMAGE_2 from './models/gpt-image-2'
@@ -18,7 +24,13 @@ import { useSettingsStore } from '@/stores/settings'
  */
 const MODELS = {
   'nano-banana-pro': NANO_BANANA_PRO,
+  'nano-banana-2': NANO_BANANA_2,
   'seedream-4': SEEDREAM_4,
+  'seedream-4.5': SEEDREAM_4_5,
+  'seedream-5-lite': SEEDREAM_5_LITE,
+  'flux-2-flex': FLUX_2_FLEX,
+  'flux-2-pro': FLUX_2_PRO,
+  'flux-2-max': FLUX_2_MAX,
   'lang-segment-anything': LANG_SEGMENT_ANYTHING,
   'gpt-image-1': GPT_IMAGE_1,
   'gpt-image-2': GPT_IMAGE_2,


### PR DESCRIPTION
# What

Six new image models show up in the Image Generator's model dropdown: **Nano Banana 2**, **SeeDream-4.5**, **SeeDream-5 Lite**, **FLUX.2 Flex**, **FLUX.2 Pro** and **FLUX.2 Max**.

They all work the way the existing ones do: a prompt and images come in through the node's ports, two options sit in the bar above the node, and everything else lives in the side panel behind the **⋮** button.

| Model | In the bar | In the panel |
|---|---|---|
| Nano Banana 2 | aspect ratio, resolution | output format, Google Search grounding, Image Search grounding |
| SeeDream-4.5 | size, aspect ratio | custom width and height, disable safety checker |
| SeeDream-5 Lite | aspect ratio, size | output format, return BytePlus URLs |
| FLUX.2 Flex | aspect ratio, resolution | steps, guidance, prompt upsampling, custom width and height, output format and quality, safety tolerance, seed |
| FLUX.2 Pro | aspect ratio, resolution | custom width and height, output format and quality, safety tolerance, seed |
| FLUX.2 Max | aspect ratio, resolution | custom width and height, output format and quality, safety tolerance, seed |

A few model-specific details worth knowing:

- **SeeDream-4.5 dropped the 1K size**, so it offers 2K, 4K and custom. SeeDream-5 Lite only does 2K and 3K, with no custom dimensions at all.
- **The FLUX models take a custom aspect ratio.** Pick it and the width and height from the panel take over; pick anything else and the resolution in the bar is what counts. The dimensions are rounded to the multiple of 16 the model works in, so what you type and what gets sent match.
- **Nano Banana 2 can ground on the web.** Turning on Google Search lets it use real-time information; Image Search pulls web images in as visual context and turns on web search along with it.
- **Both SeeDreams generate a single image**, same as every other model on the canvas.

# Why

Adding a model is meant to be a matter of dropping a config in `src/services/models/` and registering it, and that held up here: the Image Generator builds its dropdown from `listModels('image')`, so no component needed touching. The `uiSchema` split into `controls` and `advancedControls` did the rest — the toolbar is a single row and would wrap into an unusable block with nine FLUX options in it, so only the two worth a single click stay there.

Two things did need care.

The **payload key for reference images is not the same across providers**: Google and ByteDance read `image_input`, Black Forest Labs and OpenAI read `input_images`. Each `buildInput` maps the node's images onto its own key, so the node stays unaware of the difference.

And **the FLUX models have mutually exclusive parameters**. `resolution` is ignored when the aspect ratio is `custom`, and `width` and `height` are ignored when it is anything else. Rather than hide controls based on other controls, `buildInput` sends whichever pair applies and omits the other, which keeps the panel a flat list of options and puts the decision where the model already makes it.

The seedream pair got the same treatment as seedream-4 on multi-image: `max_images` and `sequential_image_generation` are fixed in `defaults`, read from there rather than from `params`, and never rendered. The node shows one image, so a batch would be billed and thrown away.

# Tests

e2e tests and local.

New spec `e2e/new-image-models.spec.js` with 13 tests: every new model reachable from the dropdown, the toolbar-versus-panel split for each of the six (including that no option is duplicated across both), and one payload assertion per family — Nano Banana 2 with its grounding flags, both SeeDreams asking for a single image, FLUX.2 Flex sending steps, guidance and a numeric seed, FLUX.2 Pro swapping resolution for rounded dimensions on a custom ratio, and FLUX.2 Max sending its defaults untouched.

New mocks in `e2e/mocks/api.js` for the six endpoints. The three FLUX ones share `mockFlux2(page, variant)` since the payload shape is the same.

Full suite: 99 passing, with only the 5 pre-existing `copy-paste` macOS failures left, identical to the baseline.

# How to test

- [ ] Drop an **Image Generator** and open the model dropdown: the six new models are in the list.
- [ ] Pick **FLUX.2 Flex**: the bar shows aspect ratio and resolution, and **⋮** opens a panel with steps, guidance, prompt upsampling and the rest.
- [ ] Set the aspect ratio to **custom**, type a width of 1500 in the panel, generate, and check the request carries `width: 1504` and no `resolution`.
- [ ] Leave the ratio at 1:1, generate, and check the request carries `resolution` and no width or height.
- [ ] On **Nano Banana 2**, tick Google Search grounding and generate: the request carries `google_search: true`.
- [ ] On **SeeDream-4.5**, check the size dropdown offers 2K, 4K and custom, with no 1K.
- [ ] Generate with **SeeDream-4.5** and **SeeDream-5 Lite**: both requests ask for a single image, with no way to change that in the UI.
- [ ] Connect an **Image** node into a FLUX generator and generate: the request carries the image under `input_images`.
- [ ] Do the same with **Nano Banana 2**: the image arrives under `image_input`.
- [ ] Set a seed on **FLUX.2 Pro**, generate twice, and check the request carries the same number both times.
- [ ] Fill in some advanced options, export the flow to JSON and load it back: the values survive the round trip.
