### PR TITLE
feat: add the p-image-upscale model to the Image Generator

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -701,6 +701,7 @@ const result = await replicateService.generateImage({
 | `flux-2-pro` | image | Up to 8 reference images |
 | `flux-2-max` | image | Highest fidelity of the FLUX family |
 | `gpt-image-1`, `gpt-image-2` | image | Need an OpenAI key for gpt-image-1 |
+| `p-image-upscale` | image | Upscaler: takes no prompt, needs one input image |
 | `lang-segment-anything` | image | Segmentation, no prompt-driven generation |
 | `gpt-5`, `gemini-2.5-flash` | text | |
 | `p-video` | video | |
@@ -723,6 +724,27 @@ The FLUX models also swap parameters depending on the aspect ratio: `custom` sen
 and `height` and omits `resolution`, anything else sends `resolution` and omits the
 dimensions. The panel shows all three at once because the model, not the UI, decides which
 ones matter.
+
+### Models without a prompt
+
+A model config can declare `requiresPrompt: false`. `p-image-upscale` is the first one:
+it rewrites the image it is handed, so there is nothing for the user to describe.
+
+The flag is read in two places, and nowhere else:
+
+- `generateImage()` in `replicate.js` skips the "Prompt is required" guard for it
+- `ImageGeneratorNode.vue` computes `requiresPrompt` from it and drops the prompt textarea,
+  the connected-prompt preview and the `prompt` entry of `:inputs` — which is what makes
+  the input handle disappear
+
+Taking a handle away leaves any edge that landed on it pointing at nothing, so
+`onModelChange` removes the incoming prompt edges when it switches to a model that declares
+the flag. Handles are indexed by position (`input-0`, `input-1`), and `prompt` is the last
+one, so removing it does not renumber the image port and existing image edges survive.
+
+The node type's static IO config in `node-shapes.js` is left alone: it still declares both
+ports, which is what `connection.js` validates against. The flag hides a port, it does not
+redefine the node.
 
 ### One image per generation
 

--- a/docs/replicate-models-docs/image/p-image-upscale.md
+++ b/docs/replicate-models-docs/image/p-image-upscale.md
@@ -1,0 +1,247 @@
+## Basic model info
+
+Model name: prunaai/p-image-upscale
+Model description: Fastest image upscaler in the world (<1s) supporting outputs up to 128 MP. contact us for dedicated endpoints.
+
+
+## Model inputs
+
+- image (required): Input image to upscale. (string)
+- upscale_mode (optional): Upscale mode. 'target' scales to a fixed megapixel resolution. 'factor' multiplies each side by the given factor. (string)
+- target (optional): Target resolution in megapixels (used when upscale_mode is 'target'). (integer)
+- factor (optional): Scaling factor applied to each side of the image (used when upscale_mode is 'factor'). Output capped at 128 MP. (number)
+- enhance_details (optional): Enhance fine textures and small details. May increase contrast and introduce minor deviations from the original image. (boolean)
+- enhance_realism (optional): Improve realism. May deviate more from the original image. Recommended for AI-generated images. (boolean)
+- output_format (optional): Format of the output images (string)
+- output_quality (optional): Quality when saving the output images, from 0 to 100. 100 is best quality, 0 is lowest quality. Not relevant for .png outputs (integer)
+- disable_safety_checker (optional): Disable safety checker for generated images. (boolean)
+- no_op (optional): Deprecated and ignored. Predictions always run normally. (boolean)
+
+
+## Model output schema
+
+{
+  "type": "string",
+  "title": "Output",
+  "format": "uri"
+}
+
+If the input or output schema includes a format of URI, it is referring to a file.
+
+
+## Example inputs and outputs
+
+Use these example outputs to better understand the types of inputs the model accepts, and the types of outputs the model returns:
+
+### Example (https://replicate.com/p/qjdxz5nd0drmy0cx1fx9p513n0)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/OmaliydBQQZna8XQXcCLvRp07gRpPRM7UgEmOCFs3GpQUc1T/out-3.jpg",
+  "no_op": false,
+  "factor": 2,
+  "target": 8,
+  "upscale_mode": "target",
+  "output_format": "jpg",
+  "output_quality": 80,
+  "enhance_details": false,
+  "enhance_realism": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/f1dkK41oYekHtkPk50m9o2hRpwZxBxeLyr76743EmymTKklsA/upscaled_image.jpg"
+```
+
+
+### Example (https://replicate.com/p/h8jafqa3bnrmy0cx1fxr1yzsgm)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/OmamKGxQ16YLy3VAAGqnruURQty3klGtKVro6bhtPdgKZrfd/out-4.jpg",
+  "no_op": false,
+  "factor": 2,
+  "target": 2,
+  "upscale_mode": "target",
+  "output_format": "jpg",
+  "output_quality": 80,
+  "enhance_details": true,
+  "enhance_realism": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/3AEX209HuSKvHJ79Wd4tODme4kjY9L72NjO1GxGqRtQ3CZJLA/upscaled_image.jpg"
+```
+
+
+### Example (https://replicate.com/p/avxz79s189rmy0cx1fy9t6ynmw)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/OmanE9cRIlGFlupO4KTtgwlI3PmQkY9Toec3duevhcH678O1/out-5.jpg",
+  "no_op": false,
+  "factor": 2,
+  "target": 8,
+  "upscale_mode": "target",
+  "output_format": "jpg",
+  "output_quality": 80,
+  "enhance_details": false,
+  "enhance_realism": true
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/Ren2HpF8wUxSEKu7OWGpeQWYZAdub2UBvRDbD1sYBe6QNklsA/upscaled_image.jpg"
+```
+
+
+### Example (https://replicate.com/p/0tfrtqdymhrmt0cx1fzb6tk6vr)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/Omapvg7uP3fcEwCVz1mHy7qJPOBk5vt7kOdVE68fOCIexXuh/output_138235.jpg",
+  "no_op": false,
+  "factor": 8,
+  "target": 2,
+  "upscale_mode": "factor",
+  "output_format": "jpg",
+  "output_quality": 80,
+  "enhance_details": true,
+  "enhance_realism": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/2HDqKvWVhfRLLiO0YLj3In9eQLYsefQoK6FrtOWENNeVKRWyC/upscaled_image.jpg"
+```
+
+
+### Example (https://replicate.com/p/7vtgpb88s1rmy0cx1fzrqb0c34)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/OmaqEldcmFFDgj2ftvYO6P6DmutvJs7PiwuR3AlE2lRwyFVI/output_300147.jpg",
+  "no_op": false,
+  "factor": 8,
+  "target": 2,
+  "upscale_mode": "factor",
+  "output_format": "jpg",
+  "output_quality": 80,
+  "enhance_details": true,
+  "enhance_realism": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/r4cqgeGeN9jXL0M3sNtGMRkaFfvfUmIcf2cxJTFysuqvMRWyC/upscaled_image.jpg"
+```
+
+
+### Example (https://replicate.com/p/1ac86kdtvnrmr0cx1g58srqr3c)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/Omb2L1aOCEjqoP5R1bm6biU0MsbI1PGMtsoUdoIdOaO4Pc16/rltivouao62wpy9zcl5o3woj1wam.jpg",
+  "no_op": false,
+  "factor": 2,
+  "target": 4,
+  "upscale_mode": "target",
+  "output_format": "jpg",
+  "output_quality": 50,
+  "enhance_details": false,
+  "enhance_realism": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/xGbjxWJ62fVXCCNFL7M2cOSY8zOSXqCENAWxnhidorFyKZJLA/upscaled_image.jpg"
+```
+
+
+### Example (https://replicate.com/p/13qw7crgndrmr0cx9tkt6yexzm)
+
+#### Input
+
+```json
+{
+  "image": "https://replicate.delivery/pbxt/Omaod5X49qN1VNDfR52POKGR8DRDsWSCAXklmmBCRU9WCc3d/out.jpg",
+  "no_op": false,
+  "factor": 2,
+  "target": 4,
+  "upscale_mode": "target",
+  "output_format": "jpg",
+  "output_quality": 80,
+  "enhance_details": false,
+  "enhance_realism": false
+}
+```
+
+#### Output
+
+```json
+"https://replicate.delivery/xezq/9yC53SmqfmR8bKlUWUCatWKJ6W4b8yjNp8rJ6Bct040klhLLA/upscaled_image.jpg"
+```
+
+
+## Model readme
+
+> # P-Image-Upscale
+> 
+> P-Image-Upscale is Pruna's AI-powered image upscaling model. Give it an image and a target resolution, and it increases the resolution while preserving detail. It can upscale images to 4 megapixels in under a second, with support for outputs up to 8 MP.
+> 
+> ## How it works
+> 
+> You can upscale in two modes:
+> 
+> - **Target mode** (default): set a target resolution in megapixels (1–8 MP), and the model scales your image to match.
+> - **Factor mode**: multiply each side of the image by a scaling factor (1–8x). Output is capped at 8 MP.
+> 
+> ## Enhancement options
+> 
+> Two optional toggles let you improve the quality of the upscaled image:
+> 
+> - **Enhance realism** (on by default): improves the overall realism of the output. Works especially well on AI-generated images. May deviate slightly from the original.
+> - **Enhance details**: sharpens fine textures and small details. Can increase contrast and may introduce minor differences from the original.
+> 
+> You can use either or both depending on the result you're after.
+> 
+> ## Output formats
+> 
+> Supports JPEG, PNG, and WebP. For JPEG and WebP, you can set the output quality from 0–100 (default is 80).
+> 
+> ## Pricing
+> 
+> | Output resolution | Price |
+> |---|---|
+> | 1–4 MP | $0.005 / image |
+> | 5–8 MP | $0.01 / image |
+> 
+> ## Links
+> 
+> - [Pruna API documentation](https://docs.api.pruna.ai/guides/models/p-image-upscale)
+

--- a/e2e/image-upscaler.spec.js
+++ b/e2e/image-upscaler.spec.js
@@ -1,0 +1,224 @@
+import { test, expect } from '@playwright/test'
+import {
+  FAKE_GENERATED_IMAGE_2,
+  mockPImageUpscale,
+} from './mocks/api.js'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  connectNodes,
+  positionNodes,
+  uploadImageToNode,
+  selectModel,
+} from './helpers/canvas.js'
+
+const MORE_OPTIONS_BUTTON = 'button[title="More options"]'
+const PANEL = '.node-options-panel'
+
+/**
+ * Drop an Image node feeding an Image Generator set to the upscaler.
+ * The two are wired before the model changes, so the image port keeps its index
+ */
+async function setupUpscaler(page, { connect = true } = {}) {
+  await setupBlankCanvas(page)
+  await addNodeFromSidebar(page, 'Image')
+  await addNodeFromSidebar(page, 'Image Generator')
+
+  const imageNode = page.locator('.vue-flow__node-image')
+  const generatorNode = page.locator('.vue-flow__node-image-generator')
+
+  await positionNodes(page, [
+    { type: 'image', x: 100, y: 200 },
+    { type: 'image-generator', x: 500, y: 200 },
+  ])
+
+  await uploadImageToNode(page, imageNode)
+
+  if (connect) {
+    await connectNodes(page, imageNode, 'output-0', generatorNode, 'input-0')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(1, { timeout: 5000 })
+  }
+
+  await selectModel(page, generatorNode, 'p-image-upscale')
+
+  return { imageNode, generatorNode }
+}
+
+/**
+ * Select the generator so its toolbar shows. `selectModel` clicks away when it
+ * is done, which dismisses it
+ */
+async function selectNode(page, nodeLocator) {
+  const box = await nodeLocator.boundingBox()
+  await page.mouse.click(box.x + box.width / 2, box.y + 30)
+  await page.locator('#model-select').waitFor({ state: 'visible', timeout: 5000 })
+}
+
+/**
+ * Select the generator again and open its options panel.
+ */
+async function openPanel(page, nodeLocator) {
+  await selectNode(page, nodeLocator)
+
+  await page.locator(MORE_OPTIONS_BUTTON).click()
+  await expect(page.locator(PANEL)).toBeVisible()
+}
+
+test.describe('Image upscaler model', () => {
+  test('is offered in the dropdown, marked as an upscaler', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    const generatorNode = page.locator('.vue-flow__node-image-generator')
+    await positionNodes(page, [{ type: 'image-generator', x: 320, y: 220 }])
+
+    const box = await generatorNode.boundingBox()
+    await page.mouse.click(box.x + box.width / 2, box.y + 30)
+
+    const modelSelect = page.locator('#model-select')
+    await modelSelect.waitFor({ state: 'visible', timeout: 5000 })
+
+    const label = await modelSelect
+      .locator('option[value="p-image-upscale"]')
+      .textContent()
+
+    expect(label.trim()).toContain('(upscaler)')
+  })
+
+  test('hides the prompt, its port and the target stays in the toolbar', async ({ page }) => {
+    const { generatorNode } = await setupUpscaler(page)
+
+    // No textarea and no hint of a connected prompt
+    await expect(generatorNode.locator('textarea')).toHaveCount(0)
+    await expect(generatorNode.locator('.connected-prompt-info')).toHaveCount(0)
+    await expect(generatorNode.locator('.upscaler-hint')).toBeVisible()
+
+    // The prompt input port is gone, only the image one is left
+    await expect(generatorNode.locator('.vue-flow__handle-left')).toHaveCount(1)
+
+    // Target is the one option worth a click, in megapixels
+    await selectNode(page, generatorNode)
+    await expect(page.locator('#control-target')).toBeVisible()
+    await expect(page.locator('label[for="control-target"]')).toContainText('MP')
+  })
+
+  test('keeps upscale mode and factor out of the UI entirely', async ({ page }) => {
+    const { generatorNode } = await setupUpscaler(page)
+    await openPanel(page, generatorNode)
+
+    for (const key of ['upscale_mode', 'factor', 'no_op']) {
+      await expect(page.locator(`#control-${key}`)).toHaveCount(0)
+      await expect(page.locator(`#panel-control-${key}`)).toHaveCount(0)
+    }
+
+    // What the panel does show
+    await expect(page.locator('#panel-control-enhance_realism')).toBeVisible()
+    await expect(page.locator('#panel-control-enhance_details')).toBeVisible()
+    await expect(page.locator('#panel-control-output_format')).toBeVisible()
+    await expect(page.locator('#panel-control-output_quality')).toBeVisible()
+    await expect(page.locator('#panel-control-disable_safety_checker')).toBeVisible()
+  })
+
+  test('upscales the connected image and sends target mode', async ({ page }) => {
+    let received = null
+    await mockPImageUpscale(page, { assertRequest: (body) => { received = body.input } })
+
+    const { generatorNode } = await setupUpscaler(page)
+
+    await generatorNode.getByRole('button', { name: 'Generate Image' }).click()
+
+    await expect(generatorNode.locator('.image-preview img')).toBeVisible({ timeout: 15000 })
+    await expect(generatorNode.locator('.image-preview img'))
+      .toHaveAttribute('src', FAKE_GENERATED_IMAGE_2)
+
+    // The single input image travels under `image`, not as an array
+    expect(typeof received.image).toBe('string')
+    expect(received.image.startsWith('data:')).toBe(true)
+    expect(received.prompt).toBeUndefined()
+
+    // Target mode is fixed, so the megapixels in the toolbar are what counts
+    expect(received.upscale_mode).toBe('target')
+    expect(received.target).toBe(4)
+    expect(received.factor).toBeUndefined()
+    expect(received.enhance_realism).toBe(true)
+    expect(received.output_format).toBe('jpg')
+  })
+
+  test('sends the options changed in the toolbar and the panel', async ({ page }) => {
+    let received = null
+    await mockPImageUpscale(page, { assertRequest: (body) => { received = body.input } })
+
+    const { generatorNode } = await setupUpscaler(page)
+    await openPanel(page, generatorNode)
+
+    await page.locator('#panel-control-enhance_details').check()
+    await page.locator('#panel-control-output_format').selectOption('png')
+    await page.locator('#panel-control-output_quality').fill('55')
+    await page.locator('#panel-control-output_quality').blur()
+
+    await page.locator('#control-target').fill('8')
+
+    // Clicking away dismisses the toolbar and closes the panel with it
+    await page.mouse.click(10, 10)
+    await expect(page.locator(PANEL)).toBeHidden()
+
+    await generatorNode.getByRole('button', { name: 'Generate Image' }).click()
+    await expect(generatorNode.locator('.image-preview img')).toBeVisible({ timeout: 15000 })
+
+    expect(received.target).toBe(8)
+    expect(received.enhance_details).toBe(true)
+    expect(received.output_format).toBe('png')
+    expect(received.output_quality).toBe(55)
+  })
+
+  test('cannot generate without a connected image', async ({ page }) => {
+    const { generatorNode } = await setupUpscaler(page, { connect: false })
+
+    await expect(generatorNode.getByRole('button', { name: 'Generate Image' }))
+      .toBeDisabled()
+  })
+
+  test('drops a prompt edge when switching to the upscaler', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    const generatorNode = page.locator('.vue-flow__node-image-generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'image-generator', x: 600, y: 200 },
+    ])
+
+    await promptNode.locator('textarea').fill('a golden sunset')
+    await promptNode.locator('textarea').blur()
+    await page.waitForTimeout(200)
+
+    await connectNodes(page, promptNode, 'output-0', generatorNode, 'input-1')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(1, { timeout: 5000 })
+
+    // The port the edge lands on disappears with the model change, so the edge
+    // has to go with it rather than dangle
+    await selectModel(page, generatorNode, 'p-image-upscale')
+    await expect(page.locator('.vue-flow__edge')).toHaveCount(0)
+  })
+
+  test('restores the prompt when switching back to a generator', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    const generatorNode = page.locator('.vue-flow__node-image-generator')
+    await positionNodes(page, [{ type: 'image-generator', x: 320, y: 220 }])
+
+    await generatorNode.locator('textarea').fill('a lighthouse in a storm')
+    await generatorNode.locator('textarea').blur()
+
+    await selectModel(page, generatorNode, 'p-image-upscale')
+    await expect(generatorNode.locator('textarea')).toHaveCount(0)
+
+    await selectModel(page, generatorNode, 'nano-banana-pro')
+    await expect(generatorNode.locator('textarea')).toHaveValue('a lighthouse in a storm')
+    await expect(generatorNode.locator('.vue-flow__handle-left')).toHaveCount(2)
+  })
+})

