### PR TITLE
feat: let the user pick the shape of the edges between nodes

### DIFF
--- a/src/components/canvas/SettingsModal.vue
+++ b/src/components/canvas/SettingsModal.vue
@@ -22,6 +22,31 @@
         </div>
       </div>
 
+      <!-- Connections Section -->
+      <div class="settings-section">
+        <h3 class="settings-section-title">Connections</h3>
+        <div class="settings-option">
+          <label for="edge-type" class="settings-label">
+            Edge shape
+          </label>
+          <BaseSelect
+            id="edge-type"
+            v-model="settingsStore.edgeType"
+          >
+            <option
+              v-for="option in EDGE_TYPE_OPTIONS"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </BaseSelect>
+          <p class="settings-option-description settings-option-description--flush">
+            {{ edgeTypeDescription }}
+          </p>
+        </div>
+      </div>
+
       <!-- Save Behavior Section -->
       <div class="settings-section">
         <h3 class="settings-section-title">Save Behavior</h3>
@@ -126,7 +151,17 @@ import { ref, computed, watch } from 'vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import BaseCheckbox from '@/components/ui/BaseCheckbox.vue'
 import BaseInput from '@/components/ui/BaseInput.vue'
+import BaseSelect from '@/components/ui/BaseSelect.vue'
 import { useSettingsStore } from '@/stores/settings'
