### PR TITLE
feat: add undo and redo for the whole canvas

### DIFF
--- a/e2e/undo-redo.spec.js
+++ b/e2e/undo-redo.spec.js
@@ -1,0 +1,297 @@
+import { test, expect } from '@playwright/test'
+import { mockNanaBananaPro } from './mocks/api.js'
+import {
+  setupBlankCanvas,
+  addNodeFromSidebar,
+  positionNodes,
+  connectNodesProgrammatic,
+} from './helpers/canvas.js'
+
+// Longer than the history's 400ms debounce, so a step is closed before the next
+const SETTLED = 600
+
+/**
+ * Positions, ids and data are not in the DOM: read them from the store, the same
+ * access positionNodes uses.
+ */
+async function readGraph(page) {
+  return page.evaluate(() => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    return {
+      nodes: flowStore.nodes.map(n => ({
+        id: n.id,
+        type: n.type,
+        x: n.position.x,
+        y: n.position.y,
+        parentNode: n.parentNode || null,
+        data: n.data,
+      })),
+      edges: flowStore.edges.map(e => ({
+        source: e.source,
+        target: e.target,
+        sourceHandle: e.sourceHandle,
+        targetHandle: e.targetHandle,
+      })),
+    }
+  })
+}
+
+/** Mark nodes as selected in the store, the selection a click cannot express */
+async function selectNodesProgrammatic(page, matchers) {
+  await page.evaluate((specs) => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    flowStore.nodes.forEach(n => { n.selected = false })
+    for (const { type, nth } of specs) {
+      const matching = flowStore.nodes.filter(n => n.type === type)
+      const node = matching[nth || 0]
+      if (node) node.selected = true
+    }
+  }, matchers)
+  await page.waitForTimeout(100)
+}
+
+/** Move a node straight through the store, the way positionNodes does */
+async function moveNode(page, type, x, y, nth = 0) {
+  await page.evaluate(({ type, x, y, nth }) => {
+    const pinia = document.querySelector('#app').__vue_app__.config.globalProperties.$pinia
+    const flowStore = pinia._s.get('flow')
+    const node = flowStore.nodes.filter(n => n.type === type)[nth]
+    if (node) node.position = { x, y }
+  }, { type, x, y, nth })
+  await page.waitForTimeout(SETTLED)
+}
+
+async function undo(page) {
+  await page.evaluate(() => document.activeElement?.blur())
+  await page.keyboard.press('Control+z')
+  await page.waitForTimeout(400)
+}
+
+async function redo(page, key = 'Control+Shift+z') {
+  await page.evaluate(() => document.activeElement?.blur())
+  await page.keyboard.press(key)
+  await page.waitForTimeout(400)
+}
+
+test.describe('Undo and redo', () => {
+  test('undoes a move and redoes it', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 200, y: 200 }])
+    await page.waitForTimeout(SETTLED)
+
+    await moveNode(page, 'prompt', 600, 400)
+    expect((await readGraph(page)).nodes[0]).toMatchObject({ x: 600, y: 400 })
+
+    await undo(page)
+    expect((await readGraph(page)).nodes[0]).toMatchObject({ x: 200, y: 200 })
+
+    await redo(page)
+    expect((await readGraph(page)).nodes[0]).toMatchObject({ x: 600, y: 400 })
+  })
+
+  test('Ctrl+Y redoes too', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 200, y: 200 }])
+    await page.waitForTimeout(SETTLED)
+
+    await moveNode(page, 'prompt', 500, 300)
+    await undo(page)
+    expect((await readGraph(page)).nodes[0]).toMatchObject({ x: 200, y: 200 })
+
+    await redo(page, 'Control+y')
+    expect((await readGraph(page)).nodes[0]).toMatchObject({ x: 500, y: 300 })
+  })
+
+  test('a typed sentence is one step, not one per keystroke', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 200, y: 200 }])
+    await page.waitForTimeout(SETTLED)
+
+    const textarea = page.locator('.vue-flow__node-prompt textarea')
+    await textarea.click()
+    // Typed, not filled: every keystroke writes to the store through a watcher
+    await textarea.pressSequentially('a cute cat', { delay: 30 })
+    await textarea.blur()
+    await page.waitForTimeout(SETTLED)
+
+    expect((await readGraph(page)).nodes[0].data.prompt).toBe('a cute cat')
+
+    // A single undo has to clear the whole burst
+    await undo(page)
+    expect((await readGraph(page)).nodes[0].data.prompt ?? '').toBe('')
+    await expect(textarea).toHaveValue('')
+  })
+
+  test('undoing a delete brings the node and its edges back', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Text Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 80, y: 80 },
+      { type: 'prompt', nth: 1, x: 80, y: 400 },
+      { type: 'text-generator', x: 600, y: 200 },
+    ])
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceNth: 0, sourceHandle: 'output-0', targetType: 'prompt', targetNth: 1, targetHandle: 'input-0' },
+      { sourceType: 'prompt', sourceNth: 1, sourceHandle: 'output-0', targetType: 'text-generator', targetHandle: 'input-1' },
+    ])
+    await page.waitForTimeout(SETTLED)
+
+    const before = await readGraph(page)
+    expect(before.edges).toHaveLength(2)
+
+    // The middle prompt carries both edges
+    await selectNodesProgrammatic(page, [{ type: 'prompt', nth: 1 }])
+    await page.keyboard.press('Delete')
+    await page.waitForTimeout(SETTLED)
+
+    expect((await readGraph(page)).edges).toHaveLength(0)
+
+    await undo(page)
+
+    const after = await readGraph(page)
+    expect(after.nodes).toHaveLength(3)
+    expect(after.edges).toHaveLength(2)
+    expect(new Set(after.edges.map(e => `${e.source}>${e.target}`)))
+      .toEqual(new Set(before.edges.map(e => `${e.source}>${e.target}`)))
+  })
+
+  test('undoing a group takes the container away and frees its children', async ({ page }) => {
+    const warnings = []
+    page.on('console', message => {
+      if (message.type() === 'warning' || message.type() === 'error') warnings.push(message.text())
+    })
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Prompt')
+
+    await positionNodes(page, [
+      { type: 'prompt', nth: 0, x: 200, y: 200 },
+      { type: 'prompt', nth: 1, x: 500, y: 200 },
+    ])
+    await page.waitForTimeout(SETTLED)
+
+    await selectNodesProgrammatic(page, [
+      { type: 'prompt', nth: 0 },
+      { type: 'prompt', nth: 1 },
+    ])
+    await page.keyboard.press('Control+g')
+    await page.waitForTimeout(SETTLED)
+
+    expect(await page.locator('.vue-flow__node-group').count()).toBe(1)
+
+    await undo(page)
+
+    const after = await readGraph(page)
+    expect(after.nodes.filter(n => n.type === 'group')).toHaveLength(0)
+    // Children back to absolute coordinates, no parent pointing at a node that
+    // no longer exists
+    expect(after.nodes.every(n => n.parentNode === null)).toBe(true)
+    expect(after.nodes.map(n => [n.x, n.y])).toEqual([[200, 200], [500, 200]])
+    expect(warnings.filter(w => w.includes('parent'))).toEqual([])
+  })
+
+  test('a generated image survives undoing a later move', async ({ page }) => {
+    await mockNanaBananaPro(page)
+
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await addNodeFromSidebar(page, 'Image Generator')
+
+    await positionNodes(page, [
+      { type: 'prompt', x: 100, y: 200 },
+      { type: 'image-generator', x: 600, y: 200 },
+    ])
+
+    const promptNode = page.locator('.vue-flow__node-prompt')
+    await promptNode.locator('textarea').fill('a cute cat')
+    await promptNode.locator('textarea').blur()
+
+    await connectNodesProgrammatic(page, [
+      { sourceType: 'prompt', sourceHandle: 'output-0', targetType: 'image-generator', targetHandle: 'input-1' },
+    ])
+    await page.waitForTimeout(SETTLED)
+
+    const generatorNode = page.locator('.vue-flow__node-image-generator')
+    await generatorNode.getByRole('button', { name: 'Generate Image' }).click()
+    await expect(generatorNode.locator('.image-preview img')).toBeVisible({ timeout: 15000 })
+    await page.waitForTimeout(SETTLED)
+
+    const generated = (await readGraph(page)).nodes
+      .find(n => n.type === 'image-generator').data.lastOutputSrc
+    expect(generated).toBeTruthy()
+
+    // Move something unrelated, then take it back
+    await moveNode(page, 'prompt', 150, 500)
+    await undo(page)
+
+    const after = await readGraph(page)
+    expect(after.nodes.find(n => n.type === 'prompt')).toMatchObject({ x: 100, y: 200 })
+    // The whole point of the design: the undo did not throw away the result
+    expect(after.nodes.find(n => n.type === 'image-generator').data.lastOutputSrc).toBe(generated)
+    await expect(generatorNode.locator('.image-preview img')).toBeVisible()
+  })
+
+  test('stops at 30 steps', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 100, y: 100 }])
+    await page.waitForTimeout(SETTLED)
+
+    // 35 moves, each its own step
+    for (let step = 1; step <= 35; step++) {
+      await moveNode(page, 'prompt', 100 + step * 10, 100)
+    }
+    expect((await readGraph(page)).nodes[0].x).toBe(450)
+
+    for (let step = 0; step < 40; step++) {
+      await page.keyboard.press('Control+z')
+    }
+    await page.waitForTimeout(600)
+
+    // 30 undoable steps back from move 35 lands on move 5, never on the start
+    expect((await readGraph(page)).nodes[0].x).toBe(150)
+  })
+
+  test('importing a flow clears the history', async ({ page }) => {
+    await setupBlankCanvas(page)
+    await addNodeFromSidebar(page, 'Prompt')
+    await positionNodes(page, [{ type: 'prompt', x: 200, y: 200 }])
+    await page.waitForTimeout(SETTLED)
+    await moveNode(page, 'prompt', 500, 500)
+
+    // Import a flow holding a single comment node, through the real hidden input
+    await page.locator('input[type="file"][accept*="json"]').setInputFiles({
+      name: 'imported.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify({
+        version: '1.0.0',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        nodes: [{
+          id: 'imported_1',
+          type: 'comment',
+          position: { x: 300, y: 300 },
+          data: { label: 'Imported', comment: 'hello' },
+          io: { inputs: [], outputs: [] },
+        }],
+        edges: [],
+      })),
+    })
+    await page.waitForTimeout(1000)
+
+    expect((await readGraph(page)).nodes.map(n => n.type)).toEqual(['comment'])
+
+    // Nothing to go back to: the imported flow is step zero
+    await undo(page)
+    expect((await readGraph(page)).nodes.map(n => n.type)).toEqual(['comment'])
+  })
+})

