### PR TITLE
feat: add a reroute node to bend connections and tidy the graph

### DIFF
--- a/docs/CREATING-NODES.md
+++ b/docs/CREATING-NODES.md
@@ -770,7 +770,12 @@ Useful emojis for BaseNode's `icon` prop:
 - [ ] Composables used (`useNode`, `useVueFlow`)
 - [ ] Node registered in `node-registry.js`
 - [ ] IO configuration added in `getNodeIOConfig()`
+- [ ] Added to a category and given an icon in `NodesSidebar.vue` (both are
+      hardcoded there, and without this the node is unreachable from the UI)
 - [ ] Data initialization in `FlowCanvasView.vue` (if needed)
+- [ ] A `case` in `shouldExecuteNode()` in `workflow-executor.js`, unless the
+      node really does run: anything with an output port falls through to the
+      default and the executor will wait on it
 - [ ] Error handling implemented
 - [ ] Loading state implemented (if async)
 - [ ] Scoped CSS styles added

--- a/e2e/reroute-node.spec.js
+++ b/e2e/reroute-node.spec.js
@@ -1,0 +1,358 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+  connectNodes,
+  connectNodesProgrammatic,
+} from './helpers/canvas.js'
+
+/**
+ * Edges carry no ids in the DOM, and a reroute stores nothing at all: what it
+ * is carrying only shows up in the wiring, so the store is the place to read.
+ */
+async function readGraph(page) {
+  return page.evaluate(() => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    return {
+      nodes: flowStore.nodes.map(n => ({ id: n.id, type: n.type, data: n.data })),
+      edges: flowStore.edges.map(e => ({
+        source: e.source,
+        target: e.target,
+        sourceHandle: e.sourceHandle,
+        targetHandle: e.targetHandle,
+      })),
+    }
+  })
+}
+
+/** Node ids by type, in creation order */
+async function idsOfType(page, type) {
+  const { nodes } = await readGraph(page)
+  return nodes.filter(n => n.type === type).map(n => n.id)
+}
+
+/** Mark nodes as selected in the store, the selection a click cannot express */
+async function selectNodesProgrammatic(page, matchers) {
+  await page.evaluate((specs) => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    flowStore.nodes.forEach(n => { n.selected = false })
+    for (const { type, nth } of specs) {
+      const matching = flowStore.nodes.filter(n => n.type === type)
+      const node = matching[nth || 0]
+      if (node) node.selected = true
+    }
+  }, matchers)
+  await page.waitForTimeout(100)
+}
+
+test.describe('Reroute node', () => {
+  test('passes a prompt through to the node downstream', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Text Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'reroute', x: 450, y: 220 },
+      { type: 'text-generator', x: 700, y: 200 },
+    ])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    const textGenNode = page.locator('.vue-flow__node-text-generator')
+
+    await promptNode.locator('textarea').fill('a cute cat')
+    await promptNode.locator('textarea').blur()
+    await page.waitForTimeout(200)
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+      { sourceType: 'reroute', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+    ])
+
+    // The generator reads its prompt one hop back, and that hop is the reroute
+    await expect(textGenNode.locator('.prompt-preview')).toContainText('a cute cat')
+  })
+
+  test('takes the colour of the port feeding it', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'reroute', x: 500, y: 220 },
+    ])
+
+    const rerouteNode = page.locator('.vue-flow__node-reroute')
+    const outputHandle = rerouteNode.locator('.vue-flow__handle[data-handleid="output-0"]')
+
+    // Unconnected: no type yet, so the neutral fallback
+    const unconnected = await outputHandle.evaluate(el => getComputedStyle(el).backgroundColor)
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+    ])
+
+    const connected = await outputHandle.evaluate(el => getComputedStyle(el).backgroundColor)
+    expect(connected).not.toBe(unconnected)
+  })
+
+  test('refuses a port type it is not carrying', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Image')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Prompt')
+
+    await positionNodes(page, [
+      { type: 'image', x: 100, y: 150 },
+      { type: 'reroute', x: 450, y: 170 },
+      { type: 'prompt', x: 700, y: 150 },
+    ])
+
+    // Now the reroute carries an image
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'image', sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+    ])
+
+    const rerouteNode = page.locator('.vue-flow__node-reroute')
+    const promptNode = page.locator('.vue-flow__node-prompt')
+
+    await connectNodes(page, rerouteNode, 'output-0', promptNode, 'input-0')
+    await page.waitForTimeout(300)
+
+    // Only the image edge survives: an image cannot land on a prompt input
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(1)
+  })
+
+  test('accepts the port type it is carrying', async ({ page }) => {
+    // The control for the test above: same gesture onto the same handle, so a
+    // rejection there is the validation talking and not a drag that missed
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Prompt')
+
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 100, y: 150 },
+      { type: 'reroute', x: 450, y: 170 },
+      { type: 'prompt', nth: 1, x: 700, y: 150 },
+    ])
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceNth: 0, sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+    ])
+
+    const rerouteNode = page.locator('.vue-flow__node-reroute')
+    const secondPrompt = page.locator('.vue-flow__node-prompt').nth(1)
+
+    await connectNodes(page, rerouteNode, 'output-0', secondPrompt, 'input-0')
+    await page.waitForTimeout(300)
+
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(2)
+  })
+
+  test('takes a single input', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 100, y: 100 },
+      { type: 'prompt', nth: 1, x: 100, y: 350 },
+      { type: 'reroute', x: 500, y: 220 },
+    ])
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceNth: 0, sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+    ])
+
+    const secondPrompt = page.locator('.vue-flow__node-prompt').nth(1)
+    const rerouteNode = page.locator('.vue-flow__node-reroute')
+
+    await connectNodes(page, secondPrompt, 'output-0', rerouteNode, 'input-0')
+    await page.waitForTimeout(300)
+
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(1)
+  })
+
+  test('deleting it leaves the wire connected', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Text Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'reroute', x: 450, y: 220 },
+      { type: 'text-generator', x: 700, y: 200 },
+    ])
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+      { sourceType: 'reroute', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+    ])
+
+    const [promptId] = await idsOfType(page, 'prompt')
+    const [textGenId] = await idsOfType(page, 'text-generator')
+
+    await selectNodesProgrammatic(page, [{ type: 'reroute' }])
+    await page.keyboard.press('Delete')
+    await page.waitForTimeout(400)
+
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(1)
+    expect(edges[0]).toMatchObject({
+      source: promptId,
+      sourceHandle: 'output-0',
+      target: textGenId,
+      targetHandle: 'input-1',
+    })
+  })
+
+  test('deleting it rewires every node it was feeding', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Text Generator')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'reroute', x: 450, y: 220 },
+      { type: 'text-generator', x: 700, y: 60 },
+      { type: 'image-generator', x: 700, y: 420 },
+    ])
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+      { sourceType: 'reroute', sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+      { sourceType: 'reroute', sourceHandle: 'output-0', targetType: 'image-generator', targetHandle: 'input-1' },
+    ])
+
+    const [promptId] = await idsOfType(page, 'prompt')
+
+    await selectNodesProgrammatic(page, [{ type: 'reroute' }])
+    await page.keyboard.press('Delete')
+    await page.waitForTimeout(400)
+
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(2)
+    expect(edges.every(e => e.source === promptId)).toBe(true)
+  })
+
+  test('deleting a whole chain of them leaves one edge behind', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Text Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'reroute', nth: 0, x: 350, y: 220 },
+      { type: 'reroute', nth: 1, x: 550, y: 220 },
+      { type: 'text-generator', x: 750, y: 200 },
+    ])
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'reroute', targetNth: 0, targetHandle: 'input-0' },
+      { sourceType: 'reroute', sourceNth: 0, sourceHandle: 'output-0', targetType: 'reroute', targetNth: 1, targetHandle: 'input-0' },
+      { sourceType: 'reroute', sourceNth: 1, sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+    ])
+
+    const [promptId] = await idsOfType(page, 'prompt')
+    const [textGenId] = await idsOfType(page, 'text-generator')
+
+    await selectNodesProgrammatic(page, [
+      { type: 'reroute', nth: 0 },
+      { type: 'reroute', nth: 1 },
+    ])
+    await page.keyboard.press('Delete')
+    await page.waitForTimeout(400)
+
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(1)
+    expect(edges[0]).toMatchObject({ source: promptId, target: textGenId })
+  })
+
+  test('deleting the middle one keeps the reroute that survives', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Reroute')
+    await addNodeFromSidebar(page, 'Text Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'reroute', nth: 0, x: 350, y: 220 },
+      { type: 'reroute', nth: 1, x: 550, y: 220 },
+      { type: 'text-generator', x: 750, y: 200 },
+    ])
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'reroute', targetNth: 0, targetHandle: 'input-0' },
+      { sourceType: 'reroute', sourceNth: 0, sourceHandle: 'output-0', targetType: 'reroute', targetNth: 1, targetHandle: 'input-0' },
+      { sourceType: 'reroute', sourceNth: 1, sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+    ])
+
+    const firstRerouteId = (await idsOfType(page, 'reroute'))[0]
+    const [textGenId] = await idsOfType(page, 'text-generator')
+
+    await selectNodesProgrammatic(page, [{ type: 'reroute', nth: 1 }])
+    await page.keyboard.press('Delete')
+    await page.waitForTimeout(400)
+
+    // The surviving reroute is a legitimate source, so the wire stops there
+    const { edges } = await readGraph(page)
+    expect(edges).toHaveLength(2)
+    expect(edges.some(e => e.source === firstRerouteId && e.target === textGenId)).toBe(true)
+  })
+
+  test('carries nothing into the exported flow', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Reroute')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'reroute', x: 500, y: 220 },
+    ])
+
+    await page.locator('.vue-flow__node-prompt textarea').fill('a cute cat')
+    await page.locator('.vue-flow__node-prompt textarea').blur()
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'reroute', targetHandle: 'input-0' },
+    ])
+
+    const { nodes } = await readGraph(page)
+    const reroute = nodes.find(n => n.type === 'reroute')
+
+    // Everything about it is recomputed from the graph, so its data holds only
+    // the label every node gets
+    expect(reroute.data.prompt).toBeUndefined()
+    expect(reroute.data.portType).toBeUndefined()
+  })
+
+  test('Backspace in a prompt edits text instead of deleting nodes', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 300, y: 200 }])
+
+    const textarea = page.locator('.vue-flow__node-prompt textarea')
+    await textarea.fill('cats')
+    await textarea.press('Backspace')
+    await page.waitForTimeout(200)
+
+    await expect(textarea).toHaveValue('cat')
+    await expect(page.locator('.vue-flow__node-prompt')).toHaveCount(1)
+  })
+})

