### PR TITLE
fix: keep the image edge on its handle when the prompt port goes

### DIFF
--- a/e2e/image-upscaler.spec.js
+++ b/e2e/image-upscaler.spec.js
@@ -45,6 +45,31 @@ async function setupUpscaler(page, { connect = true } = {}) {
 }
 
 /**
+ * Vertical distance in screen pixels between where the edge ends and the centre
+ * of the image input handle it is wired to. VueFlow draws edges inside a
+ * transformed viewport, so the path point is mapped through the SVG's screen
+ * matrix. Only the vertical axis is measured: an edge ends at the node's edge
+ * rather than at the middle of the handle, which is a constant horizontal
+ * offset, while the bug this guards against moves the handle up or down
+ */
+async function edgeToHandleGap(page) {
+  return page.evaluate(() => {
+    const path = document.querySelector('.vue-flow__edge-path')
+    const handle = document.querySelector(
+      '.vue-flow__node-image-generator .vue-flow__handle-left'
+    )
+    if (!path || !handle) return null
+
+    const end = path.getPointAtLength(path.getTotalLength())
+    const screenEnd = end.matrixTransform(path.getScreenCTM())
+
+    const box = handle.getBoundingClientRect()
+
+    return Math.abs(screenEnd.y - (box.y + box.height / 2))
+  })
+}
+
+/**
  * Select the generator so its toolbar shows. `selectModel` clicks away when it
  * is done, which dismisses it
  */
@@ -202,6 +227,20 @@ test.describe('Image upscaler model', () => {
     // has to go with it rather than dangle
     await selectModel(page, generatorNode, 'p-image-upscale')
     await expect(page.locator('.vue-flow__edge')).toHaveCount(0)
+  })
+
+  test('keeps the image edge on its handle when the prompt port goes', async ({ page }) => {
+    const { generatorNode } = await setupUpscaler(page)
+
+    // Dropping the prompt port moves the image handle from a third of the way
+    // down the node to the middle, and the edge has to follow it
+    expect(await edgeToHandleGap(page)).toBeLessThan(4)
+
+    await selectModel(page, generatorNode, 'nano-banana-pro')
+    await expect(generatorNode.locator('.vue-flow__handle-left')).toHaveCount(2)
+
+    // And back again, now that the prompt port has returned
+    expect(await edgeToHandleGap(page)).toBeLessThan(4)
   })
 
   test('restores the prompt when switching back to a generator', async ({ page }) => {

--- a/src/components/base/BaseNode.vue
+++ b/src/components/base/BaseNode.vue
@@ -460,7 +460,16 @@ function getPortColor(portType) {
   border: var(--flora-border-width-thick) solid var(--flora-color-surface);
   box-shadow: var(--flora-shadow-md);
   cursor: crosshair;
-  transition: all var(--flora-transition-fast);
+  /* Deliberately not `all`: handles are spread down the side of the node, so
+     `top` changes whenever a node gains or loses a port. VueFlow reads handle
+     positions once per change and would catch one mid-slide, leaving the edge
+     pinned to a spot the handle has already left */
+  transition:
+    width var(--flora-transition-fast),
+    height var(--flora-transition-fast),
+    background-color var(--flora-transition-fast),
+    border-color var(--flora-transition-fast),
+    box-shadow var(--flora-transition-fast);
 }
 
 :deep(.vue-flow__handle:hover) {

--- a/src/components/nodes/ImageGeneratorNode.vue
+++ b/src/components/nodes/ImageGeneratorNode.vue
@@ -240,7 +240,7 @@ onExecutionRequested(async () => {
 
 // VueFlow composables
 const { node } = useNode()
-const { updateNodeData, removeEdges } = useVueFlow()
+const { updateNodeData, removeEdges, updateNodeInternals } = useVueFlow()
 
 // Get the current node data from useNode composable
 const nodeData = computed(() => node.data)
@@ -314,6 +314,17 @@ const requiresPrompt = computed(() => {
 })
 
 const nodeInputs = computed(() => requiresPrompt.value ? ['image', 'prompt'] : ['image'])
+
+// Handles are spread evenly down the left side, so dropping the prompt port
+// moves the image one from a third of the way down to the middle. VueFlow reads
+// handle positions once per change, so it has to be told to look again or the
+// edge already wired to the image port stays where the handle used to be.
+// `flush: 'post'` runs it after the DOM has settled, and the watch also covers
+// the way back, and any path that swaps the model without going through
+// onModelChange, such as loading a flow
+watch(requiresPrompt, () => {
+  updateNodeInternals([props.id])
+}, { flush: 'post' })
 
 // Without a prompt there is nothing to generate from but the connected image
 const canGenerate = computed(() => {


### PR DESCRIPTION
# What

Switching an Image Generator between a normal model and the upscaler left the image connection looking broken: the edge was still there, but it no longer met the port it was plugged into — it ended somewhere above it, in empty space. Redrawing the connection by hand fixed it, and it happened in both directions.

Now the edge follows its port across the switch, with nothing to redo.

# Why

An upscaler takes no prompt, so switching to it removes the prompt input port. Ports are spread evenly down the side of a node, which means going from two to one moves the image port from a third of the way down to the middle — and back again on the way out.

Two things had to line up for the edge to follow.

The handles carried `transition: all`, meant for the hover effect that grows them slightly. `all` covers `top` as well, so the port did not jump to its new spot, it **slid** there over a fraction of a second. VueFlow reads handle positions once per change, and it was reading them mid-slide: it recorded a position the handle was still travelling through and pinned the edge to it. Measured in a test, the edge was landing about 75px off. The transition now names the properties the hover state actually animates, so the port is simply where it says it is.

The other half is telling VueFlow to look again at all. Nothing about the node's ports is part of its saved data, so a model change is invisible to it. `ImageGeneratorNode` now watches its own `requiresPrompt` and asks for a fresh read, after the DOM has settled rather than before. The watch covers the way back too, and any path that swaps the model without going through the dropdown, such as loading a saved flow.

# Tests

e2e tests and local.

New test in `e2e/image-upscaler.spec.js` measuring the real geometry: it maps the end point of the edge path through the SVG's screen matrix and compares it against the centre of the image handle, across a switch to the upscaler and back. It reads about 75px off without the fix and under 4px with it.

Full suite: 108 passing, with only the 5 pre-existing `copy-paste` macOS failures left, identical to the baseline.

# How to test

- [ ] Drop an **Image** node and an **Image Generator**, and connect the image into it.
- [ ] With the generator on Nano Banana Pro or any other model, switch it to **P-Image Upscale (upscaler)**: the prompt port disappears and the edge stays attached to the image port, meeting it exactly.
- [ ] Switch back to the original model: the prompt port comes back and the edge is still attached.
- [ ] Do it a few times in a row, quickly: the edge keeps up.
- [ ] Drag the node around afterwards: the edge tracks the port as usual.
- [ ] Hover a handle: it still grows slightly, the same as before.