--- a/src/components/nodes/TextGeneratorNode.vue
+++ b/src/components/nodes/TextGeneratorNode.vue
@@ -267,6 +267,19 @@ watch(localPrompt, (newPrompt) => {
   updateNodeData(props.id, { userPrompt: newPrompt })
 })
 
+// The store is the source of truth after an undo, an import or a batch run.
+// Without this the textarea would keep the newer text and the next keystroke
+// would write it straight back, which reads as a broken undo
+watch(() => nodeData.value.userPrompt, (newPrompt) => {
+  if ((newPrompt ?? '') !== localPrompt.value) localPrompt.value = newPrompt ?? ''
+})
+
+// `immediate` because currentModel never read the stored model: loading a flow
+// left the dropdown on gpt-5 no matter what the node was set to
+watch(() => nodeData.value.model, (newModel) => {
+  if (newModel && newModel !== currentModel.value) currentModel.value = newModel
+}, { immediate: true })
+
 // Handle model change
 function onModelChange(event) {
   currentModel.value = event.target.value

--- a/src/composables/useAutoLayout.js
+++ b/src/composables/useAutoLayout.js
@@ -1,22 +1,17 @@
 /**
  * Composable for Auto Layout
- * Rearranges the canvas by dependency and offers a one step undo, since the
- * repo has no history and a layout throws away every manual placement
+ * Rearranges the canvas by dependency. Reverting it is the canvas-wide undo's
+ * job now, see useFlowHistory
  */
 
-import { computed, nextTick, ref } from 'vue'
+import { nextTick } from 'vue'
 import { computeAutoLayout } from '@/lib/auto-layout'
-import { getGroupSize, isCenterInsideGroup } from '@/lib/group-membership'
+import { isCenterInsideGroup } from '@/lib/group-membership'
 import { NODE_TYPES } from '@/lib/node-shapes'
 import { useSettingsStore } from '@/stores/settings'
 
-export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
+export function useAutoLayout(flowStore, { applyNodeChanges, fitView, flushHistory }) {
   const settingsStore = useSettingsStore()
-
-  // Positions and group sizes as they were right before the last layout
-  const snapshot = ref(null)
-
-  const canUndoLayout = computed(() => snapshot.value !== null)
 
   /**
    * Group sizes live in `style` because that is what the JSON keeps. Writing
@@ -60,11 +55,10 @@ export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
     // before reading them
     await nextTick()
 
-    const previous = flowStore.nodes.map(node => ({
-      id: node.id,
-      position: { ...node.position },
-      size: node.type === NODE_TYPES.GROUP ? getGroupSize(node) : null
-    }))
+    // Close whatever step is in flight, so the whole rearrangement is ONE entry
+    // of the history and a single Ctrl+Z takes it back, positions and group
+    // sizes together
+    flushHistory()
 
     const { positions, groupSizes } = computeAutoLayout(flowStore.nodes, flowStore.edges, {
       layoutGroupContents: settingsStore.autoLayoutGroupContents
@@ -82,41 +76,13 @@ export function useAutoLayout(flowStore, { applyNodeChanges, fitView }) {
       if (node.selected) node.selected = false
     }
 
-    snapshot.value = previous
-
     if (import.meta.env.DEV) warnOnStrayNodes()
 
     await nextTick()
     fitView({ duration: 300, padding: 0.2 })
   }
 
-  /**
-   * Put every node back where it was before the last layout. Nodes added or
-   * removed since then are skipped rather than resurrected.
-   */
-  async function undoAutoLayout() {
-    if (!snapshot.value) return
-
-    const previous = snapshot.value
-    snapshot.value = null
-
-    resizeGroups(new Map(
-      previous.filter(entry => entry.size).map(entry => [entry.id, entry.size])
-    ))
-
-    const byId = new Map(flowStore.nodes.map(node => [node.id, node]))
-    for (const entry of previous) {
-      const node = byId.get(entry.id)
-      if (node) node.position = { ...entry.position }
-    }
-
-    await nextTick()
-    fitView({ duration: 300, padding: 0.2 })
-  }
-
   return {
-    canUndoLayout,
-    handleAutoLayout,
-    undoAutoLayout
+    handleAutoLayout
   }
 }

--- a/src/composables/useFlowHistory.js
+++ b/src/composables/useFlowHistory.js
@@ -1,0 +1,322 @@
+/**
+ * Composable for undo/redo of the canvas
+ *
+ * A selective watcher rather than a hook per action. The watcher getter reads
+ * only what gets serialized, so it stays blind to `dragging`, `dimensions`,
+ * `selected` and the rest of the internals VueFlow keeps on the very same node
+ * objects, and a debounce collapses a drag or a burst of typing into one step
+ *
+ * In memory only: the history never travels in the exported .json
+ */
+
+import { computed, nextTick, ref, watch } from 'vue'
+import { mergeRestoredData, sameSnapshot, takeSnapshot } from '@/lib/history-snapshot'
+import { useWorkflowExecutionStore } from '@/stores/workflow-execution'
+import { useBatchStore } from '@/stores/batch'
+
+// 30 undoable steps means 31 states
+const MAX_ENTRIES = 31
+// Longer than the gap between keystrokes, far longer than a drag frame
+const DEBOUNCE_MS = 400
+// Ceiling, so three minutes of typing is not a single step and does not eat the 30
+const MAX_WAIT_MS = 1500
+
+export function useFlowHistory(flowStore, {
+  findNode,
+  addNodes,
+  removeNodes,
+  addEdges,
+  removeEdges,
+  applyNodeChanges,
+  updateNodeData
+}) {
+  const executionStore = useWorkflowExecutionStore()
+  const batchStore = useBatchStore()
+
+  const entries = []
+  const index = ref(-1)
+
+  let cache = new Map()
+  let timer = null
+  let burstStart = 0
+  let isRestoring = false
+  let restoreToken = 0
+
+  /**
+   * A run writes results across many nodes, and a batch rewrites the inputs of
+   * every row before putting the originals back. None of that is an edit
+   * Both flags are needed: between batch rows `isExecuting` drops back to false
+   */
+  const isBusy = computed(() => executionStore.isExecuting || batchStore.isRunning)
+
+  const canUndo = computed(() => index.value > 0)
+  const canRedo = computed(() => index.value < entries.length - 1)
+
+  function snapshot() {
+    const next = takeSnapshot(flowStore, cache)
+    cache = next.cache
+
+    return next
+  }
+
+  /**
+   * Push a state, unless it says the same as the one we are on
+   * @param {Object} next
+   */
+  function commit(next) {
+    if (index.value >= 0 && sameSnapshot(entries[index.value], next)) return
+
+    // Doing something new abandons the redo branch
+    entries.splice(index.value + 1)
+    entries.push(next)
+    if (entries.length > MAX_ENTRIES) entries.shift()
+
+    index.value = entries.length - 1
+  }
+
+  function cancel() {
+    clearTimeout(timer)
+    timer = null
+    burstStart = 0
+  }
+
+  function record() {
+    timer = null
+    burstStart = 0
+
+    if (isRestoring || isBusy.value) return
+
+    // Position changes on every frame of a drag, so wait for the drop and the
+    // whole gesture is one step. This runs from a setTimeout, meaning outside any
+    // effect, so reading `dragging` here does NOT pull it into the watcher getter
+    if (flowStore.nodes.some(node => node.dragging)) {
+      schedule()
+      return
+    }
+
+    commit(snapshot())
+  }
+
+  function schedule() {
+    if (isRestoring) return
+
+    const now = Date.now()
+    if (!burstStart) burstStart = now
+
+    clearTimeout(timer)
+    timer = setTimeout(record, Math.min(DEBOUNCE_MS, Math.max(0, burstStart + MAX_WAIT_MS - now)))
+  }
+
+  /**
+   * Close the step in flight, so whatever happens next is a step of its own
+   */
+  function flush() {
+    cancel()
+    record()
+  }
+
+  /**
+   * Rebase the history onto whatever is on the canvas right now, without adding
+   * a step. Used after a run, and as the initial state
+   */
+  function rebase() {
+    cancel()
+
+    if (index.value < 0) commit(snapshot())
+    else entries[index.value] = snapshot()
+  }
+
+  /**
+   * Drop the history entirely and start over from the current canvas
+   * Loading a flow replaces everything, and going back to what was there before
+   * is not something the history is meant to offer
+   */
+  function reset() {
+    cancel()
+    entries.length = 0
+    index.value = -1
+    cache = new Map()
+    restoreToken++
+    isRestoring = false
+    commit(snapshot())
+  }
+
+  /**
+   * Reconcile the canvas onto a snapshot, touching only what differs
+   * @param {Object} target
+   */
+  function restore(target) {
+    const token = ++restoreToken
+    isRestoring = true
+    cancel()
+
+    const current = snapshot()
+    const currentById = new Map(current.nodes.map(node => [node.id, node]))
+    const targetIds = new Set(target.nodes.map(node => node.id))
+
+    // 1. The ones still around, in place. This is the common case (a move, an
+    //    edit) and it never touches the structure, so there is no watcher hop
+    const resizes = []
+
+    for (const wanted of target.nodes) {
+      const live = findNode(wanted.id)
+      if (!live) continue
+
+      const before = currentById.get(wanted.id)
+
+      if (before.x !== wanted.x || before.y !== wanted.y) {
+        live.position = { x: wanted.x, y: wanted.y }
+      }
+
+      if (before.parentNode !== wanted.parentNode) {
+        if (wanted.parentNode) live.parentNode = wanted.parentNode
+        else delete live.parentNode
+      }
+
+      if (before.extent !== wanted.extent) {
+        if (wanted.extent) live.extent = wanted.extent
+        else delete live.extent
+      }
+
+      // A group's size lives in `style`. Writing it as a dimensions change keeps
+      // `dimensions` and `style` in step, the same route NodeResizer takes
+      if (before.width !== wanted.width || before.height !== wanted.height) {
+        resizes.push({
+          id: wanted.id,
+          type: 'dimensions',
+          dimensions: {
+            width: parseInt(wanted.width) || 0,
+            height: parseInt(wanted.height) || 0
+          },
+          updateStyle: true
+        })
+      }
+
+      if (before.data !== wanted.data) {
+        updateNodeData(
+          wanted.id,
+          mergeRestoredData(live.data, wanted.data, wanted.type),
+          { replace: true }
+        )
+      }
+    }
+
+    if (resizes.length) applyNodeChanges(resizes)
+
+    // 2. The ones that no longer belong. After step 1, which is where a node that
+    //    outlived its group had its `parentNode` cleared
+    const gone = current.nodes
+      .filter(node => !targetIds.has(node.id))
+      .map(node => node.id)
+    if (gone.length) removeNodes(gone, false)
+
+    // 3. The ones missing. `addNodes` parses and lands them in VueFlow's own
+    //    state synchronously, so the edges below already find their endpoints:
+    //    that is why no undo needs the setTimeout importFlow relies on
+    const missing = target.nodes
+      .filter(node => !findNode(node.id))
+      .map(node => ({
+        id: node.id,
+        type: node.type,
+        position: { x: node.x, y: node.y },
+        data: node.data,
+        io: node.io,
+        ...(node.parentNode && { parentNode: node.parentNode }),
+        ...(node.extent && { extent: node.extent }),
+        ...(node.style && { style: node.style })
+      }))
+    if (missing.length) addNodes(missing)
+
+    // 4. Edges are never edited, only born and removed. Remove before adding, or
+    //    validateConnection would reject a transient duplicate
+    const targetEdgeIds = new Set(target.edges.map(edge => edge.id))
+
+    const stale = current.edges
+      .filter(edge => !targetEdgeIds.has(edge.id))
+      .map(edge => edge.id)
+    if (stale.length) removeEdges(stale)
+
+    const kept = new Set(
+      current.edges.filter(edge => targetEdgeIds.has(edge.id)).map(edge => edge.id)
+    )
+    const born = target.edges.filter(edge => !kept.has(edge.id))
+    if (born.length) addEdges(born)
+
+    settle(token)
+  }
+
+  /**
+   * VueFlow writes its state back to the store on the next flush, and the nodes
+   * react to their new data a tick later. Rebasing once everything has landed
+   * keeps a component that re-derives a field (DrawNode republishing its output,
+   * PromptTemplate its prompt) from looking like a brand new step
+   * The token lets 30 rapid Ctrl+Z apply synchronously: only the last one rebases
+   * @param {number} token
+   */
+  async function settle(token) {
+    await nextTick()
+    await nextTick()
+
+    if (token !== restoreToken) return
+
+    entries[index.value] = snapshot()
+    isRestoring = false
+  }
+
+  function undo() {
+    // An edit still inside the debounce window is a step of its own
+    flush()
+    if (!canUndo.value) return
+
+    index.value -= 1
+    restore(entries[index.value])
+  }
+
+  function redo() {
+    if (!canRedo.value) return
+
+    index.value += 1
+    restore(entries[index.value])
+  }
+
+  watch(
+    () => [
+      // `updateNodeData` replaces `node.data` outright, so a fresh identity IS
+      // the signal that someone wrote. Reading only the reference keeps this
+      // getter clear of `dragging`, `dimensions`, `selected` and the rest of the
+      // VueFlow internals that live on the same objects
+      flowStore.nodes.map(node => node.data),
+      flowStore.nodes.map(node =>
+        `${node.id}@${node.position.x},${node.position.y}` +
+        `>${node.parentNode ?? ''}` +
+        // Groups keep their size in `style`, which is what the .json preserves.
+        // The measuring burst on mount does not write style - only a change
+        // carrying `updateStyle` does - so this does not wake the history up
+        `#${node.style?.width ?? ''}x${node.style?.height ?? ''}`
+      ).join('|'),
+      flowStore.edges.map(edge =>
+        `${edge.id}:${edge.source}/${edge.sourceHandle}>${edge.target}/${edge.targetHandle}`
+      ).join('|')
+    ],
+    schedule,
+    { flush: 'post' }
+  )
+
+  // Coming back from a run: whatever it wrote is the new starting point, never a
+  // step of its own
+  watch(isBusy, busy => {
+    if (!busy) rebase()
+  })
+
+  // Importing a flow starts over. The edges land a moment after the nodes
+  // (flow-io waits for VueFlow to see them), so the reset waits for the whole
+  // thing to settle instead of recording a canvas with no wires
+  watch(() => flowStore.importToken, () => {
+    setTimeout(reset, 200)
+  })
+
+  // The canvas as it stands is step zero
+  rebase()
+
+  return { undo, redo, canUndo, canRedo, flush, reset }
+}

--- a/src/composables/useKeyboardShortcuts.js
+++ b/src/composables/useKeyboardShortcuts.js
@@ -1,13 +1,13 @@
 /**
  * Composable for Keyboard Shortcuts
- * Handles global keyboard shortcuts (Ctrl+C, Ctrl+V, Ctrl+G, Ctrl+Z)
+ * Handles global keyboard shortcuts (Ctrl+C, Ctrl+V, Ctrl+G, Ctrl+Z, Ctrl+Y)
  * Copy and paste act on the whole selection, see useCopyPaste
- * Ctrl+Z only reverts an auto layout, see useAutoLayout
+ * Undo and redo cover the whole canvas, see useFlowHistory
  */
 
 import { onMounted, onUnmounted } from 'vue'
 
-export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, canUndoLayout, copiedNodes, flowStore }) {
+export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undo, redo, copiedNodes, flowStore }) {
   /**
    * Handle keyboard shortcuts
    */
@@ -45,13 +45,20 @@ export function useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, und
       handleGroup()
     }
 