--- a/e2e/mocks/api.js
+++ b/e2e/mocks/api.js
@@ -226,6 +226,30 @@ export async function mockFlux2(page, variant, { response = FAKE_GENERATED_IMAGE
 }
 
 /**
+ * Mock the P-Image-Upscale endpoint.
+ * The real model returns a single URI, so `output` is a plain string here.
+ */
+export async function mockPImageUpscale(page, { response = FAKE_GENERATED_IMAGE_2, assertRequest } = {}) {
+  await page.route('**/v1/models/prunaai/p-image-upscale/predictions', async (route) => {
+    const body = JSON.parse(route.request().postData())
+
+    if (assertRequest) {
+      assertRequest(body)
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'upscale-pred-' + Date.now(),
+        status: 'succeeded',
+        output: response,
+      }),
+    })
+  })
+}
+
+/**
  * Mock the P-Video video generation endpoint.
  * The real model returns a single URI, so `output` is a plain string here.
  */

--- a/src/components/nodes/ImageGeneratorNode.vue
+++ b/src/components/nodes/ImageGeneratorNode.vue
@@ -96,7 +96,7 @@
     :type="type"
     :data="nodeData"
     :label="nodeData.label"
-    :inputs="['image', 'prompt']"
+    :inputs="nodeInputs"
     :outputs="['image']"
     :loading="isGenerating"
     :error="nodeData.error"