+
+// VueFlow's built-in edge types. 'default' is the bezier curve it ships with
+const EDGE_TYPE_OPTIONS = [
+  { value: 'default', label: 'Curved (bezier)', description: 'Smooth curves leaving each handle, the default' },
+  { value: 'simplebezier', label: 'Simple curve', description: 'A softer bezier that ignores the handle direction' },
+  { value: 'smoothstep', label: 'Right angles (rounded)', description: '90 degree turns with rounded corners' },
+  { value: 'step', label: 'Right angles (sharp)', description: '90 degree turns with sharp corners' },
+  { value: 'straight', label: 'Straight line', description: 'A direct line from handle to handle' }
+]
 
 const props = defineProps({
   modelValue: {
@@ -142,6 +177,11 @@ const settingsStore = useSettingsStore()
 const isOpen = computed({
   get: () => props.modelValue,
   set: (value) => emit('update:modelValue', value)
+})
+
+const edgeTypeDescription = computed(() => {
+  const option = EDGE_TYPE_OPTIONS.find((o) => o.value === settingsStore.edgeType)
+  return option ? option.description : ''
 })
 
 // Local state for API keys - initialized from store
@@ -219,6 +259,12 @@ function handleClearKeys() {
   font-size: var(--flora-font-size-xs);
   color: var(--flora-color-text-tertiary);
   padding-left: calc(18px + var(--flora-space-2));
+}
+
+/* Selects and inputs are full width, so their hint does not need the
+   checkbox indent */
+.settings-option-description--flush {
+  padding-left: 0;
 }
 
 .settings-option-description a {

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -40,6 +40,9 @@ export const useSettingsStore = defineStore('settings', () => {
   const showNodeHeaders = ref(persisted.showNodeHeaders ?? false)
   const skipSaveDialog = ref(persisted.skipSaveDialog ?? false)
 
+  // Shape of the edges between nodes. 'default' is VueFlow's bezier curve
+  const edgeType = ref(persisted.edgeType ?? 'default')
+
   // Beta features, hidden until the user opts in
   const betaAutoLayout = ref(persisted.betaAutoLayout ?? false)
 
@@ -56,6 +59,7 @@ export const useSettingsStore = defineStore('settings', () => {
     () => ({
       showNodeHeaders: showNodeHeaders.value,
       skipSaveDialog: skipSaveDialog.value,
+      edgeType: edgeType.value,
       betaAutoLayout: betaAutoLayout.value,
       autoLayoutGroupContents: autoLayoutGroupContents.value,
       replicateApiKey: replicateApiKey.value,
@@ -78,6 +82,10 @@ export const useSettingsStore = defineStore('settings', () => {
 
   function setSkipSaveDialog(value) {
     skipSaveDialog.value = value
+  }
+
+  function setEdgeType(value) {
+    edgeType.value = value
   }
 
   function setBetaAutoLayout(value) {
@@ -123,6 +131,7 @@ export const useSettingsStore = defineStore('settings', () => {
     // State
     showNodeHeaders,
     skipSaveDialog,
+    edgeType,
     betaAutoLayout,
     autoLayoutGroupContents,
     replicateApiKey,
@@ -132,6 +141,7 @@ export const useSettingsStore = defineStore('settings', () => {
     toggleNodeHeaders,
     setNodeHeaders,
     setSkipSaveDialog,
+    setEdgeType,
     setBetaAutoLayout,
     setAutoLayoutGroupContents,
     setReplicateApiKey,

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -72,6 +72,8 @@
         :connection-radius="60"
         :snap-to-handle="true"
         :connection-line-style="{ strokeWidth: 2 }"
+        :default-edge-options="{ type: settingsStore.edgeType }"
+        :connection-line-type="settingsStore.edgeType"
         elevate-edges-on-select
         elevate-nodes-on-select
       >
@@ -113,7 +115,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onUnmounted, ref, markRaw } from 'vue'
+import { computed, onMounted, onUnmounted, ref, markRaw, watch } from 'vue'
 import { VueFlow, useVueFlow } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
 import { useFlowStore } from '@/stores/flow'
@@ -165,6 +167,21 @@ const showIntro = ref(false)
 
 // Show alert if no Replicate API key is configured
 const showAlert = computed(() => !settingsStore.getReplicateApiKey())
+
+// defaultEdgeOptions only stamps the type on edges as they are added, so edges
+// already on the canvas (or restored from a .json saved with another shape)
+// keep whatever type they had. Rewrite them whenever either side changes
+watch(
+  [() => settingsStore.edgeType, () => flowStore.edges.length],
+  () => {
+    for (const edge of flowStore.edges) {
+      if (edge.type !== settingsStore.edgeType) {
+        edge.type = settingsStore.edgeType
+      }
+    }
+  },
+  { immediate: true }
+)
 
 // VueFlow composable
 const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, applyNodeChanges, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()


### PR DESCRIPTION
# What

The connections between nodes were always drawn as bezier curves, with no way to change them. This adds an **Edge shape** setting so each person can pick how the wires on the canvas look: the curve it already had, right angles (rounded or sharp), a softer curve, or a plain straight line.

The choice sticks between sessions and applies to the whole canvas at once, including flows opened from a `.json`. The preview line you drag while creating a connection now uses the same shape too, so what you draw is what you get.

Nothing changes for anyone who does not touch the setting: the default is still the bezier curve.

# Why

Right angles read better than curves on dense flows, where several crossing bezier wires are hard to follow. It is a matter of taste more than anything, so a setting beats picking one for everybody.

The setting lives in the `settings` store next to the rest of the preferences, so it is persisted to localStorage for free, and `SettingsModal` renders it as a select in a new **Connections** section.

One detail worth knowing for review: VueFlow's `defaultEdgeOptions` only stamps the type on an edge as it is added, so edges already on screen would keep their old shape. `FlowCanvasView` watches the setting and rewrites the type on every edge, which also means the setting wins over whatever was saved in a flow file. Opening someone else's flow no longer changes how your canvas looks.

# Tests

Local. Production build passes (`npm run build`).

## How to test

- [ ] Open the app with an existing flow, or drop a few connected nodes on the canvas
- [ ] Open **Settings** and find the new **Connections** section
- [ ] Switch **Edge shape** to `Right angles (rounded)`: every edge on the canvas turns into 90 degree segments right away, not just new ones
- [ ] Drag a new connection out of a handle: the preview line follows the same shape as the finished edge
- [ ] Go through the rest of the options (`Right angles (sharp)`, `Straight line`, `Simple curve`) and check the hint under the select changes with each one
- [ ] Reload the page: the shape you picked is still there
- [ ] Save the flow to `.json`, set the shape back to `Curved (bezier)`, and load that file again: the edges come back as curves, following the setting rather than the file