-    // Check for Ctrl+Z or Cmd+Z (Mac) - Undo the last auto layout.
-    // Nothing else in the app is undoable, so with no layout to revert the key
-    // is left alone and the browser keeps its own undo
-    if ((event.ctrlKey || event.metaKey) && event.key === 'z') {
-      if (!isEditableField && canUndoLayout.value) {
+    // Ctrl/Cmd+Z undoes, Ctrl/Cmd+Shift+Z and Ctrl/Cmd+Y redo.
+    // Inside a text field the browser's own undo wins: the node adopts whatever
+    // the field ends up holding, so the edit is still undoable from the canvas a
+    // step later
+    if ((event.ctrlKey || event.metaKey) && !isEditableField) {
+      // With Shift held, `event.key` for that key is an uppercase 'Z'
+      const key = event.key.toLowerCase()
+
+      if (key === 'z' && !event.shiftKey) {
         event.preventDefault()
-        undoAutoLayout()
+        undo()
+      } else if ((key === 'z' && event.shiftKey) || key === 'y') {
+        event.preventDefault()
+        redo()
       }
     }
   }

--- a/src/lib/flow-io.js
+++ b/src/lib/flow-io.js
@@ -175,6 +175,10 @@ export async function importFlow(flowData, flowStore, vueFlowHelpers = {}) {
       flowStore.edges.push(...importedEdges)
     }
 
+    // The canvas is now someone else's flow, so anything the history held about
+    // the previous one is gone
+    flowStore.markImported()
+
     console.log('Flow imported successfully:', {
       nodes: flowData.nodes.length,
       edges: flowData.edges.length,

--- a/src/lib/history-snapshot.js
+++ b/src/lib/history-snapshot.js
@@ -1,0 +1,189 @@
+/**
+ * Snapshots for undo/redo
+ *
+ * A snapshot holds what an exported .json holds, minus the fields a generation
+ * writes: those are never undone, so a Ctrl+Z can't throw away an image that
+ * cost a real API call
+ *
+ * The `data` objects are kept BY REFERENCE, never cloned. Every write in the app
+ * goes through `updateNodeData`, which replaces `node.data` with a fresh object,
+ * so a node nobody touched carries the very same object from one snapshot to the
+ * next. That is what makes a snapshot cost a handful of small objects even when a
+ * node holds a base64 image of several megabytes, and what makes comparing two
+ * snapshots a chain of identity checks instead of a JSON.stringify
+ */
+
+import { NODE_TYPES } from './node-shapes'
+
+/**
+ * Written by a failure and wiped by a setTimeout 5s later, on any node type
+ * Keeping it out is what stops that deferred wipe from becoming a history entry
+ */
+const VOLATILE_ANY_TYPE = ['error']
+
+/**
+ * Written by a generator when a result comes back
+ * `model` and `params` are deliberately absent: the person picks those, and a
+ * generator rewrites the same value it was given
+ */
+const VOLATILE_BY_TYPE = {
+  [NODE_TYPES.IMAGE_GENERATOR]: ['lastOutputSrc', 'generationId', 'generationMetadata'],
+  // `prompt` is this node's OUTPUT - what the person types lives in `userPrompt`
+  [NODE_TYPES.TEXT_GENERATOR]: ['generatedText', 'prompt', 'lastGenerationId'],
+  [NODE_TYPES.VIDEO_GENERATOR]: ['lastOutputVideoSrc', 'generationId', 'generationMetadata']
+}
+
+const EMPTY_DATA = Object.freeze({})
+
+/**
+ * Fields of a node type that the history neither records nor restores
+ * Note this is per type on purpose: `lastOutputSrc` is a generation on an image
+ * generator but the result of drawing on a DrawNode, and excluding it globally
+ * would make drawing impossible to undo
+ * @param {string} nodeType - NODE_TYPES value
+ * @returns {Array<string>}
+ */
+export function volatileFields(nodeType) {
+  const byType = VOLATILE_BY_TYPE[nodeType]
+
+  return byType ? [...VOLATILE_ANY_TYPE, ...byType] : VOLATILE_ANY_TYPE
+}
+
+/**
+ * @param {Object} data
+ * @param {string} nodeType
+ * @returns {Object} A copy without the volatile fields
+ */
+function stripVolatile(data, nodeType) {
+  const stripped = { ...data }
+  for (const field of volatileFields(nodeType)) delete stripped[field]
+
+  return stripped
+}
+
+/**
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {boolean}
+ */
+function shallowEqual(a, b) {
+  const keys = Object.keys(a)
+
+  return keys.length === Object.keys(b).length &&
+    keys.every(key => Object.is(a[key], b[key]))
+}
+
+/**
+ * Take a snapshot of everything the history is responsible for
+ * @param {Object} flowStore - Pinia flow store
+ * @param {Map} [cache] - The previous snapshot's cache. Reusing it is what keeps
+ *   an untouched node on the same stripped `data` object, so the next snapshot
+ *   still compares equal by identity
+ * @returns {{ nodes: Array, edges: Array, cache: Map }}
+ */
+export function takeSnapshot(flowStore, cache = new Map()) {
+  // Rebuilt every time, so entries for deleted nodes fall out on their own
+  const nextCache = new Map()
+
+  const nodes = flowStore.nodes.map(node => {
+    const raw = node.data ?? EMPTY_DATA
+    const hit = cache.get(node.id)
+    let data
+
+    if (hit && hit.raw === raw) {
+      // Nobody wrote to this node at all
+      data = hit.data
+    } else {
+      const stripped = stripVolatile(raw, node.type)
+      // A generation only moved volatile fields: hold on to the old identity so
+      // the snapshot compares equal and no entry is born
+      data = hit && shallowEqual(hit.data, stripped) ? hit.data : stripped
+    }
+
+    nextCache.set(node.id, { raw, data })
+
+    return {
+      id: node.id,
+      type: node.type,
+      x: node.position.x,
+      y: node.position.y,
+      parentNode: node.parentNode ?? null,
+      extent: node.extent ?? null,
+      // A group keeps its size in `style`, which is what the .json preserves.
+      // Pulled apart here so comparing two snapshots stays a scalar check
+      width: node.style?.width ?? null,
+      height: node.style?.height ?? null,
+      style: node.style ? { ...node.style } : null,
+      // Never mutated at runtime, so a reference is enough
+      io: node.io,
+      data
+    }
+  })
+
+  const edges = flowStore.edges.map(edge => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    sourceHandle: edge.sourceHandle ?? null,
+    targetHandle: edge.targetHandle ?? null
+  }))
+
+  return { nodes, edges, cache: nextCache }
+}
+
+/**
+ * Whether two snapshots describe the same canvas
+ * Compares `data` by identity, which the cache in takeSnapshot is what makes
+ * meaningful: no deep walk, no stringify
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {boolean}
+ */
+export function sameSnapshot(a, b) {
+  if (!a || !b) return false
+  if (a.nodes.length !== b.nodes.length) return false
+  if (a.edges.length !== b.edges.length) return false
+
+  for (let i = 0; i < a.nodes.length; i++) {
+    const left = a.nodes[i]
+    const right = b.nodes[i]
+
+    if (left.id !== right.id) return false
+    if (left.data !== right.data) return false
+    if (left.x !== right.x || left.y !== right.y) return false
+    if (left.parentNode !== right.parentNode) return false
+    if (left.width !== right.width || left.height !== right.height) return false
+  }
+
+  for (let i = 0; i < a.edges.length; i++) {
+    const left = a.edges[i]
+    const right = b.edges[i]
+
+    if (left.id !== right.id) return false
+    if (left.source !== right.source || left.target !== right.target) return false
+    if (left.sourceHandle !== right.sourceHandle) return false
+    if (left.targetHandle !== right.targetHandle) return false
+  }
+
+  return true
+}
+
+/**
+ * The data to write back into a node: the snapshot for everything that belongs
+ * to the person, the live value for everything a generation produced
+ * Without this merge, undoing a move made after a generation would wipe the
+ * generated image, since the snapshot never held it
+ * @param {Object} currentData - The node's data right now
+ * @param {Object} snapshotData - The data recorded in the snapshot
+ * @param {string} nodeType
+ * @returns {Object}
+ */
+export function mergeRestoredData(currentData, snapshotData, nodeType) {
+  const merged = { ...snapshotData }
+
+  for (const field of volatileFields(nodeType)) {
+    if (currentData && field in currentData) merged[field] = currentData[field]
+  }
+
+  return merged
+}

--- a/src/stores/flow.js
+++ b/src/stores/flow.js
@@ -7,6 +7,11 @@ export const useFlowStore = defineStore('flow', () => {
   const edges = ref([])
   const isLoading = ref(false)
   const error = ref(null)
+  // Bumped by every flow import. Loading a flow replaces the whole canvas, and
+  // the history drops what it had rather than offering to undo back past it.
+  // A counter on the store is what lets all three import routes - the menu, a
+  // dropped .json and the intro modal - signal that with one line each
+  const importToken = ref(0)
 
   // Actions
   const reset = () => {
@@ -28,12 +33,18 @@ export const useFlowStore = defineStore('flow', () => {
     error.value = null
   }
 
+  const markImported = () => {
+    importToken.value += 1
+  }
+
   return {
     nodes,
     edges,
     isLoading,
     error,
+    importToken,
     reset,
+    markImported,
     setLoading,
     setError,
     clearError

--- a/src/views/FlowCanvasView.vue
+++ b/src/views/FlowCanvasView.vue
@@ -140,6 +140,7 @@ import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import { useGroupManagement } from '@/composables/useGroupManagement'
 import { useAutoLayout } from '@/composables/useAutoLayout'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
+import { useFlowHistory } from '@/composables/useFlowHistory'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useConnectionDrop } from '@/composables/useConnectionDrop'
 import { useSidePanel, PANEL_TYPES } from '@/composables/useSidePanel'
@@ -167,7 +168,13 @@ const showIntro = ref(false)
 const showAlert = computed(() => !settingsStore.getReplicateApiKey())
 
 // VueFlow composable
-const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, applyNodeChanges, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData } = useVueFlow()
+const { findNode, onConnect, onConnectStart, onConnectEnd, addEdges, viewport, onNodeDragStop, fitView, applyNodeChanges, screenToFlowCoordinate, onPaneContextMenu, onNodeContextMenu, updateNodeData, addNodes, removeNodes, removeEdges } = useVueFlow()
+
+// Undo/redo of the whole canvas, minus the results of a generation. Instantiated
+// before the composables it has to close a step for
+const { undo, redo, flush: flushHistory } = useFlowHistory(flowStore, {
+  findNode, addNodes, removeNodes, addEdges, removeEdges, applyNodeChanges, updateNodeData
+})
 
 // Use composables
 const { fileInput, handleExport, handleImport, onFileSelected, getDefaultFilename } = useFlowIO(flowStore, { addEdges })
@@ -232,7 +239,7 @@ const {
 } = useConnectionDrop(flowStore, createNodeAtPosition, screenToFlowCoordinate, { addEdges }, openNodesMenuAt, closeMenu)
 const { onDragStart, onNodeItemClick, onDrop } = useDragAndDrop(viewport, createNodeAtPosition, isNodesMenuOpen, flowStore, { addEdges }, closeNodesMenu, menuOrigin)
 const { handleGroup } = useGroupManagement(flowStore, onNodeDragStop)
-const { handleAutoLayout, undoAutoLayout, canUndoLayout } = useAutoLayout(flowStore, { applyNodeChanges, fitView })
+const { handleAutoLayout } = useAutoLayout(flowStore, { applyNodeChanges, fitView, flushHistory })
 
 // Register right-click handlers for context menus
 onPaneContextMenu(handlePaneContextMenu)
@@ -268,7 +275,7 @@ function onRenameConfirm(label) {
 }
 
 // Setup keyboard shortcuts
-useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undoAutoLayout, canUndoLayout, copiedNodes, flowStore })
+useKeyboardShortcuts({ handleCopy, handlePaste, handleGroup, undo, redo, copiedNodes, flowStore })
 
 // Register connection handler - use addEdges directly
 onConnect((params) => {
@@ -313,9 +320,15 @@ function handleClickOutside(event) {
 }
 
 // Validate connection before allowing it (visual feedback)
-function isValidConnection(connection) {
-  const sourceNode = flowStore.nodes.find(n => n.id === connection.source)
-  const targetNode = flowStore.nodes.find(n => n.id === connection.target)
+// VueFlow always hands over its own view of the graph, both while dragging a
+// handle and while parsing new edges. Preferring that over the store is what
+// lets an undo bring back a node and its edges in the same tick: the store runs
+// one flush behind VueFlow's internal state, so a node that has just been added
+// is not in `flowStore.nodes` yet and the edge would be dropped in silence
+function isValidConnection(connection, context = {}) {
+  const allNodes = context.nodes ?? flowStore.nodes
+  const sourceNode = context.sourceNode ?? allNodes.find(n => n.id === connection.source)
+  const targetNode = context.targetNode ?? allNodes.find(n => n.id === connection.target)
 
   if (!sourceNode || !targetNode) return false
 
@@ -323,8 +336,8 @@ function isValidConnection(connection) {
     connection,
     sourceNode,
     targetNode,
-    flowStore.edges,
-    flowStore.nodes  // Pass all nodes for port type validation
+    context.edges ?? flowStore.edges,
+    allNodes  // Pass all nodes for port type validation
   )
 
   if (!validation.valid) {


### PR DESCRIPTION
> Stacked on top of #52 (`feat/reroute-node`), which in turn sits on #51. Base is `feat/reroute-node` so the diff shows only the history work.

# What

Ctrl+Z now works on the canvas. Thirty steps back, and Ctrl+Shift+Z or Ctrl+Y to come forward again.

Everything the project file holds is undoable — where nodes sit, how they are wired, prompts, model settings, groups and their sizes, uploaded images. With one deliberate exception: **the results of a generation are never undone.** An image, a text or a video that came back from the API cost real money, so no amount of undoing will throw one away. Generate an image, move a node by mistake, hit Ctrl+Z, and the image is still sitting there.

Two details about how a "step" is defined, because they are what make it feel right rather than annoying:

- Dragging a node is one step, taken when you let go — not one per frame of movement, and not two if you pause mid-gesture.
- Typing a sentence is one step per burst, not one per letter.

The history lives in memory only. It does not travel inside the exported `.json`, and loading a flow starts over: you can't undo your way back past an import into someone else's workflow.

# Why

Losing work had no remedy. The only reversible thing in the app was the auto layout, through a one-step Ctrl+Z of its own (`useAutoLayout`) that existed precisely because there was no history to lean on. That absence has been shaping decisions for a while — the reroute node in #52 goes out of its way to reconnect wires on delete partly because there is no safety net behind it.

Two ideas carry the implementation, both in a single new composable (`useFlowHistory`) and a pure module next to it (`history-snapshot`):

**One selective watcher instead of a hook per action.** Deleting, pasting, grouping, connecting and dragging all end up somewhere different, and some of them run inside VueFlow. Rather than chase every one, the history watches a getter that reads only the fields that get serialized. That is what keeps it from waking up on the drag, measurement and selection state VueFlow stores on those very same node objects.

**Snapshots hold node data by reference, never copied.** Every write in the app goes through `updateNodeData`, which swaps `node.data` for a fresh object, so a node nobody touched carries the identical object from one snapshot to the next. Thirty snapshots with the same 5MB image cost what one costs, and comparing two snapshots is a chain of identity checks rather than a walk through megabytes. It also means a generation produces no history entry at all: strip the generated fields and the result comes out equal to the previous state, so nothing is recorded.

Restoring reconciles by id — update what is still there, drop what is gone, add what is missing — instead of rebuilding the graph the way an import does. That keeps the common case synchronous, so thirty rapid presses of Ctrl+Z are actually usable.

Two things got fixed on the way because the history exposed them: the text generator was the only node holding local state without a watcher back from the store (its textarea would have kept the newer text through an undo, and its model dropdown ignored what was saved in a loaded flow), and connection validation now uses the graph VueFlow hands it rather than the store, which runs one flush behind.

# Tests

e2e and local. Production build clean.

`e2e/undo-redo.spec.js` adds 8 cases. Full suite at **127 passing**; the 5 `copy-paste` failures are pre-existing on `main` and unrelated.

`e2e/auto-layout.spec.js` is the canary here — it presses Ctrl+Z and demands exact positions back. It passes **untouched and with a single press**, which is the thing that had to hold when the auto layout's own undo was folded in.

Worth knowing what is *not* covered: the tests move nodes through the store rather than with the mouse, so the guard that makes a real drag one step is not exercised by any test. Same for the batch pause — it is implemented and reasoned about, but there is no test that runs a batch and checks the stack stays put. Both are on the manual checklist below.

## How to test

- [ ] Move a node, press Ctrl+Z: it goes back. Ctrl+Shift+Z: it returns. Same with Ctrl+Y
- [ ] **Drag a node with the mouse and pause halfway through the gesture** before letting go — one Ctrl+Z must take the whole drag back, not half of it
- [ ] Type a sentence into a Prompt node, click away, Ctrl+Z: the whole sentence goes, not the last letter
- [ ] Type into a Prompt and press Ctrl+Z **while still in the textarea**: the browser's own undo handles the text, the canvas stays put
- [ ] Delete a node that has connections on both sides, Ctrl+Z: node and both wires come back
- [ ] Select two nodes, Ctrl+G, Ctrl+Z: the group goes away and the two nodes are back where they were, no warnings in the console
- [ ] Resize a group, Ctrl+Z: it goes back to its previous size
- [ ] Enable the Auto Layout beta, rearrange, and press Ctrl+Z **once**: everything back, positions and group sizes together
- [ ] **Generate an image, then move any node, then Ctrl+Z**: the node moves back and the generated image is untouched
- [ ] **Run a batch of several rows**, then press Ctrl+Z: it should undo whatever you did *before* the batch, not step through the rows
- [ ] Make 35 changes, then hold Ctrl+Z: it stops after 30
- [ ] Load a `.json`, then Ctrl+Z: nothing happens — an import is the new starting point