@@ -130,7 +130,7 @@
       </div>
 
       <!-- Prompt input (hidden if there's a connected prompt) -->
-      <div v-if="!connectedPrompt" class="prompt-section">
+      <div v-if="requiresPrompt && !connectedPrompt" class="prompt-section">
         <BaseLabel for="prompt">Prompt:</BaseLabel>
         <BaseTextarea
           id="prompt"
@@ -143,9 +143,14 @@
       </div>
 
       <!-- Show connected prompt info -->
-      <div v-else class="connected-prompt-info">
+      <div v-else-if="requiresPrompt" class="connected-prompt-info">
         <div class="section-label">📝 Using connected prompt</div>
         <div class="prompt-preview">{{ connectedPrompt }}</div>
+      </div>
+
+      <!-- An upscaler works off the connected image alone -->
+      <div v-else class="upscaler-hint">
+        Upscales the connected image. This model takes no prompt.
       </div>
 
       <!-- Generate button -->
@@ -153,7 +158,7 @@
         <BaseButton
           variant="primary"
           size="md"
-          :disabled="isGenerating || (!connectedPrompt && !localPrompt.trim())"
+          :disabled="isGenerating || !canGenerate"
           @click="handleGenerate"
         >
           {{ isGenerating ? 'Generating...' : 'Generate Image' }}
@@ -235,7 +240,7 @@ onExecutionRequested(async () => {
 
 // VueFlow composables
 const { node } = useNode()
-const { updateNodeData } = useVueFlow()
+const { updateNodeData, removeEdges } = useVueFlow()
 
 // Get the current node data from useNode composable
 const nodeData = computed(() => node.data)
@@ -301,6 +306,21 @@ const controls = computed(() => uiSchema.value?.controls || [])
 // Model options that go to the side panel instead of the toolbar
 const advancedControls = computed(() => uiSchema.value?.advancedControls || [])
 
+// An upscaler rewrites the image it is handed, so it declares
+// `requiresPrompt: false` and the node drops everything prompt related:
+// the textarea, the preview of a connected prompt and the input port itself
+const requiresPrompt = computed(() => {
+  return replicateService.getModel(currentModel.value)?.requiresPrompt !== false
+})
+
+const nodeInputs = computed(() => requiresPrompt.value ? ['image', 'prompt'] : ['image'])
+
+// Without a prompt there is nothing to generate from but the connected image
+const canGenerate = computed(() => {
+  if (!requiresPrompt.value) return connectedImages.value.length > 0
+  return Boolean(connectedPrompt.value || localPrompt.value.trim())
+})
+
 const { openPanel } = useSidePanel()
 
 // Get model label from uiSchema
@@ -323,6 +343,19 @@ function onModelChange(event) {
     model: newModel,
     params: defaults
   })
+
+  // Switching to a model without a prompt takes the input port away with it, so
+  // any prompt edge would be left pointing at a handle that is no longer there
+  if (replicateService.getModel(newModel)?.requiresPrompt === false) {
+    const orphanedEdges = flowStore.edges.filter(edge => {
+      if (edge.target !== props.id) return false
+      return getEdgePortType(edge, flowStore.nodes, nodeRegistry, false) === PORT_TYPES.PROMPT
+    })
+
+    if (orphanedEdges.length > 0) {
+      removeEdges(orphanedEdges)
+    }
+  }
 }
 
 // Handle parameter change
@@ -359,18 +392,24 @@ async function handleGenerate() {
   // Already generating - skip
   if (isGenerating.value) return
 
-  // No prompt available - throw error so workflow executor knows this node failed
-  if (!promptToUse.trim()) {
+  // Missing input - throw error so workflow executor knows this node failed
+  if (requiresPrompt.value && !promptToUse.trim()) {
     throw new Error('No prompt available. Connect a prompt node or enter a prompt.')
+  }
+
+  if (!requiresPrompt.value && connectedImages.value.length === 0) {
+    throw new Error('No image available. Connect an image node to upscale.')
   }
 
   isGenerating.value = true
 
   try {
-    // Update prompt before generating
-    updateNodeData(props.id, {
-      prompt: promptToUse
-    })
+    // Update prompt before generating, unless the model has no use for one
+    if (requiresPrompt.value) {
+      updateNodeData(props.id, {
+        prompt: promptToUse
+      })
+    }
 
     // Prepare input images from connected nodes
     // The API accepts HTTP URLs and data URLs (base64)
@@ -412,7 +451,9 @@ async function handleGenerate() {
 
     // Update node with generated image
     updateNodeData(props.id, {
-      prompt: promptToUse,
+      // A prompt typed before switching to an upscaler is left untouched, so it
+      // is still there if the user switches back
+      ...(requiresPrompt.value && { prompt: promptToUse }),
       lastOutputSrc: imageData,
       model: result.model,
       generationId: result.id,
@@ -560,6 +601,15 @@ async function handleGenerate() {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.upscaler-hint {
+  padding: var(--flora-space-2);
+  background: var(--flora-color-info-bg);
+  border-radius: var(--flora-radius-md);
+  border: var(--flora-border-width-thin) solid var(--flora-color-info-border);
+  font-size: var(--flora-font-size-xs);
+  color: var(--flora-color-text-tertiary);
 }
 
 .generate-section {

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -138,6 +138,27 @@ dials, Max is the highest fidelity of the three.
 **Input Images:** Flex takes up to 10, Pro and Max up to 8. The payload key is
 `input_images`, not `image_input`
 
+#### p-image-upscale (PrunaAI)
+
+An upscaler rather than a generator. It rewrites the image it is given, so it
+declares `requiresPrompt: false` and the Image Generator node hides its prompt
+textarea and its prompt input port while this model is selected.
+
+**Parameters:**
+- `target`: 1-8 megapixels (default: 4)
+- `enhance_realism`: boolean (default: true) - Recommended for AI generated images
+- `enhance_details`: boolean (default: false)
+- `output_format`: "jpg", "png", "webp" (default: "jpg")
+- `output_quality`: 0-100 (default: 80), ignored for png
+- `disable_safety_checker`: boolean (default: false)
+
+`upscale_mode` is fixed at `"target"` in `defaults` and read from there, and
+`factor` is never sent: the node offers a target resolution, which is the mode
+that reads it. `no_op` is deprecated and ignored by the model.
+
+**Input Images:** Exactly one, sent as `image` (a plain string, not an array).
+Any extra connected image is ignored
+
 ### Text Generation Models
 
 #### GPT-5 (OpenAI)

--- a/src/services/models/p-image-upscale.js
+++ b/src/services/models/p-image-upscale.js
@@ -1,0 +1,205 @@
+/**
+ * PrunaAI P-Image-Upscale Model Configuration
+ * Model: prunaai/p-image-upscale
+ */
+
+export const P_IMAGE_UPSCALE = {
+  id: 'p-image-upscale',
+  name: 'P-Image Upscale',
+  owner: 'prunaai',
+  version: 'latest',
+  category: 'image', // Model category: image generation
+  endpointPath: '/v1/models/prunaai/p-image-upscale/predictions',
+
+  /**
+   * This model rewrites an image instead of generating one, so the node hides
+   * its prompt: there is nothing for the user to describe
+   */
+  requiresPrompt: false,
+
+  /**
+   * Default parameters for the model
+   *
+   * `upscale_mode` is fixed at 'target' and `factor` is never sent: the node
+   * offers a target resolution in megapixels, which is the mode that reads it.
+   * `no_op` is deprecated and ignored by the model
+   */
+  defaults: {
+    target: 4,
+    enhance_realism: true,
+    enhance_details: false,
+    output_format: 'jpg',
+    output_quality: 80,
+    disable_safety_checker: false,
+    upscale_mode: 'target'
+  },
+
+  /**
+   * UI Schema - defines controls for the node toolbar
+   * Used to dynamically render UI controls for model parameters
+   */
+  uiSchema: {
+    id: 'p-image-upscale',
+    // The suffix tells the two kinds of image model apart in the dropdown
+    label: 'P-Image Upscale (upscaler)',
+    controls: [
+      {
+        key: 'target',
+        label: 'Target (MP)',
+        type: 'number',
+        min: 1,
+        max: 8,
+        default: 4
+      }
+    ],
+
+    /**
+     * Secondary options, rendered in the node options side panel
+     */
+    advancedControls: [
+      {
+        key: 'enhance_realism',
+        label: 'Enhance realism',
+        type: 'checkbox',
+        default: true,
+        description: 'Recommended for AI generated images. May deviate more from the original'
+      },
+      {
+        key: 'enhance_details',
+        label: 'Enhance details',
+        type: 'checkbox',
+        default: false,
+        description: 'Sharpens fine textures. May raise the contrast a little'
+      },
+      {
+        key: 'output_format',
+        label: 'Output format',
+        type: 'select',
+        enum: ['jpg', 'png', 'webp'],
+        default: 'jpg'
+      },
+      {
+        key: 'output_quality',
+        label: 'Output quality',
+        type: 'number',
+        min: 0,
+        max: 100,
+        default: 80,
+        description: 'Ignored for png outputs'
+      },
+      {
+        key: 'disable_safety_checker',
+        label: 'Disable safety checker',
+        type: 'checkbox',
+        default: false,
+        description: 'Skips the moderation pass on the upscaled image'
+      }
+    ]
+  },
+
+  /**
+   * Valid values for each parameter
+   */
+  validValues: {
+    output_format: ['jpg', 'png', 'webp']
+  },
+
+  /**
+   * Build input payload for the API
+   * @param {Object} options
+   * @param {Array<string>} [options.imageInput] - Input image (only the first entry is used)
+   * @param {Object} [options.params] - Additional parameters
+   * @returns {Object} API input payload
+   */
+  buildInput(options) {
+    const { imageInput = [], params = {} } = options
+
+    if (imageInput.length === 0) {
+      throw new Error('An input image is required. Connect an image to this node.')
+    }
+
+    return {
+      // The model upscales a single image, so any extra input is ignored
+      image: imageInput[0],
+      target: params.target ?? this.defaults.target,
+      enhance_realism: params.enhance_realism !== undefined
+        ? params.enhance_realism
+        : this.defaults.enhance_realism,
+      enhance_details: params.enhance_details !== undefined
+        ? params.enhance_details
+        : this.defaults.enhance_details,
+      output_format: params.output_format || this.defaults.output_format,
+      output_quality: params.output_quality ?? this.defaults.output_quality,
+      disable_safety_checker: params.disable_safety_checker !== undefined
+        ? params.disable_safety_checker
+        : this.defaults.disable_safety_checker,
+      // Fixed: the toolbar asks for megapixels, see `defaults`
+      upscale_mode: this.defaults.upscale_mode
+    }
+  },
+
+  /**
+   * Validate and sanitize parameters
+   * @param {Object} params
+   * @returns {Object} Validated parameters
+   */
+  validateParams(params = {}) {
+    const validated = {}
+
+    if (params.output_format && !this.validValues.output_format.includes(params.output_format)) {
+      throw new Error(`Invalid output_format. Must be one of: ${this.validValues.output_format.join(', ')}`)
+    }
+
+    if (params.target !== undefined && params.target !== null) {
+      const target = parseInt(params.target)
+      if (isNaN(target) || target < 1 || target > 8) {
+        throw new Error('target must be between 1 and 8 megapixels')
+      }
+      validated.target = target
+    }
+
+    if (params.output_quality !== undefined && params.output_quality !== null) {
+      const quality = parseInt(params.output_quality)
+      if (isNaN(quality) || quality < 0 || quality > 100) {
+        throw new Error('output_quality must be between 0 and 100')
+      }
+      validated.output_quality = quality
+    }
+
+    return {
+      target: validated.target,
+      enhance_realism: params.enhance_realism,
+      enhance_details: params.enhance_details,
+      output_format: params.output_format,
+      output_quality: validated.output_quality,
+      disable_safety_checker: params.disable_safety_checker
+      // upscale_mode and factor are deliberately dropped: buildInput always
+      // upscales to a target resolution
+    }
+  },
+
+  /**
+   * Parse response from API
+   * @param {Object} response - API response
+   * @returns {Object} Parsed result
+   */
+  parseResponse(response) {
+    if (!response.output) {
+      throw new Error('No output in response')
+    }
+
+    // The model returns a single URI, but tolerate an array response
+    const imageUrl = Array.isArray(response.output)
+      ? response.output[0]
+      : response.output
+
+    return {
+      imageUrl,
+      id: response.id,
+      status: response.status,
+      model: this.id
+    }
+  }
+}
+
+export default P_IMAGE_UPSCALE

--- a/src/services/replicate.js
+++ b/src/services/replicate.js
@@ -11,6 +11,7 @@ import SEEDREAM_5_LITE from './models/seedream-5-lite'
 import FLUX_2_FLEX from './models/flux-2-flex'
 import FLUX_2_PRO from './models/flux-2-pro'
 import FLUX_2_MAX from './models/flux-2-max'
+import P_IMAGE_UPSCALE from './models/p-image-upscale'
 import LANG_SEGMENT_ANYTHING from './models/lang-segment-anything'
 import GPT_IMAGE_1 from './models/gpt-image-1'
 import GPT_IMAGE_2 from './models/gpt-image-2'
@@ -31,6 +32,7 @@ const MODELS = {
   'flux-2-flex': FLUX_2_FLEX,
   'flux-2-pro': FLUX_2_PRO,
   'flux-2-max': FLUX_2_MAX,
+  'p-image-upscale': P_IMAGE_UPSCALE,
   'lang-segment-anything': LANG_SEGMENT_ANYTHING,
   'gpt-image-1': GPT_IMAGE_1,
   'gpt-image-2': GPT_IMAGE_2,
@@ -236,13 +238,14 @@ class ReplicateService {
       params = {}
     } = options
 
-    // Validate inputs
-    if (!prompt) {
-      throw new Error('Prompt is required')
-    }
-
     // Get model configuration
     const model = this.getModel(modelId)
+
+    // An upscaler rewrites the image it is given, so it declares
+    // `requiresPrompt: false` and the node never asks for one
+    if (!prompt && model.requiresPrompt !== false) {
+      throw new Error('Prompt is required')
+    }
 
     // Prepare image input
     let imageInput = []
@@ -251,7 +254,7 @@ class ReplicateService {
     }
 
     console.log('Replicate service - preparing generation:')
-    console.log('  Prompt:', prompt.substring(0, 50) + '...')
+    console.log('  Prompt:', prompt ? prompt.substring(0, 50) + '...' : '(model takes no prompt)')
     console.log('  Image inputs:', imageInput.length, 'images')
     if (imageInput.length > 0) {
       console.log('  Image types:', imageInput.map(src => {
@@ -515,8 +518,8 @@ class ReplicateService {
     // Simulate API delay
     await new Promise(resolve => setTimeout(resolve, 1500))
 
-    // Generate mock image URL
-    const text = encodeURIComponent(prompt.substring(0, 30))
+    // Generate mock image URL. A model without a prompt still gets a label
+    const text = encodeURIComponent(prompt ? prompt.substring(0, 30) : 'upscaled')
     const color = Math.random() > 0.5 ? '4CAF50' : '2196F3'
     const imageUrl = `https://via.placeholder.com/512x512/${color}/FFFFFF?text=${text}`
 


### PR DESCRIPTION
# What

**P-Image Upscale** joins the Image Generator's model dropdown, marked **(upscaler)** at the end of its name so it is not mistaken for a generator.

Pick it and the node changes shape: it upscales the image you connect to it, so the prompt goes away entirely — the textarea, the preview of a connected prompt, and the prompt input port itself. What is left is one image input, one image output, and a note saying the model takes no prompt.

- **Target resolution in megapixels** sits in the bar above the node, from 1 to 8 MP.
- The panel behind **⋮** holds enhance realism (on by default, recommended for AI generated images), enhance details, output format and quality, and the safety checker toggle.
- **Only one image goes in.** The model upscales a single image, so any extra connected one is ignored.
- The upscale mode and the scaling factor are not offered anywhere. The node always upscales to the target resolution you set.

If a prompt was already wired into the node, switching to the upscaler removes that connection — the port it was plugged into no longer exists. Anything typed in the textarea is kept, so switching back to a generator brings it right back.

# Why

An upscaler takes an image and returns an image, which is what the Image Generator already does. A node of its own would be a near-identical copy of it, so the model config grew one optional flag instead: `requiresPrompt: false`.

It is read in exactly two places. `generateImage()` in `replicate.js` skips its "Prompt is required" guard, and `ImageGeneratorNode.vue` computes `requiresPrompt` from it to hide the prompt textarea and to drop `prompt` from the node's `:inputs`, which is what makes the handle disappear. Every other model leaves the flag undefined and behaves exactly as before.

Taking a handle away is the one thing that needed care: an edge already landing on it would be left pointing at nothing. `onModelChange` removes the incoming prompt edges when it switches to a model carrying the flag. Handles are indexed by position and `prompt` is the last one, so the image port keeps its index and image connections survive the switch.

The node type's static port config in `node-shapes.js` is untouched and still declares both ports, since that is what connection validation reads. The flag hides a port; it does not redefine the node.

On the model itself, `upscale_mode` is fixed at `target` in `defaults` and read from there rather than from the saved params, and `factor` is never sent — the two are mutually exclusive, and the toolbar asks for megapixels, which is what target mode reads. `no_op` is deprecated and ignored by the model, so it is not sent either.

# Tests

e2e tests and local.

New spec `e2e/image-upscaler.spec.js` with 8 tests: the model is in the dropdown and labelled as an upscaler, the prompt and its port are hidden while the target control stays in the toolbar, upscale mode and factor appear nowhere in the UI, the connected image travels under `image` as a plain string with no prompt in the payload, toolbar and panel changes reach the request, the generate button stays disabled with no image connected, a prompt edge is dropped on switching to the upscaler, and the typed prompt comes back on switching away.

New `mockPImageUpscale` in `e2e/mocks/api.js`.

Full suite: 107 passing, with only the 5 pre-existing `copy-paste` macOS failures left, identical to the baseline.

# How to test

- [ ] Drop an **Image Generator** and open the model dropdown: **P-Image Upscale (upscaler)** is in the list.
- [ ] Pick it: the prompt textarea disappears, and so does the prompt input port on the left. Only the image port is left.
- [ ] The bar shows **Target (MP)** with 4 in it, and **⋮** opens a panel with enhance realism, enhance details, output format, output quality and the safety checker.
- [ ] With nothing connected, the Generate button is disabled.
- [ ] Connect an **Image** node and generate: the request carries the image under `image` as a string, `upscale_mode: "target"`, `target: 4`, and no `prompt` or `factor`.
- [ ] Change the target to 8 and tick enhance details: the next request carries both.
- [ ] Wire a **Prompt** node into a normal Image Generator, then switch it to the upscaler: the connection is removed rather than left dangling.
- [ ] Type a prompt on a normal generator, switch to the upscaler, then switch back: the prompt is still there and the port is back.
- [ ] Connect two images to the upscaler: it uses the first and the generation still works.
- [ ] Set some panel options, export the flow to JSON and load it back: the values survive the round trip.