--- a/src/components/base/BaseNode.vue
+++ b/src/components/base/BaseNode.vue
@@ -114,6 +114,7 @@ import { Handle, Position, useVueFlow } from '@vue-flow/core'
 import { useSettingsStore } from '@/stores/settings'
 import { canTakeBatchRole } from '@/lib/batch-io'
 import { ensureUniqueLabel } from '@/lib/node-label'
+import { getPortColor } from '@/lib/node-shapes'
 
 const settingsStore = useSettingsStore()
 const { updateNodeData, getNodes } = useVueFlow()
@@ -273,19 +274,6 @@ function getPortLabel(port) {
   return port.label || port.type
 }
 
-/**
- * Get color for port type using Flora design tokens
- */
-function getPortColor(portType) {
-  const colorMap = {
-    image: 'var(--flora-color-port-image)',
-    prompt: 'var(--flora-color-port-prompt)',
-    text: 'var(--flora-color-port-text)',
-    number: 'var(--flora-color-port-number)',
-    video: 'var(--flora-color-port-video)'
-  }
-  return colorMap[portType] || 'var(--flora-color-border-strong)'
-}
 </script>
 
 <style scoped>

--- a/src/components/canvas/NodesSidebar.vue
+++ b/src/components/canvas/NodesSidebar.vue
@@ -130,7 +130,8 @@ const helperNodes = computed(() =>
     n.type === NODE_TYPES.DRAW ||
     n.type === NODE_TYPES.DIFF ||
     n.type === NODE_TYPES.COMPARE ||
-    n.type === NODE_TYPES.COMMENT
+    n.type === NODE_TYPES.COMMENT ||
+    n.type === NODE_TYPES.REROUTE
   )
 )
 
@@ -145,7 +146,8 @@ function getNodeIcon(type) {
     [NODE_TYPES.VIDEO_GENERATOR]: '🎬',
     [NODE_TYPES.PROMPT_TEMPLATE]: '📋',
     [NODE_TYPES.DRAW]: '🖌️',
-    [NODE_TYPES.COMMENT]: '🗒️'
+    [NODE_TYPES.COMMENT]: '🗒️',
+    [NODE_TYPES.REROUTE]: '🔀'
   }
   return icons[type] || '⚙️'
 }

--- a/src/components/canvas/SettingsModal.vue
+++ b/src/components/canvas/SettingsModal.vue
@@ -22,6 +22,31 @@
         </div>
       </div>
 
+      <!-- Connections Section -->
+      <div class="settings-section">
+        <h3 class="settings-section-title">Connections</h3>
+        <div class="settings-option">
+          <label for="edge-type" class="settings-label">
+            Edge shape
+          </label>
+          <BaseSelect
+            id="edge-type"
+            v-model="settingsStore.edgeType"
+          >
+            <option
+              v-for="option in EDGE_TYPE_OPTIONS"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </BaseSelect>
+          <p class="settings-option-description settings-option-description--flush">
+            {{ edgeTypeDescription }}
+          </p>
+        </div>
+      </div>
+
       <!-- Save Behavior Section -->
       <div class="settings-section">
         <h3 class="settings-section-title">Save Behavior</h3>
@@ -126,7 +151,17 @@ import { ref, computed, watch } from 'vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import BaseCheckbox from '@/components/ui/BaseCheckbox.vue'
 import BaseInput from '@/components/ui/BaseInput.vue'
+import BaseSelect from '@/components/ui/BaseSelect.vue'
 import { useSettingsStore } from '@/stores/settings'
+
+// VueFlow's built-in edge types. 'default' is the bezier curve it ships with
+const EDGE_TYPE_OPTIONS = [
+  { value: 'default', label: 'Curved (bezier)', description: 'Smooth curves leaving each handle, the default' },
+  { value: 'simplebezier', label: 'Simple curve', description: 'A softer bezier that ignores the handle direction' },
+  { value: 'smoothstep', label: 'Right angles (rounded)', description: '90 degree turns with rounded corners' },
+  { value: 'step', label: 'Right angles (sharp)', description: '90 degree turns with sharp corners' },
+  { value: 'straight', label: 'Straight line', description: 'A direct line from handle to handle' }
+]
 
 const props = defineProps({
   modelValue: {
@@ -142,6 +177,11 @@ const settingsStore = useSettingsStore()
 const isOpen = computed({
   get: () => props.modelValue,
   set: (value) => emit('update:modelValue', value)
+})
+
+const edgeTypeDescription = computed(() => {
+  const option = EDGE_TYPE_OPTIONS.find((o) => o.value === settingsStore.edgeType)
+  return option ? option.description : ''
 })
 
 // Local state for API keys - initialized from store
@@ -219,6 +259,12 @@ function handleClearKeys() {
   font-size: var(--flora-font-size-xs);
   color: var(--flora-color-text-tertiary);
   padding-left: calc(18px + var(--flora-space-2));
+}
+
+/* Selects and inputs are full width, so their hint does not need the
+   checkbox indent */
+.settings-option-description--flush {
+  padding-left: 0;
 }
 
 .settings-option-description a {

--- a/src/components/nodes/DiffNode.vue
+++ b/src/components/nodes/DiffNode.vue
@@ -43,9 +43,8 @@ import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import { useNode } from '@vue-flow/core'
 import { useFlowStore } from '@/stores/flow'
 import BaseNode from '@/components/base/BaseNode.vue'
-import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
-import nodeRegistry from '@/lib/node-registry'
+import { readUpstreamAll, pickImage } from '@/lib/upstream'
 
 const props = defineProps({
   id: { type: String, required: true },
@@ -64,32 +63,17 @@ const { node } = useNode()
 // Get the current node data from useNode composable
 const nodeData = computed(() => node.data)
 
-// Get connected images from incoming edges
-// Using flowStore directly for reactivity with PORT_TYPE validation
-const connectedImages = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  return incomingEdges
-    .map(edge => {
-      // Validate port type
-      const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-      if (portType !== PORT_TYPES.IMAGE) return null
-
-      const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-      if (!sourceNode) return null
-
-      // Get image from source node
-      const imageSrc = sourceNode.data?.src || sourceNode.data?.lastOutputSrc
-      if (!imageSrc) return null
-
-      return {
-        src: imageSrc,
-        handle: edge.targetHandle,
-        nodeId: edge.source
-      }
-    })
-    .filter(img => img !== null)
-})
+// Get connected images from incoming edges, reaching past any reroute in
+// between. Kept in edge order, which is what tells the two inputs apart
+const connectedImages = computed(() =>
+  readUpstreamAll(props.id, flowStore.nodes, flowStore.edges, pickImage, {
+    portType: PORT_TYPES.IMAGE
+  }).map(input => ({
+    src: input.value,
+    handle: input.handle,
+    nodeId: input.nodeId
+  }))
+)
 
 const hasImage1 = computed(() => {
   return connectedImages.value.some(img => img.handle === 'input-0')

--- a/src/components/nodes/DrawNode.vue
+++ b/src/components/nodes/DrawNode.vue
@@ -76,9 +76,8 @@
 import { ref, computed, watchEffect } from 'vue'
 import { useNode, useVueFlow } from '@vue-flow/core'
 import { useFlowStore } from '@/stores/flow'
-import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
-import nodeRegistry from '@/lib/node-registry'
+import { readUpstream, pickImage } from '@/lib/upstream'
 import BaseNode from '@/components/base/BaseNode.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
@@ -116,23 +115,12 @@ const nodeData = computed(() => node.data)
 const showDrawingModal = ref(false)
 const drawingCanvasRef = ref(null)
 
-// Get connected image from upstream nodes
-const connectedImage = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  for (const edge of incomingEdges) {
-    const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-    if (portType !== PORT_TYPES.IMAGE) continue
-
-    const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-    if (!sourceNode || !sourceNode.data) continue
-
-    const imageSrc = sourceNode.data.src || sourceNode.data.lastOutputSrc || sourceNode.data.outputSrc
-    if (imageSrc) return imageSrc
-  }
-
-  return null
-})
+// Get connected image from upstream nodes, reaching past any reroute in between
+const connectedImage = computed(() =>
+  readUpstream(props.id, flowStore.nodes, flowStore.edges, pickImage, {
+    portType: PORT_TYPES.IMAGE
+  })
+)
 
 // Current image to draw on (always the original without strokes)
 const currentImageSrc = computed(() => {

--- a/src/components/nodes/ImageCompareNode.vue
+++ b/src/components/nodes/ImageCompareNode.vue
@@ -71,9 +71,8 @@ import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { useNode, useVueFlow } from '@vue-flow/core'
 import { useFlowStore } from '@/stores/flow'
 import BaseNode from '@/components/base/BaseNode.vue'
-import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
-import nodeRegistry from '@/lib/node-registry'
+import { readUpstreamAll, pickImage } from '@/lib/upstream'
 
 const props = defineProps({
   id: { type: String, required: true },
@@ -126,32 +125,17 @@ function updatePosition(event) {
   sliderPosition.value = Math.max(0, Math.min(100, percentage))
 }
 
-// Get connected images from incoming edges
-// Using flowStore directly for reactivity with PORT_TYPE validation
-const connectedImages = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  return incomingEdges
-    .map(edge => {
-      // Validate port type
-      const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-      if (portType !== PORT_TYPES.IMAGE) return null
-
-      const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-      if (!sourceNode) return null
-
-      // Get image from source node
-      const imageSrc = sourceNode.data?.src || sourceNode.data?.lastOutputSrc
-      if (!imageSrc) return null
-
-      return {
-        src: imageSrc,
-        handle: edge.targetHandle,
-        nodeId: edge.source
-      }
-    })
-    .filter(img => img !== null)
-})
+// Get connected images from incoming edges, reaching past any reroute in
+// between. The handle is what tells the two sides of the comparison apart
+const connectedImages = computed(() =>
+  readUpstreamAll(props.id, flowStore.nodes, flowStore.edges, pickImage, {
+    portType: PORT_TYPES.IMAGE
+  }).map(input => ({
+    src: input.value,
+    handle: input.handle,
+    nodeId: input.nodeId
+  }))
+)
 
 const hasImage1 = computed(() => {
   return connectedImages.value.some(img => img.handle === 'input-0')

--- a/src/components/nodes/ImageGeneratorNode.vue
+++ b/src/components/nodes/ImageGeneratorNode.vue
@@ -202,6 +202,7 @@ import replicateService from '@/services/replicate'
 import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
 import nodeRegistry from '@/lib/node-registry'
+import { readUpstream, readUpstreamAll, pickImage, pickPrompt } from '@/lib/upstream'
 import { convertImageUrlToBase64, isHttpUrl } from '@/lib/image-utils'
 import { useWorkflowEvents } from '@/composables/useWorkflowEvents'
 import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
@@ -245,48 +246,23 @@ const { updateNodeData, removeEdges, updateNodeInternals } = useVueFlow()
 // Get the current node data from useNode composable
 const nodeData = computed(() => node.data)
 
-// Get connected images from upstream nodes
-// Using flowStore directly for reactivity
-const connectedImages = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  return incomingEdges
-    .map(edge => {
-      // Check if this edge connects an IMAGE port
-      const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-      if (portType !== PORT_TYPES.IMAGE) return null
-
-      const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-      if (!sourceNode || !sourceNode.data) return null
-
-      const imageSrc = sourceNode.data.src || sourceNode.data.lastOutputSrc
-      if (!imageSrc) return null
-
-      return {
-        src: imageSrc,
-        name: sourceNode.data.name || sourceNode.data.label
-      }
-    })
-    .filter(img => img !== null)
-})
+// Get connected images from upstream nodes, reaching past any reroute in
+// between. Kept in edge order, which is the order the model receives them in
+const connectedImages = computed(() =>
+  readUpstreamAll(props.id, flowStore.nodes, flowStore.edges, pickImage, {
+    portType: PORT_TYPES.IMAGE
+  }).map(input => ({
+    src: input.value,
+    name: input.node.data.name || input.node.data.label
+  }))
+)
 
 // Get connected prompt from upstream nodes (uses PORT_TYPE instead of node type)
-const connectedPrompt = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  for (const edge of incomingEdges) {
-    // Check if this edge connects a PROMPT port
-    const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-    if (portType !== PORT_TYPES.PROMPT) continue
-
-    const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-    if (sourceNode && sourceNode.data?.prompt) {
-      return sourceNode.data.prompt
-    }
-  }
-
-  return null
-})
+const connectedPrompt = computed(() =>
+  readUpstream(props.id, flowStore.nodes, flowStore.edges, pickPrompt, {
+    portType: PORT_TYPES.PROMPT
+  })
+)
 
 // Toolbar controls - Available models (only image generation models)
 const availableModels = computed(() => replicateService.listModels('image'))

--- a/src/components/nodes/PromptNode.vue
+++ b/src/components/nodes/PromptNode.vue
@@ -29,9 +29,8 @@
 import { ref, computed, watch } from 'vue'
 import { useNode, useVueFlow } from '@vue-flow/core'
 import { useFlowStore } from '@/stores/flow'
-import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
-import nodeRegistry from '@/lib/node-registry'
+import { readUpstream, pickPrompt } from '@/lib/upstream'
 import BaseNode from '@/components/base/BaseNode.vue'
 import BaseTextarea from '@/components/ui/BaseTextarea.vue'
 
@@ -63,23 +62,12 @@ const { updateNodeData } = useVueFlow()
 // Get the current node data from useNode composable
 const nodeData = computed(() => node.data)
 
-// Get input prompt from connected node
-const connectedPrompt = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  for (const edge of incomingEdges) {
-    // Check if this edge connects a PROMPT port
-    const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-    if (portType !== PORT_TYPES.PROMPT) continue
-
-    const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-    if (sourceNode && sourceNode.data?.prompt) {
-      return sourceNode.data.prompt
-    }
-  }
-
-  return null
-})
+// Get input prompt from connected node, reaching past any reroute in between
+const connectedPrompt = computed(() =>
+  readUpstream(props.id, flowStore.nodes, flowStore.edges, pickPrompt, {
+    portType: PORT_TYPES.PROMPT
+  })
+)
 
 // Initialize local prompt with connected prompt or stored prompt
 const localPrompt = ref(connectedPrompt.value || props.data.prompt || '')

--- a/src/components/nodes/PromptTemplateNode.vue
+++ b/src/components/nodes/PromptTemplateNode.vue
@@ -38,9 +38,8 @@
 import { ref, computed, watch } from 'vue'
 import { useNode, useVueFlow } from '@vue-flow/core'
 import { useFlowStore } from '@/stores/flow'
-import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
-import nodeRegistry from '@/lib/node-registry'
+import { readUpstream, pickPrompt } from '@/lib/upstream'
 import { extractVariables, applyVariables } from '@/lib/prompt-template'
 import BaseNode from '@/components/base/BaseNode.vue'
 import BaseInput from '@/components/ui/BaseInput.vue'
@@ -76,23 +75,12 @@ const nodeData = computed(() => node.data)
 // Local state for variables
 const localVariables = ref(props.data.variables || {})
 
-// Get input prompt from connected node
-const inputPrompt = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  for (const edge of incomingEdges) {
-    // Check if this edge connects a PROMPT port
-    const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-    if (portType !== PORT_TYPES.PROMPT) continue
-
-    const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-    if (sourceNode && sourceNode.data?.prompt) {
-      return sourceNode.data.prompt
-    }
-  }
-
-  return ''
-})
+// Get input prompt from connected node, reaching past any reroute in between
+const inputPrompt = computed(() =>
+  readUpstream(props.id, flowStore.nodes, flowStore.edges, pickPrompt, {
+    portType: PORT_TYPES.PROMPT
+  }) || ''
+)
 
 // Detect variables in the input prompt
 const detectedVariables = computed(() => extractVariables(inputPrompt.value))

--- a/src/components/nodes/RerouteNode.vue
+++ b/src/components/nodes/RerouteNode.vue
@@ -68,8 +68,10 @@ const tooltip = computed(() =>
 <style scoped>
 .reroute-node {
   position: relative;
-  width: 34px;
-  height: 14px;
+  /* Wide enough that the two handles do not read as a single blob, short
+     enough that the node stays out of the way of the wire it is bending */
+  width: 44px;
+  height: 16px;
   background: var(--flora-color-surface);
   border: var(--flora-border-width-medium) solid var(--flora-color-border-default);
   border-radius: var(--flora-radius-full);

--- a/src/components/nodes/RerouteNode.vue
+++ b/src/components/nodes/RerouteNode.vue
@@ -1,0 +1,116 @@
+<template>
+  <!--
+    Deliberately not a BaseNode: a reroute is only its two handles, and BaseNode
+    brings a 200px minimum width, content padding, a header, handle labels and
+    the execution and batch badges, all of which would have to be undone
+  -->
+  <div class="reroute-node" :class="{ selected }" :title="tooltip">
+    <Handle
+      id="input-0"
+      type="target"
+      :position="Position.Left"
+      :style="handleStyle"
+    />
+    <Handle
+      id="output-0"
+      type="source"
+      :position="Position.Right"
+      :style="handleStyle"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { Handle, Position } from '@vue-flow/core'
+import { useFlowStore } from '@/stores/flow'
+import { getPortColor } from '@/lib/node-shapes'
+import { resolveRerouteType } from '@/lib/upstream'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  type: {
+    type: String,
+    required: true
+  },
+  data: {
+    type: Object,
+    default: () => ({})
+  },
+  selected: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const flowStore = useFlowStore()
+
+/**
+ * The port type is not stored anywhere: it is read off whatever feeds the
+ * reroute, so the dots recolour on their own when the wire is repointed, and
+ * nothing about a reroute ends up in the exported .json beyond its position
+ */
+const portType = computed(() =>
+  resolveRerouteType(props.id, flowStore.nodes, flowStore.edges)
+)
+
+const handleStyle = computed(() => ({ background: getPortColor(portType.value) }))
+
+// The node is too small for a label, so what it carries goes in the tooltip
+const tooltip = computed(() =>
+  portType.value ? `Reroute (${portType.value})` : 'Reroute (not connected)'
+)
+</script>
+
+<style scoped>
+.reroute-node {
+  position: relative;
+  width: 34px;
+  height: 14px;
+  background: var(--flora-color-surface);
+  border: var(--flora-border-width-medium) solid var(--flora-color-border-default);
+  border-radius: var(--flora-radius-full);
+  box-shadow: var(--flora-shadow-md);
+  transition:
+    border-color var(--flora-transition-base),
+    box-shadow var(--flora-transition-base);
+}
+
+.reroute-node.selected {
+  border-color: var(--flora-color-accent);
+  box-shadow: var(--flora-shadow-accent-lg);
+}
+
+.reroute-node:hover {
+  box-shadow: var(--flora-shadow-lg);
+}
+
+/* BaseNode styles its handles inside its own scope, so a node that does not use
+   it has to say this itself. Same sizes, so reroute handles feel like the rest */
+:deep(.vue-flow__handle) {
+  width: 14px;
+  height: 14px;
+  border: var(--flora-border-width-thick) solid var(--flora-color-surface);
+  box-shadow: var(--flora-shadow-md);
+  cursor: crosshair;
+  transition:
+    width var(--flora-transition-fast),
+    height var(--flora-transition-fast),
+    background-color var(--flora-transition-fast),
+    box-shadow var(--flora-transition-fast);
+}
+
+:deep(.vue-flow__handle:hover) {
+  width: 16px;
+  height: 16px;
+  box-shadow: var(--flora-shadow-lg);
+}
+
+:deep(.vue-flow__handle-connecting) {
+  width: 18px;
+  height: 18px;
+}
+</style>

--- a/src/components/nodes/TextGeneratorNode.vue
+++ b/src/components/nodes/TextGeneratorNode.vue
@@ -168,9 +168,8 @@ import BaseInput from '@/components/ui/BaseInput.vue'
 import BaseCheckbox from '@/components/ui/BaseCheckbox.vue'
 import BaseLabel from '@/components/ui/BaseLabel.vue'
 import replicateService from '@/services/replicate'
-import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
-import nodeRegistry from '@/lib/node-registry'
+import { readUpstream, readUpstreamAll, pickImage, pickPrompt } from '@/lib/upstream'
 import { useWorkflowEvents } from '@/composables/useWorkflowEvents'
 import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
 
@@ -215,47 +214,23 @@ const advancedControls = computed(() => {
 
 const { openPanel } = useSidePanel()
 
-// Get connected images from incoming edges (uses PORT_TYPE)
-const connectedImages = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  return incomingEdges
-    .map(edge => {
-      // Check if this edge connects an IMAGE port
-      const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-      if (portType !== PORT_TYPES.IMAGE) return null
-
-      const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-      if (!sourceNode || !sourceNode.data) return null
-
-      const imageSrc = sourceNode.data.src || sourceNode.data.lastOutputSrc
-      if (!imageSrc) return null
-
-      return {
-        src: imageSrc,
-        name: sourceNode.data.name || sourceNode.data.label
-      }
-    })
-    .filter(img => img !== null)
-})
+// Get connected images from incoming edges, reaching past any reroute in
+// between. Kept in edge order, which is the order the model receives them in
+const connectedImages = computed(() =>
+  readUpstreamAll(props.id, flowStore.nodes, flowStore.edges, pickImage, {
+    portType: PORT_TYPES.IMAGE
+  }).map(input => ({
+    src: input.value,
+    name: input.node.data.name || input.node.data.label
+  }))
+)
 
 // Get connected prompt from incoming edges (uses PORT_TYPE)
-const connectedPrompt = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  for (const edge of incomingEdges) {
-    // Check if this edge connects a PROMPT port
-    const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-    if (portType !== PORT_TYPES.PROMPT) continue
-
-    const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-    if (sourceNode && sourceNode.data?.prompt) {
-      return sourceNode.data.prompt
-    }
-  }
-
-  return null
-})
+const connectedPrompt = computed(() =>
+  readUpstream(props.id, flowStore.nodes, flowStore.edges, pickPrompt, {
+    portType: PORT_TYPES.PROMPT
+  })
+)
 
 // Initialize local prompt from node data only on mount
 if (nodeData.value.userPrompt) {

--- a/src/components/nodes/VideoGeneratorNode.vue
+++ b/src/components/nodes/VideoGeneratorNode.vue
@@ -195,9 +195,8 @@ import BaseLabel from '@/components/ui/BaseLabel.vue'
 import BaseCheckbox from '@/components/ui/BaseCheckbox.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import replicateService from '@/services/replicate'
-import { getEdgePortType } from '@/lib/connection'
 import { PORT_TYPES } from '@/lib/node-shapes'
-import nodeRegistry from '@/lib/node-registry'
+import { readUpstream, pickImage, pickPrompt } from '@/lib/upstream'
 import { convertUrlToBase64, isHttpUrl } from '@/lib/image-utils'
 import { useWorkflowEvents } from '@/composables/useWorkflowEvents'
 import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
@@ -258,23 +257,16 @@ const inputPorts = [
 ]
 
 /**
- * Read the image coming into one of this node's image handles
+ * Read the image coming into one of this node's image handles, reaching past
+ * any reroute in between
  * @param {string} handleId - Target handle id
  * @returns {string|null} Image src or null when nothing is connected
  */
 function readImageOnHandle(handleId) {
-  const edge = flowStore.edges.find(
-    e => e.target === props.id && e.targetHandle === handleId
-  )
-  if (!edge) return null
-
-  const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-  if (portType !== PORT_TYPES.IMAGE) return null
-
-  const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-  if (!sourceNode || !sourceNode.data) return null
-
-  return sourceNode.data.src || sourceNode.data.lastOutputSrc || null
+  return readUpstream(props.id, flowStore.nodes, flowStore.edges, pickImage, {
+    portType: PORT_TYPES.IMAGE,
+    handle: handleId
+  })
 }
 
 // First frame of the video (image-to-video)
@@ -284,22 +276,11 @@ const firstFrameImage = computed(() => readImageOnHandle(FIRST_FRAME_HANDLE))
 const lastFrameImage = computed(() => readImageOnHandle(LAST_FRAME_HANDLE))
 
 // Get connected prompt from upstream nodes (uses PORT_TYPE instead of node type)
-const connectedPrompt = computed(() => {
-  const incomingEdges = flowStore.edges.filter(edge => edge.target === props.id)
-
-  for (const edge of incomingEdges) {
-    // Check if this edge connects a PROMPT port
-    const portType = getEdgePortType(edge, flowStore.nodes, nodeRegistry, true)
-    if (portType !== PORT_TYPES.PROMPT) continue
-
-    const sourceNode = flowStore.nodes.find(n => n.id === edge.source)
-    if (sourceNode && sourceNode.data?.prompt) {
-      return sourceNode.data.prompt
-    }
-  }
-
-  return null
-})
+const connectedPrompt = computed(() =>
+  readUpstream(props.id, flowStore.nodes, flowStore.edges, pickPrompt, {
+    portType: PORT_TYPES.PROMPT
+  })
+)
 
 // Toolbar controls - Available models (only video generation models)
 const availableModels = computed(() => replicateService.listModels('video'))

--- a/src/composables/useConnectionDrop.js
+++ b/src/composables/useConnectionDrop.js
@@ -11,6 +11,8 @@ import {
   getCompatibleConnectionOptions,
   validateConnection
 } from '@/lib/connection'
+import { PORT_TYPES } from '@/lib/node-shapes'
+import { resolveRerouteType } from '@/lib/upstream'
 
 // Rough node size used to place the new node around the drop point
 const NODE_WIDTH = 220
@@ -78,7 +80,16 @@ export function useConnectionDrop(
     const originNode = flowStore.nodes.find(n => n.id === origin.nodeId)
     if (!originNode) return
 
-    const portType = getHandlePortType(originNode.type, origin.handleId, origin.handleType)
+    let portType = getHandlePortType(originNode.type, origin.handleId, origin.handleType)
+
+    // A reroute declares the wildcard, so the menu has to be filtered by what it
+    // is actually carrying: otherwise every node would be offered, wired to its
+    // port 0 regardless of type. An unconnected reroute has nothing to offer and
+    // falls through the guard below, which is the right call
+    if (portType === PORT_TYPES.ANY) {
+      portType = resolveRerouteType(origin.nodeId, flowStore.nodes, flowStore.edges)
+    }
+
     if (!portType) return
 
     const dropPosition = screenToFlowCoordinate({ x: event.clientX, y: event.clientY })

--- a/src/composables/useNodeDeletion.js
+++ b/src/composables/useNodeDeletion.js
@@ -1,0 +1,72 @@
+/**
+ * Composable for deleting the selection
+ *
+ * VueFlow's own delete key is turned off (`:delete-key-code="null"`) so the
+ * removal can be wrapped: deleting a reroute must leave the wire it was only
+ * bending connected. It has to happen here rather than in a hook, because
+ * `removeNodes` fires `edgesChange` and `nodesChange` only once it has applied
+ * them, and by then the reroute's edges - the only record of where the wire
+ * went - are already gone
+ */
+
+import { onMounted, onUnmounted } from 'vue'
+import { planRerouteBypass } from '@/lib/upstream'
+
+// Same guard VueFlow applies before acting on a key, so typing in a prompt
+// never deletes nodes
+const EDITABLE_TAGS = ['INPUT', 'SELECT', 'TEXTAREA']
+
+/**
+ * Whether a keyboard event came from somewhere the canvas must keep its hands off
+ * @param {KeyboardEvent} event
+ * @returns {boolean}
+ */
+function isEditableTarget(event) {
+  const target = event.composedPath?.()?.[0] || event.target
+  if (!target) return false
+
+  if (EDITABLE_TAGS.includes(target.nodeName)) return true
+  if (target.isContentEditable) return true
+  if (typeof target.hasAttribute === 'function' && target.hasAttribute('contenteditable')) return true
+
+  return typeof target.closest === 'function' && !!target.closest('.nokey')
+}
+
+export function useNodeDeletion(flowStore, vueFlow) {
+  const { getSelectedNodes, getSelectedEdges, removeNodes, removeEdges, addEdges } = vueFlow
+
+  /**
+   * Delete the current selection, reconnecting around any reroute in it
+   */
+  function handleDelete() {
+    // Copies: removeNodes mutates the selection behind these computed
+    const nodes = [...getSelectedNodes.value]
+    const edges = [...getSelectedEdges.value]
+    if (!nodes.length && !edges.length) return
+
+    // Planned while the graph is still whole
+    const bridges = planRerouteBypass(nodes, flowStore.nodes, flowStore.edges)
+
+    // Same order VueFlow used: nodes first, their edges go with them
+    if (nodes.length) removeNodes(nodes)
+    if (edges.length) removeEdges(edges)
+
+    // Last, so the cascade cannot take the new edges with it. addEdges runs
+    // isValidConnection, which is the safety net we want here: a bridge that
+    // would duplicate a wire already on the canvas is dropped
+    if (bridges.length) addEdges(bridges)
+  }
+
+  function onKeyDown(event) {
+    if (event.key !== 'Delete' && event.key !== 'Backspace') return
+    if (isEditableTarget(event)) return
+
+    event.preventDefault()
+    handleDelete()
+  }
+
+  onMounted(() => window.addEventListener('keydown', onKeyDown))
+  onUnmounted(() => window.removeEventListener('keydown', onKeyDown))
+
+  return { handleDelete }
+}

--- a/src/lib/batch-io.js
+++ b/src/lib/batch-io.js
@@ -5,8 +5,7 @@
  */
 
 import { NODE_TYPES, PORT_TYPES } from './node-shapes'
-import { getEdgePortType } from './connection'
-import nodeRegistry from './node-registry'
+import { resolveUpstream, pickPrompt } from './upstream'
 import { extractVariables, applyVariables } from './prompt-template'
 
 /**
@@ -118,19 +117,11 @@ export function resolveUpstreamPrompt(nodeId, nodes, edges) {
  * @returns {Object|null} Source node, or null
  */
 export function resolveUpstreamPromptNode(nodeId, nodes, edges) {
-  const incomingEdges = edges.filter(edge => edge.target === nodeId)
+  // The real producer, never a reroute standing in the middle of the wire:
+  // BatchRunModal writes the batch rows into whatever comes back from here
+  const inputs = resolveUpstream(nodeId, nodes, edges, { portType: PORT_TYPES.PROMPT })
 
-  for (const edge of incomingEdges) {
-    const portType = getEdgePortType(edge, nodes, nodeRegistry, true)
-    if (portType !== PORT_TYPES.PROMPT) continue
-
-    const sourceNode = nodes.find(n => n.id === edge.source)
-    if (sourceNode?.data?.prompt) {
-      return sourceNode
-    }
-  }
-
-  return null
+  return inputs.find(input => pickPrompt(input.node))?.node || null
 }
 
 /**

--- a/src/lib/connection.js
+++ b/src/lib/connection.js
@@ -1,5 +1,7 @@
-import { PORT_TYPES } from './node-shapes'
+import { NODE_TYPES, PORT_TYPES } from './node-shapes'
 import nodeRegistry from './node-registry'
+import { getDeclaredPortType } from './ports'
+import { isPassThrough, resolveRerouteType } from './upstream'
 
 /**
  * Get the PORT_TYPE for an edge connection
@@ -7,9 +9,11 @@ import nodeRegistry from './node-registry'
  * @param {Array} nodes - Array of all nodes
  * @param {Object} registry - Node registry instance
  * @param {boolean} isSource - True for source port, false for target port
+ * @param {Array} [edges] - All edges. Needed to resolve what a reroute carries;
+ *   without it a reroute reports the wildcard
  * @returns {string|null} PORT_TYPE ('image', 'prompt') or null
  */
-export function getEdgePortType(edge, nodes, registry, isSource = true) {
+export function getEdgePortType(edge, nodes, registry, isSource = true, edges = null) {
   const nodeId = isSource ? edge.source : edge.target
   const handleId = isSource ? edge.sourceHandle : edge.targetHandle
 
@@ -18,17 +22,16 @@ export function getEdgePortType(edge, nodes, registry, isSource = true) {
   const node = nodes.find(n => n.id === nodeId)
   if (!node) return null
 
-  const nodeDef = registry.getNodeDef(node.type)
-  if (!nodeDef) return null
+  const declared = getDeclaredPortType(node.type, handleId, isSource, registry)
 
-  // Parse handle index (e.g., "output-0" -> 0)
-  const handleIndex = parseInt(handleId.split('-')[1])
-  if (isNaN(handleIndex)) return null
+  // A reroute declares the wildcard on both sides: swap it for the type it is
+  // actually carrying, and keep the wildcard while nothing feeds it so it
+  // still accepts anything
+  if (declared === PORT_TYPES.ANY && isPassThrough(node) && edges) {
+    return resolveRerouteType(node.id, nodes, edges) || PORT_TYPES.ANY
+  }
 
-  // Get port types array
-  const portTypes = isSource ? nodeDef.outputs : nodeDef.inputs
-
-  return portTypes[handleIndex] || null
+  return declared
 }
 
 /**
@@ -40,17 +43,7 @@ export function getEdgePortType(edge, nodes, registry, isSource = true) {
  * @returns {string|null} PORT_TYPE ('image', 'prompt') or null
  */
 export function getHandlePortType(nodeType, handleId, handleType) {
-  if (!nodeType || !handleId) return null
-
-  const nodeDef = nodeRegistry.getNodeDef(nodeType)
-  if (!nodeDef) return null
-
-  const handleIndex = parseInt(handleId.split('-')[1])
-  if (isNaN(handleIndex)) return null
-
-  const portTypes = handleType === 'source' ? nodeDef.outputs : nodeDef.inputs
-
-  return portTypes[handleIndex] || null
+  return getDeclaredPortType(nodeType, handleId, handleType === 'source', nodeRegistry)
 }
 
 /**
@@ -60,6 +53,11 @@ export function getHandlePortType(nodeType, handleId, handleType) {
  * @returns {boolean} true if compatible, false otherwise
  */
 function canConnect(sourcePortType, targetPortType) {
+  // A reroute reports the wildcard only while nothing feeds it: once it is
+  // carrying something, getEdgePortType hands out the concrete type and this
+  // goes back to being a strict equality
+  if (sourcePortType === PORT_TYPES.ANY || targetPortType === PORT_TYPES.ANY) return true
+
   // Ports must be of the same type to connect
   return sourcePortType === targetPortType
 }
@@ -203,22 +201,42 @@ export function validateConnection(connection, sourceNode, targetNode, existingE
 
   // IMPORTANT: Validate specific port types if handles are provided
   if (connection.sourceHandle && connection.targetHandle) {
-    const sourcePortType = getEdgePortType(connection, allNodes.length > 0 ? allNodes : [sourceNode, targetNode], nodeRegistry, true)
-    const targetPortType = getEdgePortType(connection, allNodes.length > 0 ? allNodes : [sourceNode, targetNode], nodeRegistry, false)
+    const pool = allNodes.length > 0 ? allNodes : [sourceNode, targetNode]
 
-    if (sourcePortType && targetPortType) {
-      if (sourcePortType !== targetPortType) {
-        return {
-          valid: false,
-          reason: `Incompatible port types: ${sourcePortType} → ${targetPortType}`
-        }
+    // Passing the edges is what lets a reroute be typed from the graph, so a
+    // chain of them resolves correctly mid-drag
+    const sourcePortType = getEdgePortType(connection, pool, nodeRegistry, true, existingEdges)
+    const targetPortType = getEdgePortType(connection, pool, nodeRegistry, false, existingEdges)
+
+    if (sourcePortType && targetPortType && !canConnect(sourcePortType, targetPortType)) {
+      return {
+        valid: false,
+        reason: `Incompatible port types: ${sourcePortType} → ${targetPortType}`
       }
     }
   }
 
-  // Prevent duplicate connections (same source and target)
+  // A reroute forwards exactly one signal: with several inputs both the type it
+  // carries and the value it hands on would be arbitrary
+  if (targetNode.type === NODE_TYPES.REROUTE) {
+    const alreadyFed = existingEdges.some(edge => edge.target === connection.target)
+
+    if (alreadyFed) {
+      return {
+        valid: false,
+        reason: 'A reroute already has an input'
+      }
+    }
+  }
+
+  // Prevent duplicate connections (same wire, handles included)
+  // Comparing the target handle too is what lets one source feed two different
+  // inputs of the same node, which the two image inputs of Diff and Compare
+  // have always been meant to allow
   const isDuplicate = existingEdges.some(
-    edge => edge.source === connection.source && edge.target === connection.target
+    edge => edge.source === connection.source &&
+      edge.target === connection.target &&
+      (edge.targetHandle ?? null) === (connection.targetHandle ?? null)
   )
 
   if (isDuplicate) {

--- a/src/lib/node-shapes.js
+++ b/src/lib/node-shapes.js
@@ -12,7 +12,8 @@ export const NODE_TYPES = {
   TEXT_GENERATOR: 'text-generator',
   VIDEO_GENERATOR: 'video-generator',
   GROUP: 'group',
-  COMMENT: 'comment'
+  COMMENT: 'comment',
+  REROUTE: 'reroute'
 }
 
 /**
@@ -21,7 +22,28 @@ export const NODE_TYPES = {
 export const PORT_TYPES = {
   IMAGE: 'image',
   PROMPT: 'prompt',
-  VIDEO: 'video'
+  VIDEO: 'video',
+  // Wildcard. Only a reroute declares it: it takes any port and hands on
+  // whatever it was given, so its real type is resolved from the graph
+  ANY: 'any'
+}
+
+/**
+ * Color token for a port type, used by every handle on the canvas
+ * @param {string} portType - PORT_TYPE
+ * @returns {string} CSS value
+ */
+export function getPortColor(portType) {
+  const colorMap = {
+    [PORT_TYPES.IMAGE]: 'var(--flora-color-port-image)',
+    [PORT_TYPES.PROMPT]: 'var(--flora-color-port-prompt)',
+    [PORT_TYPES.VIDEO]: 'var(--flora-color-port-video)',
+    text: 'var(--flora-color-port-text)',
+    number: 'var(--flora-color-port-number)'
+  }
+
+  // A reroute with nothing plugged in has no type yet: neutral grey
+  return colorMap[portType] || 'var(--flora-color-border-strong)'
 }
 
 /**
@@ -126,6 +148,12 @@ const NODE_IO_CONFIG = {
   [NODE_TYPES.COMMENT]: {
     inputs: [],
     outputs: []
+  },
+  // Both sides are the wildcard: the type a reroute carries is the one plugged
+  // into it, resolved from the graph rather than declared here
+  [NODE_TYPES.REROUTE]: {
+    inputs: [PORT_TYPES.ANY],
+    outputs: [PORT_TYPES.ANY]
   }
 }
 

--- a/src/lib/ports.js
+++ b/src/lib/ports.js
@@ -1,0 +1,47 @@
+/**
+ * Port helpers
+ * Handle IDs follow the `input-<index>` / `output-<index>` convention that
+ * BaseNode generates, and the index maps 1:1 onto the inputs/outputs arrays a
+ * node declares in the registry
+ *
+ * This lives apart from connection.js so that upstream.js can resolve port
+ * types without importing it: connection.js needs upstream.js to resolve what
+ * a reroute is carrying, and the two would otherwise import each other
+ */
+
+/**
+ * Index encoded in a handle ID
+ * @param {string} handleId - Handle ID (e.g. "output-0")
+ * @returns {number|null} Index, or null when the ID does not carry one
+ */
+export function getHandleIndex(handleId) {
+  if (!handleId) return null
+
+  const index = parseInt(String(handleId).split('-')[1])
+
+  return isNaN(index) ? null : index
+}
+
+/**
+ * PORT_TYPE a node type declares on one of its handles
+ * This is what the registry says, so a reroute always comes back as the
+ * wildcard here: resolving what it actually carries is upstream.js's job
+ * @param {string} nodeType - Node type
+ * @param {string} handleId - Handle ID (e.g. "output-0")
+ * @param {boolean} isSource - True for an output handle, false for an input
+ * @param {Object} registry - Node registry instance
+ * @returns {string|null} PORT_TYPE, or null when the handle does not exist
+ */
+export function getDeclaredPortType(nodeType, handleId, isSource, registry) {
+  if (!nodeType || !handleId) return null
+
+  const nodeDef = registry.getNodeDef(nodeType)
+  if (!nodeDef) return null
+
+  const handleIndex = getHandleIndex(handleId)
+  if (handleIndex === null) return null
+
+  const portTypes = isSource ? nodeDef.outputs : nodeDef.inputs
+
+  return portTypes[handleIndex] || null
+}

--- a/src/lib/register-nodes.js
+++ b/src/lib/register-nodes.js
@@ -16,6 +16,7 @@ import TextGeneratorNode from '@/components/nodes/TextGeneratorNode.vue'
 import VideoGeneratorNode from '@/components/nodes/VideoGeneratorNode.vue'
 import GroupNode from '@/components/nodes/GroupNode.vue'
 import CommentNode from '@/components/nodes/CommentNode.vue'
+import RerouteNode from '@/components/nodes/RerouteNode.vue'
 
 /**
  * Register all available node types
@@ -170,6 +171,22 @@ export function registerAllNodes() {
     inputs: [],
     outputs: [],
     component: CommentNode,
+    config: {
+      category: 'Helper',
+      color: '#6B7280'
+    }
+  })
+
+  // Register Reroute Node
+  // Both ports are the wildcard, so it shows up in every connection menu and
+  // accepts anything. What it actually carries is resolved from the graph
+  nodeRegistry.registerNode({
+    type: NODE_TYPES.REROUTE,
+    label: 'Reroute',
+    description: 'Bend a connection to tidy the graph - takes any port type and forwards it unchanged',
+    inputs: [PORT_TYPES.ANY],
+    outputs: [PORT_TYPES.ANY],
+    component: RerouteNode,
     config: {
       category: 'Helper',
       color: '#6B7280'

--- a/src/lib/upstream.js
+++ b/src/lib/upstream.js
@@ -1,0 +1,240 @@
+/**
+ * Upstream resolution
+ * A reroute node is pure wiring: it stores no data and has no port type of its
+ * own. Every node reads its inputs through this module, so a reroute sitting in
+ * the middle of a wire is invisible to whatever is downstream of it
+ */
+
+import { NODE_TYPES } from './node-shapes'
+import nodeRegistry from './node-registry'
+import { getDeclaredPortType } from './ports'
+
+// A chain longer than this is a mistake, not a workflow. The cycle guard covers
+// loops; this covers pathological depth
+const MAX_HOPS = 64
+
+/**
+ * Whether a node is transparent to upstream resolution
+ * @param {Object} node
+ * @returns {boolean}
+ */
+export function isPassThrough(node) {
+  return node?.type === NODE_TYPES.REROUTE
+}
+
+/**
+ * Walk an edge backwards until the node that actually produces the data
+ * @param {Object} edge - Edge to walk back from
+ * @param {Array} nodes - All nodes
+ * @param {Array} edges - All edges
+ * @param {(node: Object) => boolean} skip - Nodes to walk through
+ * @param {Set<string>} visited - Node IDs already walked (cycle guard)
+ * @returns {{ node: Object, sourceHandle: string, portType: string|null }|null}
+ */
+function walkBack(edge, nodes, edges, skip, visited) {
+  let current = edge
+
+  for (let hop = 0; hop <= MAX_HOPS; hop++) {
+    const source = nodes.find(n => n.id === current.source)
+    if (!source) return null
+
+    if (!skip(source)) {
+      return {
+        node: source,
+        sourceHandle: current.sourceHandle,
+        portType: getDeclaredPortType(source.type, current.sourceHandle, true, nodeRegistry)
+      }
+    }
+
+    // Nothing stops the user from wiring a reroute back into itself through
+    // another one: validateConnection only rejects source === target. A loop
+    // resolves to nothing instead of hanging the computed walking it
+    if (visited.has(source.id)) return null
+    visited.add(source.id)
+
+    // A reroute takes a single input (enforced in validateConnection)
+    const feed = edges.find(e => e.target === source.id)
+    if (!feed) return null
+
+    current = feed
+  }
+
+  return null
+}
+
+/**
+ * Every input feeding a node, with reroutes resolved to their real producer
+ * Results keep the order of the incoming edges: the nodes that hand several
+ * images to one model depend on it
+ * @param {string} nodeId - Consumer node ID
+ * @param {Array} nodes - All nodes. Pass the reactive array, never a copy, or
+ *   the computed calling this stops tracking the graph
+ * @param {Array} edges - All edges
+ * @param {Object} [options]
+ * @param {string} [options.portType] - Keep only inputs of this PORT_TYPE
+ * @param {string} [options.handle] - Keep only inputs landing on this handle
+ * @param {Function} [options.skip] - Nodes to resolve through
+ * @returns {Array<{node: Object, portType: string|null, sourceHandle: string,
+ *   handle: string, edge: Object}>}
+ */
+export function resolveUpstream(nodeId, nodes, edges, options = {}) {
+  const { portType = null, handle = null, skip = isPassThrough } = options
+  const resolved = []
+
+  for (const edge of edges) {
+    if (edge.target !== nodeId) continue
+    if (handle && edge.targetHandle !== handle) continue
+
+    // Seeded with the consumer so `consumer -> reroute -> consumer` terminates
+    const producer = walkBack(edge, nodes, edges, skip, new Set([nodeId]))
+    if (!producer) continue
+    if (portType && producer.portType !== portType) continue
+
+    resolved.push({
+      node: producer.node,
+      portType: producer.portType,
+      sourceHandle: producer.sourceHandle,
+      handle: edge.targetHandle,
+      edge
+    })
+  }
+
+  return resolved
+}
+
+/**
+ * First upstream value a picker manages to read
+ * An upstream holding nothing is skipped rather than read as "not connected",
+ * which is what the per-component loops did before
+ * @param {string} nodeId - Consumer node ID
+ * @param {Array} nodes - All nodes
+ * @param {Array} edges - All edges
+ * @param {(node: Object) => *} pick - Reads the value off a producer node
+ * @param {Object} [options] - Same options as resolveUpstream
+ * @returns {*} The value, or null when no upstream holds one
+ */
+export function readUpstream(nodeId, nodes, edges, pick, options = {}) {
+  for (const input of resolveUpstream(nodeId, nodes, edges, options)) {
+    const value = pick(input.node)
+    if (value) return value
+  }
+
+  return null
+}
+
+/**
+ * Every upstream value a picker can read, in incoming-edge order
+ * @param {string} nodeId - Consumer node ID
+ * @param {Array} nodes - All nodes
+ * @param {Array} edges - All edges
+ * @param {(node: Object) => *} pick - Reads the value off a producer node
+ * @param {Object} [options] - Same options as resolveUpstream
+ * @returns {Array<{value: *, node: Object, handle: string, nodeId: string}>}
+ */
+export function readUpstreamAll(nodeId, nodes, edges, pick, options = {}) {
+  const values = []
+
+  for (const input of resolveUpstream(nodeId, nodes, edges, options)) {
+    const value = pick(input.node)
+    if (!value) continue
+
+    values.push({ value, node: input.node, handle: input.handle, nodeId: input.node.id })
+  }
+
+  return values
+}
+
+/**
+ * Prompt text a node produces
+ * @param {Object} node
+ * @returns {string|null}
+ */
+export const pickPrompt = node => node.data?.prompt || null
+
+/**
+ * Image a node produces: uploads keep it in `src`, generators in
+ * `lastOutputSrc`, and the draw node writes `outputSrc` alongside its own
+ * @param {Object} node
+ * @returns {string|null}
+ */
+export const pickImage = node =>
+  node.data?.src || node.data?.lastOutputSrc || node.data?.outputSrc || null
+
+/**
+ * PORT_TYPE a reroute is currently carrying, null while nothing feeds it
+ * A reroute borrows the type of its producer instead of storing one, so this is
+ * recomputed from the graph every time: nothing about a reroute is serialized
+ * @param {string} nodeId - Reroute node ID
+ * @param {Array} nodes - All nodes
+ * @param {Array} edges - All edges
+ * @returns {string|null}
+ */
+export function resolveRerouteType(nodeId, nodes, edges) {
+  return resolveUpstream(nodeId, nodes, edges)[0]?.portType || null
+}
+
+/**
+ * Whether two connections describe the same wire
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {boolean}
+ */
+function isSameConnection(a, b) {
+  return a.source === b.source &&
+    a.target === b.target &&
+    (a.sourceHandle ?? null) === (b.sourceHandle ?? null) &&
+    (a.targetHandle ?? null) === (b.targetHandle ?? null)
+}
+
+/**
+ * Connections that keep a graph wired after deleting some nodes
+ * Deleting a reroute must not break the wire it was tidying, so its producer is
+ * reconnected to everything it fed. Reroutes deleted in the same gesture are
+ * walked through, which is what makes deleting a whole chain leave one edge
+ * behind instead of edges hanging off nodes that no longer exist
+ * @param {Array<Object>} deletedNodes - Nodes about to be removed
+ * @param {Array} nodes - All nodes, before the removal
+ * @param {Array} edges - All edges, before the removal
+ * @returns {Array<Object>} Connections to add after the removal. No IDs: VueFlow
+ *   mints them and drops the ones that already exist
+ */
+export function planRerouteBypass(deletedNodes, nodes, edges) {
+  const reroutes = deletedNodes.filter(isPassThrough)
+  if (!reroutes.length) return []
+
+  const deletedIds = new Set(deletedNodes.map(node => node.id))
+
+  // Only the reroutes going away are transparent here: one that survives is a
+  // legitimate source, and rewiring past it would undo the user's tidying
+  const skip = node => isPassThrough(node) && deletedIds.has(node.id)
+
+  const bridges = []
+
+  for (const reroute of reroutes) {
+    const [upstream] = resolveUpstream(reroute.id, nodes, edges, { skip })
+
+    // Nothing feeding it, or its producer is on the way out too
+    if (!upstream || deletedIds.has(upstream.node.id)) continue
+
+    for (const edge of edges) {
+      if (edge.source !== reroute.id) continue
+      if (deletedIds.has(edge.target)) continue
+
+      const bridge = {
+        source: upstream.node.id,
+        sourceHandle: upstream.sourceHandle,
+        target: edge.target,
+        targetHandle: edge.targetHandle
+      }
+
+      // VueFlow dedupes against the edges already in the store, not within the
+      // batch it is handed, so the same bridge reached through two deleted
+      // reroutes has to be caught here
+      if (bridges.some(existing => isSameConnection(existing, bridge))) continue
+
+      bridges.push(bridge)
+    }
+  }
+
+  return bridges
+}

--- a/src/services/workflow-executor.js
+++ b/src/services/workflow-executor.js
@@ -9,6 +9,7 @@ import { useWorkflowExecutionStore } from '@/stores/workflow-execution'
 import { useFlowStore } from '@/stores/flow'
 import nodeRegistry from '@/lib/node-registry'
 import { NODE_TYPES } from '@/lib/node-shapes'
+import { resolveUpstream } from '@/lib/upstream'
 
 /**
  * Default execution options
@@ -71,6 +72,12 @@ function shouldExecuteNode(node) {
     case NODE_TYPES.IMAGE:
       // Image nodes are source nodes with uploaded images
       // They don't need execution
+      return false
+
+    case NODE_TYPES.REROUTE:
+      // Pure wiring: it forwards whatever feeds it, there is nothing to run.
+      // Without this case it would fall through to the default below and hang
+      // until the node timeout, since it declares an output port
       return false
 
     default:
@@ -174,17 +181,20 @@ class WorkflowExecutor {
       dependentsMap.set(nodeId, new Set())
     }
 
-    for (const edge of edges) {
-      const sourceExecutable = executableNodes.includes(edge.source)
-      const targetExecutable = executableNodes.includes(edge.target)
+    // Dependencies are resolved through the graph rather than edge by edge: a
+    // reroute never executes, so an edge landing on one is not a dependency,
+    // the node feeding that reroute is. Walking the edges directly would drop
+    // generator -> reroute -> generator and let the second one start early
+    // A source that is not executable (a static Image node, say) is still no
+    // dependency: there is nothing to wait for
+    const executableSet = new Set(executableNodes)
 
-      if (targetExecutable) {
-        // Only add dependency if source is also executable
-        // (if source is a static node like Image, we don't wait for it)
-        if (sourceExecutable) {
-          dependencyMap.get(edge.target).add(edge.source)
-          dependentsMap.get(edge.source).add(edge.target)
-        }
+    for (const nodeId of executableNodes) {
+      for (const input of resolveUpstream(nodeId, nodes, edges)) {
+        if (!executableSet.has(input.node.id)) continue
+
+        dependencyMap.get(nodeId).add(input.node.id)
+        dependentsMap.get(input.node.id).add(nodeId)
       }
     }
 

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -40,6 +40,9 @@ export const useSettingsStore = defineStore('settings', () => {
   const showNodeHeaders = ref(persisted.showNodeHeaders ?? false)
   const skipSaveDialog = ref(persisted.skipSaveDialog ?? false)
 
+  // Shape of the edges between nodes. 'default' is VueFlow's bezier curve
+  const edgeType = ref(persisted.edgeType ?? 'default')
+
   // Beta features, hidden until the user opts in
   const betaAutoLayout = ref(persisted.betaAutoLayout ?? false)
 
@@ -56,6 +59,7 @@ export const useSettingsStore = defineStore('settings', () => {
     () => ({
       showNodeHeaders: showNodeHeaders.value,
       skipSaveDialog: skipSaveDialog.value,
+      edgeType: edgeType.value,
       betaAutoLayout: betaAutoLayout.value,
       autoLayoutGroupContents: autoLayoutGroupContents.value,
       replicateApiKey: replicateApiKey.value,
@@ -78,6 +82,10 @@ export const useSettingsStore = defineStore('settings', () => {
 
   function setSkipSaveDialog(value) {
     skipSaveDialog.value = value
+  }
+
+  function setEdgeType(value) {
+    edgeType.value = value
   }
 
   function setBetaAutoLayout(value) {
@@ -123,6 +131,7 @@ export const useSettingsStore = defineStore('settings', () => {
     // State
     showNodeHeaders,
     skipSaveDialog,
+    edgeType,
     betaAutoLayout,
     autoLayoutGroupContents,
     replicateApiKey,
@@ -132,6 +141,7 @@ export const useSettingsStore = defineStore('settings', () => {
     toggleNodeHeaders,
     setNodeHeaders,
     setSkipSaveDialog,
+    setEdgeType,
     setBetaAutoLayout,
     setAutoLayoutGroupContents,
     setReplicateApiKey,

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -72,6 +72,8 @@
         :connection-radius="60"
         :snap-to-handle="true"
         :connection-line-style="{ strokeWidth: 2 }"
+        :default-edge-options="{ type: settingsStore.edgeType }"
+        :connection-line-type="settingsStore.edgeType"
         elevate-edges-on-select
         elevate-nodes-on-select
       >
@@ -113,7 +115,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onUnmounted, ref, markRaw } from 'vue'
+import { computed, onMounted, onUnmounted, ref, markRaw, watch } from 'vue'
 import { VueFlow, useVueFlow } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
 import { useFlowStore } from '@/stores/flow'
@@ -165,6 +167,21 @@ const showIntro = ref(false)
 
 // Show alert if no Replicate API key is configured
 const showAlert = computed(() => !settingsStore.getReplicateApiKey())
+
+// defaultEdgeOptions only stamps the type on edges as they are added, so edges
+// already on the canvas (or restored from a .json saved with another shape)
+// keep whatever type they had. Rewrite them whenever either side changes
+watch(
+  [() => settingsStore.edgeType, () => flowStore.edges.length],
+  () => {
+    for (const edge of flowStore.edges) {
+      if (edge.type !== settingsStore.edgeType) {
+        edge.type = settingsStore.edgeType
+      }
+    }
+  },
+  { immediate: true }
+)
 
 // VueFlow composable
 const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, applyNodeChanges, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -65,7 +65,7 @@
         :default-viewport="{ zoom: 1 }"
         :min-zoom="0.2"
         :max-zoom="4"
-        :delete-key-code="['Delete', 'Backspace']"
+        :delete-key-code="null"
         :multi-selection-key-code="['Meta', 'Control']"
         :nodes-draggable="!isLocked"
         :pan-on-drag="!isLocked"
@@ -142,6 +142,7 @@ import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import { useGroupManagement } from '@/composables/useGroupManagement'
 import { useAutoLayout } from '@/composables/useAutoLayout'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+import { useNodeDeletion } from '@/composables/useNodeDeletion'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useConnectionDrop } from '@/composables/useConnectionDrop'
 import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
@@ -184,7 +185,11 @@ watch(
 )
 
 // VueFlow composable
-const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, applyNodeChanges, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()
+const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, applyNodeChanges, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData, getSelectedNodes, getSelectedEdges, removeNodes, removeEdges } = useVueFlow()
+
+// Deleting the selection is wrapped rather than left to VueFlow, so a reroute
+// on the way out leaves the wire it was bending connected. See useNodeDeletion
+useNodeDeletion(flowStore, { getSelectedNodes, getSelectedEdges, removeNodes, removeEdges, addEdges })
 
 // Use composables
 const { fileInput, handleExport, handleImport, onFileSelected, getDefaultFilename } = useFlowIO(flowStore, { addEdges })


### PR DESCRIPTION
> Stacked on top of #51 (`feat/configurable-edge-shape`). Merge that one first, or review this diff against it.

# What

Adds a **Reroute** node: a small pill with one input and one output that takes any port type, hands it on unchanged, and can feed as many nodes as you like. It holds nothing of its own and does no work — it exists so you can bend a connection and give a dense graph a shape that actually reads. Same idea as the reroute in ComfyUI.

It sits in the Helper section of the node menu, and it also shows up whenever you drag a connection out into empty canvas, so you can drop one mid-wire without hunting for it.

Two behaviours worth calling out:

- **Deleting one keeps the wire.** Whatever was feeding it gets reconnected to everything it was feeding, including when you delete a whole chain of them in one go. Only the reroute is treated this way — deleting any other node still cuts its connections.
- **It knows what it is carrying.** The handles take the colour of the port feeding it, and once it holds an image it stops accepting a prompt input, exactly like a regular node would.

Nothing changes for flows that do not use it, and old `.json` files load unaffected.

# Why

The obstacle was never the node, it was how the app reads its inputs. Every consumer walked `flowStore.edges`, found its **immediate** neighbour and read a field off its `data` — and that loop was copied in nine places. Anything sitting in the middle of a wire would leave the node downstream reading an empty neighbour.

So the loop moved into a shared resolver (`src/lib/upstream.js`) that walks back through reroutes to the node that actually produces the data, and the nine consumers now call it. The reroute stores nothing at all: what it carries is recomputed from the graph, and an exported flow holds no more than its position. The alternative — having the reroute mirror its upstream's `data` — would have been a much smaller diff, but it would copy every base64 image into a second place in the state and into the `.json`, in a project whose whole contract is that the canvas serializes.

The delete behaviour could not be a VueFlow hook. `onNodesDelete` does not exist in 1.48, and `nodesChange` only fires once the removal has been applied — by then the reroute's edges, the only record of where the wire went, are gone. So the canvas turns off VueFlow's delete key and wraps the removal itself in `useNodeDeletion`, planning the reconnection while the graph is still whole.

Three latent bugs got fixed along the way, all of which the reroute would have tripped over:

- `validateConnection` reimplemented its own type comparison instead of calling `canConnect`, so the two would have drifted.
- Duplicate detection compared `(source, target)` and ignored the handles, which meant one image node could never feed both image inputs of Diff or Compare. It now compares the target handle too.
- The executor only recorded a dependency when both ends of an edge were executable, so a generator wired through a non-executing node lost its dependency and could start before its real source had finished.

# Tests

e2e and local.

`e2e/reroute-node.spec.js` adds 11 cases. The full suite is at 119 passing; the 5 `copy-paste` failures are pre-existing on `main` and unrelated (verified by running that spec with these changes stashed).

The refactor of the nine consumers is the risky part, and the existing specs are its safety net: `prompt-nodes`, `processing-nodes`, `video-node`, `generator-models`, `large-pipelines` and `batch-run` all exercise those read paths with no reroute involved, and were run green after each step.

## How to test

- [ ] Open the node menu: **Reroute** is in the Helper section
- [ ] Drop one between a Prompt and a Text Generator, wire it through: the generator shows the prompt
- [ ] Its two handles are grey while nothing feeds it, and take the port colour once something does
- [ ] Feed a reroute an image, then try to wire its output to a Prompt input: rejected
- [ ] Try to feed the same reroute from a second source: rejected, it takes one input
- [ ] Delete the reroute: the original connection is still there
- [ ] Wire one reroute into three nodes and delete it: all three get reconnected to the source
- [ ] Chain two reroutes, delete only the second: the first stays and takes over the wire. Delete both at once: a single connection is left
- [ ] Type in a Prompt textarea and press Backspace: it edits the text and does not delete nodes (the canvas owns that key now)
- [ ] Drag a connection from any handle into empty canvas: Reroute is among the options offered
- [ ] Export a flow with a reroute carrying an image: the reroute adds nothing to the file. Reimport it and the destination still receives the image
- [ ] Run a workflow shaped `Generator → Reroute → Generator`: the second one waits for the first
